### PR TITLE
C++ unit test system fixes

### DIFF
--- a/src/AFQMC/Drivers/tests/test_driver_factory.cpp
+++ b/src/AFQMC/Drivers/tests/test_driver_factory.cpp
@@ -113,17 +113,8 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   // KE: Some special walker_types must match the wavefunction type;
   //     if an explicit walker type is provided to this test, use it!
   if (walker_type != UNDEFINED_WALKER_TYPE) {
-    auto toStr = [](WALKER_TYPES wt) -> std::string {
-      if (wt == CLOSED)          return "closed";
-      if (wt == COLLINEAR)       return "collinear";
-      if (wt == NONCOLLINEAR)    return "noncollinear";
-      if (wt == FULLYPOLARIZED)  return "fullypolarized";   // like Collinear but with ndown=0
-      if (wt == COLLINEAR_FT)    return "collinear-ft";     // finite temperature collinear
-      if (wt == NONCOLLINEAR_FT) return "noncollinear-ft";  // finite temperature noncollinear
-      return "collinear";
-    };
-    wlk_full.put("walker_type", toStr(walker_type));
-    wlk_min.put("walker_type", toStr(walker_type));
+    wlk_full.put("walker_type", walkerTypeToString(walker_type));
+    wlk_min.put("walker_type", walkerTypeToString(walker_type));
   }
 
   WSetFac.push("wlk0", wlk_full);

--- a/src/AFQMC/Drivers/tests/test_driver_factory.cpp
+++ b/src/AFQMC/Drivers/tests/test_driver_factory.cpp
@@ -59,7 +59,8 @@ using namespace afqmc;
 
 template<MEMORY_SPACE MEM>
 void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
-             std::string hamil_file, std::string wfn_file)
+             std::string hamil_file, std::string wfn_file,
+             WALKER_TYPES walker_type = UNDEFINED_WALKER_TYPE)
 {
   using nda::range;
   auto all = range::all;
@@ -94,7 +95,6 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   ptree wlk_full;
   wlk_full.put("name","wlk0");
   wlk_full.put("system","sys0");
-  WSetFac.push("wlk0", wlk_full);
 
   ptree prop_full;
   prop_full.put("name","prop0");
@@ -110,69 +110,117 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   ptree wlk_min;
   wlk_min.put("max_weight","4.0");
 
+  // KE: Some special walker_types must match the wavefunction type;
+  //     if an explicit walker type is provided to this test, use it!
+  if (walker_type != UNDEFINED_WALKER_TYPE) {
+    auto toStr = [](WALKER_TYPES wt) -> std::string {
+      if (wt == CLOSED)          return "closed";
+      if (wt == COLLINEAR)       return "collinear";
+      if (wt == NONCOLLINEAR)    return "noncollinear";
+      if (wt == FULLYPOLARIZED)  return "fullypolarized";   // like Collinear but with ndown=0
+      if (wt == COLLINEAR_FT)    return "collinear-ft";     // finite temperature collinear
+      if (wt == NONCOLLINEAR_FT) return "noncollinear-ft";  // finite temperature noncollinear
+      return "collinear";
+    };
+    wlk_full.put("walker_type", toStr(walker_type));
+    wlk_min.put("walker_type", toStr(walker_type));
+  }
+
+  WSetFac.push("wlk0", wlk_full);
+
   ptree prop_min;
   prop_min.put("hybrid","true");
 
   ptree exec;
 
-  
-  exec.put_child("wavefunction",wfn_min);
-  // wfn only - this is invalid unless wfn file and hamil file are the same
-  if (hamil_file == wfn_file)
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
-  
-  // wfn and ham
-  exec.put_child("hamiltonian",ham_min);
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+  const bool default_walker = (walker_type == UNDEFINED_WALKER_TYPE);
 
-  // wfn, ham, prop
-  exec.put_child("propagator",prop_min);
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+  if (default_walker) {
+    exec.put_child("wavefunction",wfn_min);
+    // wfn only - this is invalid unless wfn file and hamil file are the same
+    if (hamil_file == wfn_file) {
+      app_log(0,"[driver_fac] TEST: wfn only (inline); walker_type={}", int(walker_type));
+      REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+    }
+    
+    // wfn and ham
+    exec.put_child("hamiltonian",ham_min);
+    app_log(0,"[driver_fac] TEST: wfn+ham (inline); walker_type={}", int(walker_type));
+    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+
+    // wfn, ham, prop
+    exec.put_child("propagator",prop_min);
+    app_log(0,"[driver_fac] TEST: wfn+ham+prop (inline); walker_type={}", int(walker_type));
+    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+  }
 
   // wfn, ham, prop, wlk
+  exec.clear();
+  exec.put_child("wavefunction",wfn_min);
+  exec.put_child("hamiltonian",ham_min);
+  exec.put_child("propagator",prop_min);
   exec.put_child("walker_set",wlk_min);
+  app_log(0,"[driver_fac] TEST: wfn+ham+prop+wlk (all inline); walker_type={}", int(walker_type));
   REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
 
-  // external wfn 
+  if (default_walker) {
+    // external wfn 
+    exec.clear();
+    exec.put("wavefunction","wfn0");
+    if (hamil_file == wfn_file) {
+      app_log(0,"[driver_fac] TEST: wfn only (external); walker_type={}", int(walker_type));
+      REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+    }
+
+    // wfn and ham
+    exec.put("hamiltonian","ham0");
+    app_log(0,"[driver_fac] TEST: wfn+ham (external); walker_type={}", int(walker_type));
+    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+
+    // wfn, ham, prop
+    exec.put("propagator","prop0");
+    app_log(0,"[driver_fac] TEST: wfn+ham+prop (external); walker_type={}", int(walker_type));
+    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+  }
+
+  // wfn, ham, prop, wlk (all external)
   exec.clear();
   exec.put("wavefunction","wfn0");
-  if (hamil_file == wfn_file)
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
-
-  // wfn and ham
   exec.put("hamiltonian","ham0");
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
-
-  // wfn, ham, prop
   exec.put("propagator","prop0");
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
-
-  // wfn, ham, prop, wlk
   exec.put("walker_set","wlk0");
+  app_log(0,"[driver_fac] TEST: wfn+ham+prop+wlk (all external); walker_type={}", int(walker_type));
   REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
 
   // mixed external internal
   exec.clear();
   exec.put_child("wavefunction",wfn_min);
   exec.put("walker_set","wlk0");
-  if (hamil_file == wfn_file)
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));  
+  if (hamil_file == wfn_file) {
+    app_log(0,"[driver_fac] TEST: wfn(inline)+wlk(external); walker_type={}", int(walker_type));
+    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+  }
 
-  exec.clear();
-  exec.put_child("wavefunction",wfn_min);
-  exec.put("hamiltonian","ham0");
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));  
+  if (default_walker) {
+    exec.clear();
+    exec.put_child("wavefunction",wfn_min);
+    exec.put("hamiltonian","ham0");
+    app_log(0,"[driver_fac] TEST: wfn(inline)+ham(external); walker_type={}", int(walker_type));
+    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));  
+  }
 
   exec.clear();
   exec.put("wavefunction","wfn0");
   exec.put_child("hamiltonian",ham_min);
   exec.put("walker_set","wlk0");
+  app_log(0,"[driver_fac] TEST: wfn(external)+ham(inline)+wlk(external); walker_type={}", int(walker_type));
   REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));  
 
   exec.clear();
   exec.put("wavefunction","wfn0");
   exec.put_child("hamiltonian",ham_min);
   exec.put_child("walker_set",wlk_min);
+  app_log(0,"[driver_fac] TEST: wfn(external)+ham(inline)+wlk(inline); walker_type={}", int(walker_type));
   REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
  
   // many more possibilities (combinatorial...) Add any problematic ones if needed
@@ -194,9 +242,9 @@ TEST_CASE("driver_fac", "[driver_factory]")
     app_log(0,"Driver factory unit testing. Running standard tests.");
     auto files = utils::molecule_unit_tests_files(true,true,true,true,false);
     for( auto f : files ) { 
-      driver_fac<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));
+      driver_fac<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),std::get<2>(f));
 #if defined(ENABLE_DEVICE)
-      driver_fac<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));
+      driver_fac<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),std::get<2>(f));
 #endif
     }
   }

--- a/src/AFQMC/Drivers/tests/test_driver_factory.cpp
+++ b/src/AFQMC/Drivers/tests/test_driver_factory.cpp
@@ -140,18 +140,18 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
     // wfn only - this is invalid unless wfn file and hamil file are the same
     if (hamil_file == wfn_file) {
       app_log(0,"[driver_fac] TEST: wfn only (inline); walker_type={}", int(walker_type));
-      REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+      CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
     }
     
     // wfn and ham
     exec.put_child("hamiltonian",ham_min);
     app_log(0,"[driver_fac] TEST: wfn+ham (inline); walker_type={}", int(walker_type));
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+    CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
 
     // wfn, ham, prop
     exec.put_child("propagator",prop_min);
     app_log(0,"[driver_fac] TEST: wfn+ham+prop (inline); walker_type={}", int(walker_type));
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+    CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
   }
 
   // wfn, ham, prop, wlk
@@ -161,7 +161,7 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   exec.put_child("propagator",prop_min);
   exec.put_child("walker_set",wlk_min);
   app_log(0,"[driver_fac] TEST: wfn+ham+prop+wlk (all inline); walker_type={}", int(walker_type));
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+  CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
 
   if (default_walker) {
     // external wfn 
@@ -169,18 +169,18 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
     exec.put("wavefunction","wfn0");
     if (hamil_file == wfn_file) {
       app_log(0,"[driver_fac] TEST: wfn only (external); walker_type={}", int(walker_type));
-      REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+      CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
     }
 
     // wfn and ham
     exec.put("hamiltonian","ham0");
     app_log(0,"[driver_fac] TEST: wfn+ham (external); walker_type={}", int(walker_type));
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+    CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
 
     // wfn, ham, prop
     exec.put("propagator","prop0");
     app_log(0,"[driver_fac] TEST: wfn+ham+prop (external); walker_type={}", int(walker_type));
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+    CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
   }
 
   // wfn, ham, prop, wlk (all external)
@@ -190,7 +190,7 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   exec.put("propagator","prop0");
   exec.put("walker_set","wlk0");
   app_log(0,"[driver_fac] TEST: wfn+ham+prop+wlk (all external); walker_type={}", int(walker_type));
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+  CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
 
   // mixed external internal
   exec.clear();
@@ -198,7 +198,7 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   exec.put("walker_set","wlk0");
   if (hamil_file == wfn_file) {
     app_log(0,"[driver_fac] TEST: wfn(inline)+wlk(external); walker_type={}", int(walker_type));
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+    CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
   }
 
   if (default_walker) {
@@ -206,7 +206,7 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
     exec.put_child("wavefunction",wfn_min);
     exec.put("hamiltonian","ham0");
     app_log(0,"[driver_fac] TEST: wfn(inline)+ham(external); walker_type={}", int(walker_type));
-    REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));  
+    CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));  
   }
 
   exec.clear();
@@ -214,14 +214,14 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   exec.put_child("hamiltonian",ham_min);
   exec.put("walker_set","wlk0");
   app_log(0,"[driver_fac] TEST: wfn(external)+ham(inline)+wlk(external); walker_type={}", int(walker_type));
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));  
+  CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));  
 
   exec.clear();
   exec.put("wavefunction","wfn0");
   exec.put_child("hamiltonian",ham_min);
   exec.put_child("walker_set",wlk_min);
   app_log(0,"[driver_fac] TEST: wfn(external)+ham(inline)+wlk(inline); walker_type={}", int(walker_type));
-  REQUIRE(DriverFac.executeDriver("afqmc","drv_test",0,exec));
+  CHECK(DriverFac.executeDriver("afqmc","drv_test",0,exec));
  
   // many more possibilities (combinatorial...) Add any problematic ones if needed
 }
@@ -241,10 +241,18 @@ TEST_CASE("driver_fac", "[driver_factory]")
    } else {
     app_log(0,"Driver factory unit testing. Running standard tests.");
     auto files = utils::molecule_unit_tests_files(true,true,true,true,false);
-    for( auto f : files ) { 
-      driver_fac<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),std::get<2>(f));
+    for( auto f : files ) {
+      try {
+        driver_fac<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),std::get<2>(f));
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in driver_fac<HOST_MEMORY>(" << std::get<0>(f) << "): " << e.what());
+      }
 #if defined(ENABLE_DEVICE)
-      driver_fac<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),std::get<2>(f));
+      try {
+        driver_fac<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),std::get<2>(f));
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in driver_fac<DEVICE_MEMORY>(" << std::get<0>(f) << "): " << e.what());
+      }
 #endif
     }
   }

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -193,11 +193,11 @@ void ham_ops_basic_serial(std::shared_ptr<utils::mpi_context_t<boost::mpi3::comm
   }
 
   auto h1 = HOps.getOneBodyPropagatorMatrix(dt,X_h(0,all));
-  REQUIRE( h1.shape() == std::array<long,3>{nspin,npol*NMO,npol*NMO} );
+  CHECK( h1.shape() == std::array<long,3>{nspin,npol*NMO,npol*NMO} );
 
   auto[vHS_nspin, vHS_npol] = HOps.vHS_dims();
   auto vHS = HOps.vHS(X,dt);
-  REQUIRE( vHS.shape() == std::array<long,4>{vHS_nspin,nwalk,vHS_npol*NMO,NMO} );
+  CHECK( vHS.shape() == std::array<long,4>{vHS_nspin,nwalk,vHS_npol*NMO,NMO} );
   auto vHS_h = nda::to_host(vHS);
   ComplexType Vsum = 0;
   for (int i = 0; i < vHS.extent(2); i++)
@@ -349,10 +349,18 @@ TEST_CASE("ham_ops_basic_serial", "[hamiltonian_operations]")
   } else {
     app_log(0,"HamiltonianOperations unit testing. Running standard tests.");
     auto files = utils::molecule_unit_tests_files(true,true,true,true,false);
-    for( auto f : files ) { 
-      ham_ops_basic_serial<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));
+    for( auto f : files ) {
+      try {
+        ham_ops_basic_serial<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in ham_ops_basic_serial<HOST_MEMORY>(" << std::get<0>(f) << "): " << e.what());
+      }
 #if defined(ENABLE_DEVICE)
-      ham_ops_basic_serial<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));
+      try {
+        ham_ops_basic_serial<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in ham_ops_basic_serial<DEVICE_MEMORY>(" << std::get<0>(f) << "): " << e.what());
+      }
 #endif
     }
   }

--- a/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
@@ -58,7 +58,7 @@ void ham_factory(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>
                " Hamiltonian file not found: {}. \n Run unit test with --hamil /path/to/hamil.h5 ", hamil_file);
 
   int NMO = read_nmo_from_hdf(hamil_file);
-  REQUIRE(NMO > 0);
+  CHECK(NMO > 0);
   int nup=1, ndown=1;
 
   std::map<std::string, AFQMCInfo> InfoMap;
@@ -79,20 +79,32 @@ TEST_CASE("ham_factory", "[hamiltonian_factory]")
   auto& mpi = utils::make_unit_test_mpi_context();
 
   if(UTEST_HAMIL!="") {
-    app_log(0,"Hamiltonian factory unit testing. Running user provided test:");
-    app_log(0," Hamiltonian: {}", UTEST_HAMIL);
-    ham_factory<HOST_MEMORY>(mpi,UTEST_HAMIL);
+    DYNAMIC_SECTION("User provided hamiltonian: " + UTEST_HAMIL) {
+      app_log(0,"Hamiltonian factory unit testing. Running user provided test:");
+      app_log(0," Hamiltonian: {}", UTEST_HAMIL);
+      ham_factory<HOST_MEMORY>(mpi,UTEST_HAMIL);
 #if defined(ENABLE_DEVICE)
-    ham_factory<DEVICE_MEMORY>(mpi,UTEST_HAMIL);
+      ham_factory<DEVICE_MEMORY>(mpi,UTEST_HAMIL);
 #endif
+    }
   } else {
     app_log(0,"Hamiltonian factory unit testing. Running standard tests.");
     auto files = utils::molecule_unit_tests_files(true,true,true,true,false);
-    for( auto f : files ) { 
-      ham_factory<HOST_MEMORY>(mpi,std::get<0>(f));
+    for( auto f : files ) {
+      DYNAMIC_SECTION("Hamiltonian file: " + std::get<0>(f)) {
+        try {
+          ham_factory<HOST_MEMORY>(mpi,std::get<0>(f));
+        } catch (const sfqmc::AppAbortException& e) {
+          FAIL_CHECK("APP_ABORT in ham_factory<HOST_MEMORY>(" << std::get<0>(f) << "): " << e.what());
+        }
 #if defined(ENABLE_DEVICE)
-      ham_factory<DEVICE_MEMORY>(mpi,std::get<0>(f));
+        try {
+          ham_factory<DEVICE_MEMORY>(mpi,std::get<0>(f));
+        } catch (const sfqmc::AppAbortException& e) {
+          FAIL_CHECK("APP_ABORT in ham_factory<DEVICE_MEMORY>(" << std::get<0>(f) << "): " << e.what());
+        }
 #endif
+      }
     }
   }
 }

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -113,7 +113,7 @@ void propg_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> 
   auto& wfn = WfnFac.getWavefunction(mpi, "wfn0", type, &ham, nwalk);
 
   auto initial_guess = WfnFac.getInitialGuess("wfn0");
-  REQUIRE(initial_guess.shape() == std::array<long,3>{nspin,npol*NMO,nup});
+  CHECK(initial_guess.shape() == std::array<long,3>{nspin,npol*NMO,nup});
   wset.resize(nwalk, initial_guess);
 
   ptree prop_pt;
@@ -189,11 +189,27 @@ TEST_CASE("propg_fac", "[propagator_factory]")
     app_log(0,"Propagator factory unit testing. Running standard tests.");
     auto files = utils::molecule_unit_tests_files(true,true,true,true,false);
     for( auto f : files ) {
-      propg_fac<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),false);
-      propg_fac<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),true);
+      try {
+        propg_fac<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),false);
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in propg_fac<HOST_MEMORY>(" << std::get<0>(f) << ", dense=false): " << e.what());
+      }
+      try {
+        propg_fac<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),true);
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in propg_fac<HOST_MEMORY>(" << std::get<0>(f) << ", dense=true): " << e.what());
+      }
 #if defined(ENABLE_DEVICE)
-      propg_fac<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),false);
-      propg_fac<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),true);
+      try {
+        propg_fac<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),false);
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in propg_fac<DEVICE_MEMORY>(" << std::get<0>(f) << ", dense=false): " << e.what());
+      }
+      try {
+        propg_fac<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f),true);
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in propg_fac<DEVICE_MEMORY>(" << std::get<0>(f) << ", dense=true): " << e.what());
+      }
 #endif
     }
   }

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -120,7 +120,7 @@ void wfn_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mp
   //nwalk=nw;
   auto wset = make_WalkerSet<MEM>(mpi, wlk_pt, InfoMap["info0"], rng);
   auto initial_guess = WfnFac.getInitialGuess("wfn0");
-  REQUIRE(initial_guess.shape() == std::array<long,3>{nspin,npol*NMO,nup});
+  CHECK(initial_guess.shape() == std::array<long,3>{nspin,npol*NMO,nup});
 
   wset.resize(nwalk, initial_guess);
 

--- a/src/AFQMC/config.h
+++ b/src/AFQMC/config.h
@@ -76,6 +76,18 @@ inline WALKER_TYPES initWALKER_TYPES(int i)
   return UNDEFINED_WALKER_TYPE;
 }
 
+inline std::string walkerTypeToString(WALKER_TYPES type)
+{
+  if (type == UNDEFINED_WALKER_TYPE) return "undefined";
+  else if (type == CLOSED) return "closed";
+  else if (type == COLLINEAR) return "collinear";
+  else if (type == NONCOLLINEAR) return "noncollinear";
+  else if (type == FULLYPOLARIZED) return "fullypolarized";
+  else if (type == COLLINEAR_FT) return "collinear-ft";
+  else if (type == NONCOLLINEAR_FT) return "noncollinear-ft";
+  return "undefined";
+}
+
 enum INTEGRAL_TYPES
 {
   UNDEFINED_INTEGRAL_TYPE,

--- a/src/IO/AppAbort.hpp
+++ b/src/IO/AppAbort.hpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <stdexcept>
 #include <mpi.h>
 #include <source_location>
 #include <cstdint>
@@ -32,6 +33,12 @@
 namespace sfqmc {
 
 extern bool __app_stacktrace__;
+extern bool __app_test_mode__;
+
+/// Exception thrown by APP_ABORT when the program is running in test mode.
+struct AppAbortException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
 
 #if defined(ENABLE_SPDLOG)
 
@@ -62,6 +69,8 @@ void APP_ABORT(Args&&... args)
   }
   spdlog::get("err_console")->flush();
   // Abort
+  if (__app_test_mode__)
+    throw AppAbortException("APP_ABORT triggered (see error log for details)");
   MPI_Abort(MPI_COMM_WORLD, 1);
 }
 
@@ -96,6 +105,8 @@ void APP_ABORT_with_source(const std::source_location& loc = std::source_locatio
   }
   spdlog::get("err_console")->flush();
   // Abort
+  if (__app_test_mode__)
+    throw AppAbortException("APP_ABORT triggered (see error log for details)");
   MPI_Abort(MPI_COMM_WORLD, 1);
 }
 
@@ -124,6 +135,8 @@ void APP_ABORT(const std::string_view format_string, Args&&... args)
   }
   std::cerr.flush();
   // Abort
+  if (__app_test_mode__)
+    throw AppAbortException(std::vformat(format_string, std::make_format_args(args...)));
   MPI_Abort(MPI_COMM_WORLD, 1);
 }
 
@@ -152,6 +165,8 @@ void APP_ABORT_with_source(const std::source_location& loc, const std::string_vi
     std::cerr<<"**********************************************\n";
   }
   std::cerr.flush();
+  if (__app_test_mode__)
+    throw AppAbortException(std::vformat(format_string, std::make_format_args(args...)));
   MPI_Abort(MPI_COMM_WORLD, 1);
 }
 

--- a/src/IO/AppAbort.hpp
+++ b/src/IO/AppAbort.hpp
@@ -33,7 +33,6 @@
 namespace sfqmc {
 
 extern bool __app_stacktrace__;
-extern bool __app_test_mode__;
 
 /// Exception thrown by APP_ABORT when the program is running in test mode.
 struct AppAbortException : public std::runtime_error {
@@ -69,8 +68,8 @@ void APP_ABORT(Args&&... args)
   }
   spdlog::get("err_console")->flush();
   // Abort
-  if (__app_test_mode__)
-    throw AppAbortException("APP_ABORT triggered (see error log for details)");
+
+  throw AppAbortException("APP_ABORT triggered (see error log for details)");
   MPI_Abort(MPI_COMM_WORLD, 1);
 }
 
@@ -105,9 +104,7 @@ void APP_ABORT_with_source(const std::source_location& loc = std::source_locatio
   }
   spdlog::get("err_console")->flush();
   // Abort
-  if (__app_test_mode__)
-    throw AppAbortException("APP_ABORT triggered (see error log for details)");
-  MPI_Abort(MPI_COMM_WORLD, 1);
+  throw AppAbortException("APP_ABORT triggered (see error log for details)");
 }
 
 #else
@@ -135,9 +132,7 @@ void APP_ABORT(const std::string_view format_string, Args&&... args)
   }
   std::cerr.flush();
   // Abort
-  if (__app_test_mode__)
-    throw AppAbortException(std::vformat(format_string, std::make_format_args(args...)));
-  MPI_Abort(MPI_COMM_WORLD, 1);
+  throw AppAbortException(std::vformat(format_string, std::make_format_args(args...)));
 }
 
 template<class... Args>
@@ -165,9 +160,8 @@ void APP_ABORT_with_source(const std::source_location& loc, const std::string_vi
     std::cerr<<"**********************************************\n";
   }
   std::cerr.flush();
-  if (__app_test_mode__)
-    throw AppAbortException(std::vformat(format_string, std::make_format_args(args...)));
-  MPI_Abort(MPI_COMM_WORLD, 1);
+
+  throw AppAbortException(std::vformat(format_string, std::make_format_args(args...)));
 }
 
 #endif // ENABLE_SPDLOG

--- a/src/IO/app_loggers.cpp
+++ b/src/IO/app_loggers.cpp
@@ -104,6 +104,5 @@ void set_output_level(bool root, int output_level)
 }
 
 void set_stacktrace(bool stk) { __app_stacktrace__ = stk; }
-void set_test_mode(bool t)    { __app_test_mode__   = t; }
 
 }

--- a/src/IO/app_loggers.cpp
+++ b/src/IO/app_loggers.cpp
@@ -21,6 +21,7 @@ namespace sfqmc {
 int __app_debug_level__ = -10000; 
 int __app_output_level__ = -10000; 
 bool __app_stacktrace__  = true;
+bool __app_test_mode__   = false;
 
 // currently using 2 separate loggers
 // app_log: uses "std_console" with a clean format only on Global().root()
@@ -103,5 +104,6 @@ void set_output_level(bool root, int output_level)
 }
 
 void set_stacktrace(bool stk) { __app_stacktrace__ = stk; }
+void set_test_mode(bool t)    { __app_test_mode__   = t; }
 
 }

--- a/src/IO/app_loggers.h
+++ b/src/IO/app_loggers.h
@@ -35,6 +35,7 @@ void setup_loggers(bool root=true, int output_level=2, int debug_level=0);
 void set_output_level(bool root, int output_level);
 void set_debug_level(bool root, int debug_level);
 void set_stacktrace(bool stk);
+void set_test_mode(bool t);
 
 template<class... Args>
 void app_log(int level, const std::string_view string_format, Args&&... args)

--- a/src/IO/app_loggers.h
+++ b/src/IO/app_loggers.h
@@ -35,7 +35,6 @@ void setup_loggers(bool root=true, int output_level=2, int debug_level=0);
 void set_output_level(bool root, int output_level);
 void set_debug_level(bool root, int debug_level);
 void set_stacktrace(bool stk);
-void set_test_mode(bool t);
 
 template<class... Args>
 void app_log(int level, const std::string_view string_format, Args&&... args)

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -119,6 +119,7 @@ int main(int argc, char** argv)
 
   // setup output loggers
   sfqmc::arch::init(root,output_level,debug_level);
+  sfqmc::set_test_mode(false);
 
   std::string welcome(
     std::string("") + 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -18,6 +18,7 @@
 #include "cxxopts.hpp"
 #include "IO/ptree/InputParser.hpp"
 #include "IO/app_loggers.h"
+#include "IO/AppAbort.hpp"
 
 #include "config.h"
 #include "configuration.hpp"
@@ -36,7 +37,7 @@
 
 /** @file safire.cpp
  */
-int main(int argc, char** argv)
+int main_impl(int argc, char** argv)
 {
   using namespace sfqmc;
   mpi3::environment env(argc, argv);
@@ -119,7 +120,6 @@ int main(int argc, char** argv)
 
   // setup output loggers
   sfqmc::arch::init(root,output_level,debug_level);
-  sfqmc::set_test_mode(false);
 
   std::string welcome(
     std::string("") + 
@@ -177,7 +177,15 @@ int main(int argc, char** argv)
       exit(1);	
     }
   } // simulations end
-
   return 0;
 }
 
+int main(int argc, char** argv) {
+  try {
+    return main_impl(argc, argv);
+  } catch (const sfqmc::AppAbortException& e) {
+    MPI_Abort(MPI_COMM_WORLD, 1);
+    mpi3::environment::finalize();
+    return 1;
+  } 
+}

--- a/src/utilities/catch_main.cpp
+++ b/src/utilities/catch_main.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "arch/arch.h"
 #include "utilities/mpi_context.h"
+#include "IO/app_loggers.h"
 
 #include<iostream>
 
@@ -48,6 +49,7 @@ int main(int argc, char* argv[])
     if(debug_level > 5) debug_level=2;
   }
   sfqmc::arch::init(world.root(),output_level,debug_level);
+  sfqmc::set_test_mode(true);
 
   Catch::Session session;
   using namespace Catch::clara;

--- a/src/utilities/catch_main.cpp
+++ b/src/utilities/catch_main.cpp
@@ -49,7 +49,6 @@ int main(int argc, char* argv[])
     if(debug_level > 5) debug_level=2;
   }
   sfqmc::arch::init(world.root(),output_level,debug_level);
-  sfqmc::set_test_mode(true);
 
   Catch::Session session;
   using namespace Catch::clara;

--- a/src/utilities/test_common.hpp
+++ b/src/utilities/test_common.hpp
@@ -32,6 +32,7 @@
 #include "nda/nda.hpp"
 #include "utilities/mpi_context.h"
 #include "AFQMC/config.h"
+#include "IO/app_loggers.h"
 
 namespace sfqmc {
 namespace utils {
@@ -53,7 +54,7 @@ inline constexpr auto molecule_unit_tests_files(bool rhf, bool uhf, bool ghf, bo
 {
   std::vector< std::tuple<std::string, std::string, afqmc::WALKER_TYPES> > files;
   auto pre = unit_test_base() + "molecules/";
-  if(nomsd) { 
+  if(nomsd) {
     if(rhf) {
       files.emplace_back( std::make_tuple(pre + "BH/afqmc_inputs/afqmc_H_rhf_closed.h5", 
                                           pre + "BH/afqmc_inputs/afqmc_rhf_nomsd.h5",
@@ -69,7 +70,7 @@ inline constexpr auto molecule_unit_tests_files(bool rhf, bool uhf, bool ghf, bo
       files.emplace_back( std::make_tuple(pre + "Li/afqmc_inputs/hamil_closed.h5",
                                           pre + "Li/afqmc_inputs/rohf_nomsd_fullypolarized.h5",
                                           afqmc::FULLYPOLARIZED) );
-    }    
+    }
     if(ghf) {
       files.emplace_back( std::make_tuple(pre + "BH/afqmc_inputs/afqmc_H_rhf_noncollinear.h5",
                                           pre + "BH/afqmc_inputs/afqmc_ghf_nomsd.h5",
@@ -144,7 +145,6 @@ inline std::shared_ptr<mpi_context_t<mpi3::communicator>>& make_unit_test_mpi_co
   if(not detail::__unit_test_mpi_context__) {
     detail::__unit_test_mpi_context__ =
          std::make_shared<mpi_context_t<boost::mpi3::communicator>>(make_mpi_context());
-
   }
   return detail::__unit_test_mpi_context__;
 }

--- a/src/utilities/test_common.hpp
+++ b/src/utilities/test_common.hpp
@@ -31,6 +31,7 @@
 #include "utilities/type_traits.hpp"
 #include "nda/nda.hpp"
 #include "utilities/mpi_context.h"
+#include "AFQMC/config.h"
 
 namespace sfqmc {
 namespace utils {
@@ -50,50 +51,60 @@ inline constexpr std::string unit_test_base()
 
 inline constexpr auto molecule_unit_tests_files(bool rhf, bool uhf, bool ghf, bool nomsd, bool phmsd) 
 {
-  std::vector< std::tuple<std::string, std::string> > files;
+  std::vector< std::tuple<std::string, std::string, afqmc::WALKER_TYPES> > files;
   auto pre = unit_test_base() + "molecules/";
   if(nomsd) { 
     if(rhf) {
       files.emplace_back( std::make_tuple(pre + "BH/afqmc_inputs/afqmc_H_rhf_closed.h5", 
-                                          pre + "BH/afqmc_inputs/afqmc_rhf_nomsd.h5") );
+                                          pre + "BH/afqmc_inputs/afqmc_rhf_nomsd.h5",
+                                          afqmc::UNDEFINED_WALKER_TYPE) );
     } 
     if(uhf) {
       files.emplace_back( std::make_tuple(pre + "BH/afqmc_inputs/afqmc_H_rhf_collinear.h5",
-                                          pre + "BH/afqmc_inputs/afqmc_uhf_nomsd.h5") );
+                                          pre + "BH/afqmc_inputs/afqmc_uhf_nomsd.h5",
+                                          afqmc::UNDEFINED_WALKER_TYPE) );
       files.emplace_back( std::make_tuple(pre + "BH/afqmc_inputs/afqmc_H_rhf_collinear.h5",
-                                          pre + "BH/afqmc_inputs/afqmc_uhf_nomsd_init_rhf.h5") );
+                                          pre + "BH/afqmc_inputs/afqmc_uhf_nomsd_init_rhf.h5",
+                                          afqmc::UNDEFINED_WALKER_TYPE) );
       files.emplace_back( std::make_tuple(pre + "Li/afqmc_inputs/hamil_closed.h5",
-                                          pre + "Li/afqmc_inputs/rohf_nomsd_fullypolarized.h5") );
+                                          pre + "Li/afqmc_inputs/rohf_nomsd_fullypolarized.h5",
+                                          afqmc::FULLYPOLARIZED) );
     }    
     if(ghf) {
       files.emplace_back( std::make_tuple(pre + "BH/afqmc_inputs/afqmc_H_rhf_noncollinear.h5",
-                                          pre + "BH/afqmc_inputs/afqmc_ghf_nomsd.h5") );
+                                          pre + "BH/afqmc_inputs/afqmc_ghf_nomsd.h5",
+                                          afqmc::NONCOLLINEAR) );
       files.emplace_back( std::make_tuple(pre + "Pb/afqmc_inputs/afqmc_H_rhf_basis_noncollinear_sf.h5",
-                                          pre + "Pb/afqmc_inputs/afqmc_ghf_sf_nomsd.h5") );
+                                          pre + "Pb/afqmc_inputs/afqmc_ghf_sf_nomsd.h5",
+                                          afqmc::NONCOLLINEAR) );
       // 🚧 Complex-value H1 in Q. Chem Hamiltonian got dropped! Add it back in after consulting with Miguel
       //files.emplace_back( std::make_tuple(pre + "Pb/afqmc_inputs/afqmc_H_rhf_basis_noncollinear_soc.h5",
-      //                                    pre + "Pb/afqmc_inputs/afqmc_ghf_soc_nomsd.h5") );
+      //                                    pre + "Pb/afqmc_inputs/afqmc_ghf_soc_nomsd.h5",
+      //                                    afqmc::UNDEFINED_WALKER_TYPE) );
     }
   }
   if (phmsd) {
     if (uhf) {
       // edge case: leading det only
       files.emplace_back( std::make_tuple(pre + "BH/afqmc_inputs/afqmc_H_rhf_collinear.h5",
-                                          pre + "BH/afqmc_inputs/afqmc_casci_uhf_1phmsd.h5") );
+                                          pre + "BH/afqmc_inputs/afqmc_casci_uhf_1phmsd.h5",
+                                          afqmc::UNDEFINED_WALKER_TYPE) );
       files.emplace_back( std::make_tuple(pre + "BH/afqmc_inputs/afqmc_H_uhf_collinear.h5",
-                                          pre + "BH/afqmc_inputs/afqmc_casci_uhf_phmsd.h5") );
+                                          pre + "BH/afqmc_inputs/afqmc_casci_uhf_phmsd.h5",
+                                          afqmc::UNDEFINED_WALKER_TYPE) );
       // may be redundant with above test: good for diversity of inputs
       files.emplace_back(std::make_tuple(pre + "N2/afqmc_inputs/cas_basis_hamil.h5",
-                                        pre + "N2/afqmc_inputs/cas_wfn.h5"));
+                                        pre + "N2/afqmc_inputs/cas_wfn.h5",
+                                        afqmc::UNDEFINED_WALKER_TYPE));
       }
   }
   return files;
 }
 
 
-inline constexpr auto lattice_unit_test_files(bool rhf = true, bool uhf, bool ghf, bool nomsd, bool phmsd) 
+inline constexpr auto lattice_unit_test_files(bool rhf, bool uhf, bool ghf, bool nomsd, bool phmsd) 
 {
-  std::vector< std::tuple<std::string, std::string> > files;
+  std::vector< std::tuple<std::string, std::string, afqmc::WALKER_TYPES> > files;
   auto pre = unit_test_base() + "lattices/";
   if(nomsd) {
     if(rhf) {
@@ -101,17 +112,20 @@ inline constexpr auto lattice_unit_test_files(bool rhf = true, bool uhf, bool gh
     } 
     if(uhf) {
       files.emplace_back( std::make_tuple(pre + "square4x4/afqmc_inputs/afqmc_H_rhf_collinear.h5",
-                                          pre + "square4x4/afqmc_inputs/afqmc_uhf_nomsd.h5") );
+                                          pre + "square4x4/afqmc_inputs/afqmc_uhf_nomsd.h5",
+                                          afqmc::UNDEFINED_WALKER_TYPE) );
     }    
     if(ghf) {
       files.emplace_back( std::make_tuple(pre + "square4x4/afqmc_inputs/afqmc_H_rhf_noncollinear.h5",
-                                          pre + "square4x4/afqmc_inputs/afqmc_ghf_nomsd.h5") );
+                                          pre + "square4x4/afqmc_inputs/afqmc_ghf_nomsd.h5",
+                                          afqmc::NONCOLLINEAR) );
     }
   }
   if (phmsd) {
     if (uhf) {
       files.emplace_back( std::make_tuple(pre + "square4x4/afqmc_inputs/afqmc_H_rhf_collinear.h5",
-                                          pre + "square4x4/afqmc_inputs/afqmc_casci_uhf_phmsd.h5") );
+                                          pre + "square4x4/afqmc_inputs/afqmc_casci_uhf_phmsd.h5",
+                                          afqmc::UNDEFINED_WALKER_TYPE) );
     }
   }
   return files;


### PR DESCRIPTION
Primarily addresses #55 by implementing "test mode" for `APP_ABORT()` and `APP_ABORT_with_source()`.

"test mode" is enabled within a C++ executable by calling `sfqmc::set_test_mode(true);`. For example, see 
https://github.com/SFQMC/SAFIRE/blob/5d0066f44b9fa132f9a4bc879faa60acec6d24b2/src/utilities/catch_main.cpp#L52-L68

Changes made:

1. implemented test mode for APP_ABROT() which throws an exception, `sfqmc::AppAbortException`, and enabled it for c++ unit test executables
2. Unit tests use catch and `FAIL_CHECK()` to register failed cases, but to continue to the next test case before exiting
3. Added additional entry to test case tuples which allow the walker type to be forced in some special cases