### PR TITLE
docs/examples: fix models/01, half of models/02

### DIFF
--- a/docs/examples/models/01_4x4_hubbard_model/index.md
+++ b/docs/examples/models/01_4x4_hubbard_model/index.md
@@ -46,10 +46,10 @@ there is no sign problem.
 
 from pathlib import Path
 # simple setup
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-home = Path.home()
-scratch_dir = get_scratch_dir("4x4_square_hubbard1",home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "dfgyQ5OC5xcn"}

--- a/docs/examples/models/01_4x4_hubbard_model/index.md
+++ b/docs/examples/models/01_4x4_hubbard_model/index.md
@@ -40,15 +40,10 @@ and spin density for the same filling and value of U.
 Next, we will demonstrated how to obtain exact results using AFQMC
 for the special case of half filling for which, if care is taken,
 there is no sign problem.
-We will end with an exercise where you will be asked to compute the ground state energy,
-charge density, and spin density of the Hubbard model on the 4x4 lattice at a different value
-of U than in the walk through.
 
 ```{code-cell} ipython3
 :id: d3YMrpqs5xcm
 
-%load_ext autoreload
-%autoreload
 from pathlib import Path
 # simple setup
 from tutorial_utils import run_afqmc, get_scratch_dir
@@ -190,7 +185,7 @@ It also accepts a user-supplied twist angle to used instead.
 ```
 Generating free-electron trial wavefunction with twist = [4.10803005e-06 4.58334805e-04]
 ```
-.
+
 
 We note that, because of the twist angle, the Hamiltonian will typically need to be rebuilt.
 All of this is done internally if `free_electron()` is given the original lattice, and hamiltonian parameters
@@ -370,10 +365,7 @@ outputId: 6de71736-72b7-4efa-bc41-8e0985c0759d
 # analyze
 from stats.scalar_dat import analyze_scalar_data
 
-### Exercise 1.1.1:####################################
-# change this value to a reasonable equilibration length
-nequil = 5.0 # Ha^{-1}
-#######################################################
+nequil = 5.0
 
 analysis_settings = dict(
     fname = fe_scratch_dir /"qmc.s000.scalar.dat",
@@ -392,10 +384,14 @@ ref_stoch_uncertainty = dE
 
 The Hubbard model at half-filling is sign-free, so we would expect numerically exact results; For U/t =4, the exact energy is -13.62185, so why do we disagree?
 
-1. the free-electron trial wavefunction may not always be sufficient, especially for sign-free cases. The trial wavefunction must exactly obey particle-hole symmetry, which requires special care for a free-electron trial wavefunction.
-2. We have used spin collinear Slater determinant random walkers. In general, we want to use spin noncollinear Slater determinant random walkers.
+Even if the underlying Hamiltonian is sign-free (i.e. $\langle \Psi_\mathrm{T}|\Phi\rangle \ge 0$ for all walkers $|\Phi\rangle$), in the importance sampled AFQMC random walk, an improperly chosen trial wavefunction can still induce a bias if its nodes $\langle \Psi_\mathrm{T}|\Phi\rangle = 0$ do not coincide with those of the ground state. Especially free-electron trial wavefunctions in open-shell geometries are susceptible to this problem.
 
-Next, we will use a Hartree-Fock trial wavefunction.
+There are different approaches to dealing with this problem. One can either
+
+1. move the nodes to the right position by choosing a trial wavefunction with the correct symmetry properties such as particle-hole symmetry or
+2. allow the walkers to move around the nodes ergodically by using a noncollinear wavefunction that is not aligned with the spin axis of the Hubbard-Stratonovich decoupling.
+
+Next, we will use a noncollinear Hartree-Fock trial wavefunction.
 
 +++ {"id": "tsMzr8175xcp"}
 
@@ -550,10 +546,7 @@ outputId: 78be3a24-0f0c-4577-cb48-6ad867cb1f1b
 # analyze
 from stats.scalar_dat import analyze_scalar_data
 
-### Exercise 1.1.1:####################################
-# change this value to a reasonable equilibration length
-nequil = 20.0 # Ha^{-1}
-#######################################################
+nequil = 20.0
 
 analysis_settings = dict(
     fname = fe_scratch_dir /"qmc.s000.scalar.dat",
@@ -564,10 +557,7 @@ analysis_settings = dict(
 
 E,dE = analyze_scalar_data(analysis_settings)
 
-print(f"The AFQMC energy is {E:.6f} +/- {dE:.6f} Hartree")
-
-# we will use this value in Exercise 1.1.2 as well
-ref_stoch_uncertainty = dE
+print(f"The AFQMC energy is {E:.6f} +/- {dE:.6f}")
 ```
 
 +++ {"id": "0vF3gnwWSgir"}
@@ -575,7 +565,7 @@ ref_stoch_uncertainty = dE
 If you used all of our settings, you should get see
 
 ```
-The AFQMC energy is -13.614404 +/- 0.004229 Hartree
+The AFQMC energy is -13.614404 +/- 0.004229
 ```
 
 Again, we expect to achieve very close to the exact energy for the Hubbard model at half filling which is -13.62185 for U/t=4.
@@ -590,7 +580,7 @@ Let's rerun with a smaller $\tau = 0.005$
 
 +++ {"id": "Q-t-66BmVVn5"}
 
-## Rerun AFQMC with a smaller Tau
+## Rerun AFQMC with a smaller τ
 
 When we decrease the step size, we will
 also need to increase the number of steps, and
@@ -650,11 +640,6 @@ outputId: 1d4d7374-5c21-43a7-eae5-46bafc88d52d
 # analyze
 from stats.scalar_dat import analyze_scalar_data
 
-### Exercise 1.1.1:####################################
-# change this value to a reasonable equilibration length
-nequil = 20.0 # Ha^{-1}
-#######################################################
-
 analysis_settings = dict(
     fname = fe_scratch_dir /"qmc.s000.scalar.dat",
     xaxis = "time",     # use units of imaginary time for equilibration
@@ -664,10 +649,7 @@ analysis_settings = dict(
 
 E,dE = analyze_scalar_data(analysis_settings)
 
-print(f"The AFQMC energy is {E:.6f} +/- {dE:.6f} Hartree")
-
-# we will use this value in Exercise 1.1.2 as well
-ref_stoch_uncertainty = dE
+print(f"The AFQMC energy is {E:.6f} +/- {dE:.6f}")
 ```
 
 +++ {"id": "SVS5nLE7YvBi"}
@@ -825,7 +807,6 @@ colab:
 id: fqLt304CwKks
 outputId: 4593e5a7-2e66-446b-e2b1-483f5193b453
 ---
-%autoreload
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -836,11 +817,11 @@ from afqmctools.hamiltonian.converter import read_hamiltonian
 from afqmctools.analysis.transform import hermitize_factory
 from afqmctools.analysis.average import WALKER_TYPE,get_metadata,average_observable
 
-SAIFRE_hdf5_output = fe_scratch_dir / "qmc.s003.stat.h5"
+SAFIRE_hdf5_output = fe_scratch_dir / "qmc.s003.stat.h5"
 nspins = 1 # this is a noncollinear calculation, so one (combined) spin sector!
 M = lattice.N_sites # get the number of sites to help with plotting
 
-walker_type = WALKER_TYPE[get_metadata(SAIFRE_hdf5_output)["WalkerType"]]
+walker_type = WALKER_TYPE[get_metadata(SAFIRE_hdf5_output)["WalkerType"]]
 
 # set up a transform the hermitize the one-rdm
 hermitize = hermitize_factory(
@@ -848,7 +829,7 @@ hermitize = hermitize_factory(
 )
 
 # get the metadata for plotting
-metadata = get_metadata(SAIFRE_hdf5_output,"/Observables/BackPropagated/")
+metadata = get_metadata(SAFIRE_hdf5_output,"/Observables/BackPropagated/")
 print(metadata)
 
 bp_steps = metadata["BackPropSteps"]
@@ -866,7 +847,7 @@ rho_downs = np.zeros((naverages,*lattice.L),dtype=np.complex128)
 for avg in range(naverages):
     # Extract and Transform data
     one_rdms[avg],one_rdms_err[avg] = average_observable(
-        SAIFRE_hdf5_output,
+        SAFIRE_hdf5_output,
         eqlb=5,
         estimator='back_propagated',
         name="one_rdm",
@@ -936,13 +917,6 @@ vis.plot_lattice(
 ```
 
 ```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 690
-id: monDoPiFSqFB
-outputId: cb55b227-850c-44cc-fe35-55651c9d71e7
----
 import afqmctools.utils.visualize as vis
 
 avg_to_plot = 1
@@ -960,5 +934,3 @@ vis.plot_lattice(
     vmax=0.5
 )
 ```
-
-+++ {"id": "Ie07h4Hu2p5B"}

--- a/docs/examples/models/02_stripes/index.md
+++ b/docs/examples/models/02_stripes/index.md
@@ -52,6 +52,11 @@ import afqmctools.observables.spin as spobs
 from tutorial_utils import run_afqmc
 
 import autohf
+
+from pathlib import Path
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
+
 ```
 
 +++ {"editable": true, "id": "083d8f36-02de-4281-a56c-7cd3d5add077"}
@@ -141,7 +146,7 @@ builder.finalize()
 ```{code-cell} ipython3
 :id: f94e92dd-9802-46ea-a1db-0baffb7efbb4
 
-io.write_model_hamiltonian(builder.hamiltonian, "afqmc.h5",
+io.write_model_hamiltonian(builder.hamiltonian, scratch_dir / "afqmc.h5",
                         nelec=nelec,spin_symm="collinear")
 ```
 
@@ -155,7 +160,7 @@ colab:
 # get a trial wavefunction: First, let's try a free-electron (i.e. non-interacting) wavefunction
 from afqmctools.wavefunction.model import write_free_electron_wfn
 write_free_electron_wfn(
-    hamiltonian_fname="afqmc.h5",
+    hamiltonian_fname=scratch_dir / "afqmc.h5",
     nelec=nelec
 )
 ```
@@ -219,7 +224,7 @@ outputId: 8c812e11-d1f3-454d-82c4-0322455b50bb
 colab:
   base_uri: https://localhost:8080/
 ---
-!mpirun -np 12 $AFQMC_EXEC afqmc.json
+!mpirun -np 12 $AFQMC_EXEC data/afqmc.json
 ```
 
 ```{code-cell} ipython3
@@ -236,7 +241,7 @@ from stats.scalar_dat import analyze_scalar_data
 nequil = 20.0
 
 analysis_settings = dict(
-    fname = "qmc.s000.scalar.dat",
+    fname = scratch_dir / "qmc.s000.scalar.dat",
     xaxis = "time",     # use units of imaginary time for equilibration
     nequil = 5,    # length of equilibration phase (in units of imaginary time)
     trace = True,       # plots a trace of the scalar data
@@ -265,7 +270,7 @@ def averageOverCols(Sz,Nx,Ny):
 ```{code-cell} ipython3
 :id: 0a52fe29-2397-4436-b84d-48b95ac5f777
 
-rho_avg, delta_rho = average_afqmc_rdm(rdm_file="qmc.s000.stat.h5")
+rho_avg, delta_rho = average_afqmc_rdm(rdm_file=scratch_dir / "qmc.s000.stat.h5")
 ```
 
 ```{code-cell} ipython3
@@ -356,12 +361,12 @@ for Ueff in [1,2,3,4]:
     # NOTICE: we must be careful here! We can either keep around afqmc.h5
     # which has the original Hamiltonian (U=6) and keep the wf and its Hamiltonian together
     # or we have one file with afqmc_Ueff which has both the wf and builder.hamiltonian
-    io.write_model_hamiltonian(builder_eff.hamiltonian, f"afqmc_{Ueff}.h5",
+    io.write_model_hamiltonian(builder_eff.hamiltonian, scratch_dir / f"afqmc_{Ueff}.h5",
                             nelec=nelec,spin_symm="collinear")
 
     hf_settings = dict(
         numSteps = 2000,
-        output = f"afqmc_{Ueff}.h5", # change file name!
+        output = scratch_dir / f"afqmc_{Ueff}.h5", # change file name!
         opt_method="lbfgs",
         ansatz="SD_ROT",
         nelec = nelec,
@@ -377,7 +382,7 @@ for Ueff in [1,2,3,4]:
     print(data["E_final"])
 
     write_json(
-        f"afqmc_{Ueff}.json",
+        scratch_dir / f"afqmc_{Ueff}.json",
         fwfn0="afqmc.h5",
         fham0="afqmc.h5",
         exec_opts=afqmc_params(0)
@@ -469,7 +474,7 @@ for Ueff in Ueffs:
         fname = "afqmc.h5"
     else:
         fname = f"afqmc_{Ueff}.h5"
-    (coeffs,wfn), psi0, (na, nb),spintype = read_wavefunction(fname)
+    (coeffs,wfn), psi0, (na, nb),spintype = read_wavefunction(scratch_dir / fname)
     # We assume spin balance below
     o = wfn.reshape(lattice.N_sites,na,2,order='F').real
     o = np.stack([o[:,:,0],o[:,:,1]])

--- a/docs/examples/models/02_stripes/index.md
+++ b/docs/examples/models/02_stripes/index.md
@@ -57,7 +57,6 @@ import autohf
 from pathlib import Path
 scratch_dir = Path("data")
 scratch_dir.mkdir(parents=True, exist_ok=True)
-
 ```
 
 +++ {"editable": true, "id": "083d8f36-02de-4281-a56c-7cd3d5add077"}

--- a/docs/examples/models/02_stripes/index.md
+++ b/docs/examples/models/02_stripes/index.md
@@ -32,16 +32,10 @@ config.update("jax_enable_x64", True)
 ```
 
 ```{code-cell} ipython3
-:id: 6883d177-8f0e-4e90-bea0-54b6c711cad6
+:id: f6e937d2-fde5-4f1b-afd9-6afb3798244a
 
 import matplotlib.pyplot as plt
 import numpy as np
-```
-
-```{code-cell} ipython3
-:id: f6e937d2-fde5-4f1b-afd9-6afb3798244a
-
-# all the imports used later in the tutorial, but put here for convenience
 
 import afqmctools.systems.lattice as lat
 import afqmctools.utils.visualize as vis
@@ -51,17 +45,11 @@ import afqmctools.hamiltonian.model.director as ham
 from afqmctools.wavefunction.converter import read_wavefunction
 from afqmctools.wavefunction.model import write_free_electron_wfn
 from afqmctools.analysis.rdm import average_afqmc_rdm
-```
-
-```{code-cell} ipython3
-:id: a332abc9-fc0a-4774-b316-6016060e0091
 
 from afqmctools.observables.greens import greens_1body
 import afqmctools.observables.spin as spobs
-```
 
-```{code-cell} ipython3
-:id: 8c9febda-fb02-489c-8c4f-422a343b80a2
+from tutorial_utils import run_afqmc
 
 import autohf
 ```
@@ -122,10 +110,12 @@ vis.plot_lattice(lattice)
 The Hamiltonian will be simple,
 
 $$
-H &= H_t + H_U + H_{pin} \\
+\begin{align}
+H &= H_t + H_U + H_\text{pin} \\
 H_t &= -t \sum_{\langle i j\rangle \sigma} c^\dagger_{i\sigma} c_{j\sigma} \\
 H_U &= U\sum_i n_{i\uparrow}n_{i\downarrow}\\
-H_{pin} &= \sum_{i\in \text{edge}} (-1)^{i_x+i_y} h_i S^z_i
+H_\text{pin} &= \sum_{i\in \text{edge}} (-1)^{i_x+i_y} h_i S^z_i
+\end{align}
 $$
 
 and we have a convenience function to add the edge pinning as well. We'll assume $t=1$, $h_i=0.5$ just like in the paper
@@ -140,7 +130,7 @@ colab:
 builder = ham.HamiltonianBuilder(
           lattice=lattice,
           spin_symm="collinear" # we have no spin-flip terms
-              )
+)
 # add standard Hubbard terms
 builder.nth_neighbor_hopping(1.0)
 builder.onsite_hubbard(U)
@@ -177,79 +167,49 @@ Now we'll write the file to run AFQMC. There are some better tools than this but
 ```{code-cell} ipython3
 :id: 866c943b-b811-40b9-a8a5-e257e30bda24
 
-def getInputJson(series,wf_fname,h_fname=None):
-    if h_fname is None:
-        h_fname = wf_fname
-    return f'''{{
-  "afqmc": {{
-    "project": {{
-      "id": "qmc",
-      "series": {series},
-      "mixed_precision": false
-    }},
-    "execute": {{
-      "walker_set": {{
-        "walker_type": "COLLINEAR"
-      }},
-      "wavefunction": {{
-        "filename": "{wf_fname}"
-      }},
-      "hamiltonian": {{
-        "filename": "{h_fname}"
-      }},
-      "timestep": 0.005,
-      "steps": 20000,
-      "accumlate_interval": 2,
-      "measure_interval": 2,
-      "population_control_interval" : 2,
-      "walker_ortho_interval" : 2,
-      "n_walkers_per_mpi_task": 540,
-      "estimator": {{
-        "name": "energy",
-        "overwrite": true,
-        "print_components": true
-      }},
-      "estimator": {{
-        "name":"back_propagation",
-        "path_restoration":true,
-        "extra_path_restoration":true,
-        "bp_walker_ortho_interval":2,
-        "nsteps":500,
-        "naverages":1,
-        "equil":2000,
-        "onerdm" : {{
-          "name":"onerdm"
-	      }}
-      }}
-    }}
-  }}
-}}
-'''
-```
+from afqmctools.inputs.from_hdf import write_json
 
-```{code-cell} ipython3
----
-id: b343c03f-ab1d-490a-a421-86a44864ecf4
-outputId: 200baf2a-73d2-4f0e-d713-4cc0c39f277a
-colab:
-  base_uri: https://localhost:8080/
----
-print(getInputJson(0,"afqmc.h5"))
-```
+# make an input file
+def afqmc_params(series):
+    return {
+        "project": {
+            "series": series,
+        },
+        "timestep": 0.005,
+        "steps": 20000,
+        "population_control_interval": 2,
+        "walker_ortho_interval": 2,
+        "n_walkers_per_mpi_task": 100,
+        "measure_interval_multiplier": 1,    
+        "estimator": {
+            "name": "energy",
+            "overwrite": True,
+            "print_components": True
+        },
+        "estimator": {
+            "name":"back_propagation",
+            "path_restoration": True,
+            "extra_path_restoration": True,
+            "bp_walker_ortho_interval": 2,
+            "measure_interval_multiplier": 250,
+            "equil_multiplier": 1000,
+            "onerdm" : {
+                "name":"onerdm"
+    	    }
+        },
+        "seed" : 42,                          # just for reproducibility
+        "propagator": {
+            "use_cp_constraint": True,
+            "use_real_vbias" : True
+        }
+    }
 
-```{code-cell} ipython3
-:id: 6e930735-29d0-4dc0-838d-475283cc6bb4
-
-with open("afqmc.json","w") as f:
-    lines = getInputJson(0,"afqmc.h5")
-    f.write(lines)
-```
-
-```{code-cell} ipython3
-:id: 59c74aca-3a04-4677-b6ab-fa1e1d61d366
-:outputId: df9d0f96-bb53-4ec7-a6cc-42462bd0a27e
-
-!sbatch --wait run_afqmc.sh afqmc.json
+write_json(
+    "afqmc.json",
+    fwfn0="afqmc.h5",
+    fham0="afqmc.h5",
+    exec_opts=afqmc_params(0)
+)
 ```
 
 ```{code-cell} ipython3
@@ -263,15 +223,27 @@ colab:
 ```
 
 ```{code-cell} ipython3
-:id: e8e41aff-0a7a-49fd-bbe8-821dc49fc7a8
-:outputId: 2091d2fd-7735-4d06-ef08-73f9d31f4ae8
+---
+id: nn3u7u8k5xcp
+colab:
+  base_uri: https://localhost:8080/
+  height: 921
+outputId: 78be3a24-0f0c-4577-cb48-6ad867cb1f1b
+---
+# analyze
+from stats.scalar_dat import analyze_scalar_data
 
-!scalar_stats qmc.s000.scalar.dat -s time -t -e 10.0 --savefig energy_fe.png
+nequil = 20.0
+
+analysis_settings = dict(
+    fname = "qmc.s000.scalar.dat",
+    xaxis = "time",     # use units of imaginary time for equilibration
+    nequil = 5,    # length of equilibration phase (in units of imaginary time)
+    trace = True,       # plots a trace of the scalar data
+)
+
+E,dE = analyze_scalar_data(analysis_settings)
 ```
-
-+++ {"id": "711d86ce-c4f5-4b17-88b6-4f11c90a4f79"}
-
-<img src="https://users.flatironinstitute.org/~beskridge/tutorial_figs/6784ee4ea455921958ac327234b91ab07702736ab22fa2df804e8dccbc36a404/models/ex02_stripes/energy_fe.png" width="800px" />
 
 +++ {"id": "e5e2892a-59fe-412e-9d8b-42f42c05ff79"}
 
@@ -357,7 +329,7 @@ plt.show()
 
 ## Self Consistency w/ Hartree-Fock
 
-The idea behind self-consistent AFQMC is to have the trial wave function match as much as possible the output of AFQMC. [cite me]
+The idea behind self-consistent AFQMC is to have the trial wave function match as much as possible the output of AFQMC.
 
 For this model, we can do this by introducing an effective Hubbard model, where $U$ is replaced with $U_{eff}$. By solving Hartree-Fock (mean field theory) for this effective model and using the result as a trial wave function, we can scan through different $U_{eff}$ to find the one that matches the best.
 
@@ -382,7 +354,7 @@ for Ueff in [1,2,3,4]:
     builder_eff.finalize()
 
     # NOTICE: we must be careful here! We can either keep around afqmc.h5
-    # which has the original Hamiltonian (U=6) and keep the wf and its hamiltonian together
+    # which has the original Hamiltonian (U=6) and keep the wf and its Hamiltonian together
     # or we have one file with afqmc_Ueff which has both the wf and builder.hamiltonian
     io.write_model_hamiltonian(builder_eff.hamiltonian, f"afqmc_{Ueff}.h5",
                             nelec=nelec,spin_symm="collinear")
@@ -404,9 +376,12 @@ for Ueff in [1,2,3,4]:
     )
     print(data["E_final"])
 
-    with open(f"afqmc_{Ueff}.json","w") as f:
-        lines = getInputJson(Ueff,f"afqmc_{Ueff}.h5","afqmc.h5")
-        f.write(lines)
+    write_json(
+        f"afqmc_{Ueff}.json",
+        fwfn0="afqmc.h5",
+        fham0="afqmc.h5",
+        exec_opts=afqmc_params(0)
+    )
     print(f"Written {Ueff}")
 ```
 
@@ -630,4 +605,3 @@ Lets use this as a test bed to explore how AFQMC responds to different settings.
 - Use a trial with a small number of steps so that the solver doesn't converge. How do the results change? How could you tell this trial isn't good?
 - The free electron trial isn't a valid RHF state (why?). What would be the corresponding RHF solution? What does that output look like?
 - Explore the parameters of backpropagation, how does the 1rdm change as a function of `nsteps`? you can include `naverages` to see the results converge
-

--- a/docs/examples/models/02_stripes/index.md
+++ b/docs/examples/models/02_stripes/index.md
@@ -48,6 +48,7 @@ from afqmctools.analysis.rdm import average_afqmc_rdm
 
 from afqmctools.observables.greens import greens_1body
 import afqmctools.observables.spin as spobs
+from afqmctools.inputs.from_autohf import autohf_to_afqmc
 
 from tutorial_utils import run_afqmc
 
@@ -175,23 +176,19 @@ Now we'll write the file to run AFQMC. There are some better tools than this but
 from afqmctools.inputs.from_hdf import write_json
 
 # make an input file
-def afqmc_params(series):
-    return {
-        "project": {
-            "series": series,
-        },
+afqmc_params = {
         "timestep": 0.005,
-        "steps": 20000,
+        "steps": 10000,
         "population_control_interval": 2,
         "walker_ortho_interval": 2,
-        "n_walkers_per_mpi_task": 100,
+        "n_walkers_per_mpi_task": 40,
         "measure_interval_multiplier": 1,    
-        "estimator": {
+        "estimator1": {
             "name": "energy",
             "overwrite": True,
             "print_components": True
         },
-        "estimator": {
+        "estimator2": {
             "name":"back_propagation",
             "path_restoration": True,
             "extra_path_restoration": True,
@@ -210,10 +207,11 @@ def afqmc_params(series):
     }
 
 write_json(
-    "afqmc.json",
-    fwfn0="afqmc.h5",
-    fham0="afqmc.h5",
-    exec_opts=afqmc_params(0)
+    scratch_dir / "afqmc.json",
+    fwfn0=scratch_dir / "afqmc.h5",
+    fham0=scratch_dir / "afqmc.h5",
+    exec_opts=afqmc_params,
+    series=0
 )
 ```
 
@@ -224,7 +222,7 @@ outputId: 8c812e11-d1f3-454d-82c4-0322455b50bb
 colab:
   base_uri: https://localhost:8080/
 ---
-!mpirun -np 12 $AFQMC_EXEC data/afqmc.json
+!cd data; mpirun -np 16 $AFQMC_EXEC afqmc.json
 ```
 
 ```{code-cell} ipython3
@@ -305,12 +303,6 @@ SzDmrg = np.loadtxt("data_10x4_Ne16U6.0_15360.dat",usecols=(1,))
 ```
 
 ```{code-cell} ipython3
-:id: 3790867c-321a-4e47-84f8-e82a1a407d07
-
-
-```
-
-```{code-cell} ipython3
 :id: d2e9c723-0471-404c-acb5-30e862b7905f
 :outputId: a53dc884-c7ab-43d4-9b39-1ad5c3e23957
 
@@ -346,7 +338,8 @@ _Note:_ The Hartree-Fock code is faster if you use a GPU
 :id: ee2b575c-7d27-4a1d-a9b9-e9b02a682f8f
 :outputId: 743ad05d-6d2a-4eba-ec3c-92e78bcbe2e3
 
-for Ueff in [1,2,3,4]:
+Ueffs = [1,2,3,4]
+for Ueff in Ueffs:
 
     builder_eff = ham.HamiltonianBuilder(
               lattice=lattice,
@@ -365,27 +358,30 @@ for Ueff in [1,2,3,4]:
                             nelec=nelec,spin_symm="collinear")
 
     hf_settings = dict(
-        numSteps = 2000,
-        output = scratch_dir / f"afqmc_{Ueff}.h5", # change file name!
+        steps = 2000,
         opt_method="lbfgs",
         ansatz="SD_ROT",
         nelec = nelec,
-        numTrials = 8,
+        batch_size = 8,
         seed = 1,
         noncollinear = False
     )
-    data = autohf.solver.lattice_hf(
-        hamiltonian=builder_eff.hamiltonian,
+    results = autohf.solver.lattice_hf(
+        hamiltonian=autohf.AutoHFHamiltonian(builder_eff.hamiltonian),
         lattice=lattice,
         settings=hf_settings,
     )
-    print(data["E_final"])
+    autohf_to_afqmc(
+        results,
+        output_fname = scratch_dir / f"afqmc_{Ueff}.h5"
+    )
 
     write_json(
         scratch_dir / f"afqmc_{Ueff}.json",
-        fwfn0="afqmc.h5",
-        fham0="afqmc.h5",
-        exec_opts=afqmc_params(0)
+        fwfn0=scratch_dir / f"afqmc_{Ueff}.h5",
+        fham0=scratch_dir / "afqmc.h5",
+        exec_opts=afqmc_params,
+        id = f"afqmc_{Ueff}"
     )
     print(f"Written {Ueff}")
 ```
@@ -393,8 +389,13 @@ for Ueff in [1,2,3,4]:
 ```{code-cell} ipython3
 :id: 3d68db2c-e000-4c4f-8b48-2f4bd5836749
 
-for Ueff in [1,2,3,4]:
-    !sbatch --wait run_afqmc.sh afqmc_{Ueff}.json
+for Ueff in Ueffs:
+    run_afqmc(
+        run_dir = scratch_dir,
+        input_file = f"afqmc_{Ueff}.json",
+        np = 16,
+        output_file = None
+    )        
 ```
 
 ```{code-cell} ipython3
@@ -402,8 +403,12 @@ for Ueff in [1,2,3,4]:
 
 rhos, deltas = [],[]
 
-for Ueff in [0,1,2,3,4]:
-    rho_avg, delta_rho = average_afqmc_rdm(rdm_file=f"qmc.s00{Ueff}.stat.h5")
+for Ueff in Ueffs:
+    if Ueff==0:
+        fname = "qmc.s000.stat.h5"
+    else:
+        fname = f"afqmc_{Ueff}.s000.stat.h5"
+    rho_avg, delta_rho = average_afqmc_rdm(rdm_file=scratch_dir / fname)
     rhos.append(rho_avg)
     deltas.append(delta_rho)
 ```
@@ -411,7 +416,7 @@ for Ueff in [0,1,2,3,4]:
 ```{code-cell} ipython3
 :id: 7f7e1dc8-4378-4da3-a77a-8e2638ed3c0e
 
-for Ueff,rho_avg,delta_rho in zip([0,1,2,3,4],rhos,deltas):
+for Ueff,rho_avg,delta_rho in zip(Ueffs,rhos,deltas):
     Xs,Ys,Zs = spobs.local_spin(np.vstack(rho_avg[0]),"collinear").real
 
     delta_Sz = np.sqrt(delta_rho[0,0].diagonal()**2+delta_rho[0,1].diagonal()**2 )
@@ -421,42 +426,16 @@ for Ueff,rho_avg,delta_rho in zip([0,1,2,3,4],rhos,deltas):
 
     fig,axes = plt.subplots(1,2,figsize=(12,4))
     p = axes[0].matshow(Zs.reshape(*lattice.L).T)
-    plt.colorbar(p,ax= axes[0])
+    plt.colorbar(p,ax= axes[0], label = "$S^z$")
 
 
     p =axes[1].matshow(delta_Sz.reshape(*lattice.L).T)
-    plt.colorbar(p,ax= axes[1])
+    plt.colorbar(p,ax= axes[1], label="$ΔSz$")
     if Ueff==0:
         fig.suptitle(f"Free Electron")
     else:
         fig.suptitle(f"{Ueff=}")
     plt.show()
-```
-
-```{code-cell} ipython3
-:id: 283e9c2b-2cac-44e7-80d6-42225a466de9
-
-# now we'll average over the columns
-
-for Ueff,rho_avg,delta_rho in zip([0,1,2,3,4],rhos,deltas):
-    Xs,Ys,Zs = spobs.local_spin(np.vstack(rho_avg[0]),"collinear").real
-
-    delta_Sz = np.sqrt(delta_rho[0,0].diagonal()**2+delta_rho[0,1].diagonal()**2 )
-    avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1))
-    if Ueff==0:
-        label = "AFQMC Free Electron"
-    else:
-        label = f"AFQMC W/ HF Ueff={Ueff}"
-    plt.errorbar(np.arange(lattice.L[0]),averageOverCols(Zs,*lattice.L),yerr=avg_delta_Sz,
-                 fmt='o-',label=label)
-plt.plot(-averageOverCols(SzDmrg,*lattice.L),'x-',label="DMRG",c='k')
-
-plt.xlabel("Col")
-plt.ylabel("Staggered Sz")
-plt.legend()
-
-# plt.ylim(-0.3,0.2)
-plt.show()
 ```
 
 +++ {"id": "8445abd3-e472-4406-9c2a-9ca3a8c8d3a3"}
@@ -487,16 +466,15 @@ for Ueff in Ueffs:
 :id: 2926392c-64b7-4c5b-be5a-d289adc38ff5
 
 # now we'll average over the columns
-Ueffs = [0,1,2,3,4]
-for Ueff,trial_rho in zip(Ueffs,trial_rhos):
-    Xs,Ys,Zs = spobs.local_spin(np.vstack(trial_rho),"collinear").real
-
-
+for Ueff,rho in zip(Ueffs,rhos):
+    Xs,Ys,Zs = spobs.local_spin(np.vstack(rho[0]),"collinear").real
+    
     avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1))
     if Ueff==0:
         label = "Free Electron"
     else:
         label = f"HF W/ HF Ueff={Ueff}"
+
     plt.errorbar(np.arange(lattice.L[0]),
                  averageOverCols(Zs,*lattice.L),yerr=avg_delta_Sz,
                  fmt='o--',label=label)

--- a/docs/examples/models/03_half_filling_hubbard/index.md
+++ b/docs/examples/models/03_half_filling_hubbard/index.md
@@ -63,7 +63,7 @@ The Hubbard model at Half Filling ($n=1$) has a special "symmetry" known as part
 
 [1]: _Benchmark study of the two-dimensional Hubbard model with auxiliary-field quantum Monte Carlo method_  
 M Qin, H Shi, S Zhang Phys. Rev. B 94, 085103 4 August, 2016  
-DOI: https://doi.org/10.1103/PhysRevB.94.085103  
+DOI: https://doi.org/10.1103/PhysRevB.94.085103
 
 +++ {"id": "678e6d9b-4d8f-4f74-87ee-2420b8588c57"}
 
@@ -115,9 +115,11 @@ plt.show()
 The Hamiltonian will be simple,
 
 $$
+\begin{align}
 H &= H_t + H_U \\
 H_t &= -t \sum_{\langle i j\rangle \sigma} c^\dagger_{i\sigma} c_{j\sigma} \\
 H_U &= U\sum_i n_{i\uparrow}n_{i\downarrow}
+\end{align}
 $$
 
 ```{code-cell} ipython3

--- a/docs/examples/models/03_half_filling_hubbard/index.md
+++ b/docs/examples/models/03_half_filling_hubbard/index.md
@@ -52,7 +52,14 @@ import afqmctools.observables.spin as spobs
 
 from stats.scalar_dat import analyze_scalar_data
 
+from tutorial_utils import run_afqmc
+
 import autohf
+from afqmctools.inputs.from_autohf import autohf_to_afqmc
+
+from pathlib import Path
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"editable": true, "id": "f91cf26c-5663-416e-9802-aeb1aa5a77c6"}

--- a/docs/examples/models/03_half_filling_hubbard/index.md
+++ b/docs/examples/models/03_half_filling_hubbard/index.md
@@ -173,7 +173,7 @@ T = builderHF.hamiltonian.get_one_body().toarray().reshape(2,lattice.N_sites,lat
 Because of the open shell at half filling, we'll follow Ref. 1 and use a GHF trial w/ AFM constrained to the X-Y plane (eq 14)
 
 $$
-H_{GHF} = -t\sum_{\langle ij\rangle \sigma} c^\dagger_{i\sigma}c_{j\sigma} + h.c. + \sum_{i}M_i c^\dagger_{i\uparrow}c_{i\downarrow} + h.c.
+H_\mathrm{GHF} = -t\sum_{\langle ij\rangle \sigma} c^\dagger_{i\sigma}c_{j\sigma} + \text{h.c.} + \sum_{i}M_i c^\dagger_{i\uparrow}c_{i\downarrow} + \text{h.c.}
 $$
 where $M_i= (-1)^i\Delta_i$
 
@@ -184,7 +184,7 @@ where $M_i= (-1)^i\Delta_i$
 We'll want to optimize $M$ directly, and to do this we'll use AutoHF's custom ansatz power to build a modification of the `DIAG` ansatz
 
 To do that we'll need:
-* `orbFunc` This takes a `state` and produces the orbitals
+* `orbitalFunc` This takes a `state` and produces the orbitals
 * `rdmFunc` this takes a `state` and produces the rdm $\langle c^\dagger_{\sigma i}c_{\sigma^\prime j}\rangle$
 * `state0` the initial state
 * `state0_ref` the initial state that should correspond to e.g. $U=0$
@@ -215,7 +215,7 @@ def orbitalFunc(state):
 
 def rdmFunc(state):
     o = orbitalFunc(state)
-    return autohf.solver.sdToRDM_noncollinear(o)
+    return autohf.solver.sd_to_rdm_noncollinear(o)
 ```
 
 ```{code-cell} ipython3
@@ -239,27 +239,27 @@ def checkPH(state):
 hf_settings = {
     "verbose": False,
     "plot": False,
-    "numSteps": 200,
+    "steps": 200,
     "seed": 1479,
     "noncollinear": True,
     "gpu": False,
     "ansatz": "CUSTOM",
     "opt_method": "lbfgs",
-    "numTrials": 16,
+    "batch_size": 16,
     "nelec": [Ne, Ne],
 }
 
 rng = np.random.default_rng(42)
 state0_ref = 0.0 * np.arange(N).reshape(N)
-state0 = state0_ref + rng.normal(scale=0.01, size=(hf_settings["numTrials"], N))
+state0 = state0_ref + rng.normal(scale=0.01, size=(hf_settings["batch_size"], N))
 
 
 dataHFC = autohf.solver.lattice_hf(
-    hamiltonian=builderHF.hamiltonian,
+    hamiltonian=autohf.AutoHFHamiltonian(builderHF.hamiltonian),
     lattice=lattice,
     settings=hf_settings,
-    orbFunc=orbitalFunc,
-    rdmFunc=rdmFunc,
+    state2orbitals=orbitalFunc,
+    state2rdm=rdmFunc,
     state0=state0,
     state0_ref=state0_ref,
 )
@@ -273,14 +273,14 @@ Let's check out what M values we got
 :id: e650b2a3-278d-4bed-8849-bd9952a2d028
 :outputId: 0380df75-7c1d-4fca-8576-44afe3681c1b
 
-dataHFC["state"]
+dataHFC[0]["state"]
 ```
 
 ```{code-cell} ipython3
 :id: 5186a0f6-63c1-4eb9-ab05-33c912a696b5
 :outputId: 489164a5-5f87-437d-9711-54d8adb6eb94
 
-plt.imshow(dataHFC["state"].reshape(4,4))
+plt.imshow(dataHFC[0]["state"].reshape(4,4))
 ```
 
 +++ {"id": "7956d434-41e8-4d69-b88e-4d4dc2f364cb"}
@@ -302,31 +302,35 @@ wfn_fname = "autoHF_wfn.h5"
 hf_settings = {
     "verbose": False,
     "plot": False,
-    "numSteps": 2000,  # increase
-    "output": wfn_fname,
+    "steps": 2000,  # increase
     "seed": 1479,
     "noncollinear": True,
     "gpu": False,
     "ansatz": "CUSTOM",
     "opt_method": "lbfgs",
-    "numTrials": 16,
+    "num_batches": 16,
     "nelec": [Ne, Ne],
 }
 
 rng = np.random.default_rng(42)
 state0_ref = 0.0 * np.arange(N).reshape(N)
-state0 = state0_ref + rng.normal(scale=0.01, size=(hf_settings["numTrials"], N))
+state0 = state0_ref + rng.normal(scale=0.01, size=(hf_settings["num_batches"], N))
 
 
-dataHFC = autohf.solver.lattice_hf(
-    hamiltonian=builderHF.hamiltonian,
+dataHFC2 = autohf.solver.lattice_hf(
+    hamiltonian=autohf.AutoHFHamiltonian(builderHF.hamiltonian),
     lattice=lattice,
     settings=hf_settings,
-    orbFunc=orbitalFunc,
-    rdmFunc=rdmFunc,
+    state2orbitals=orbitalFunc,
+    state2rdm=rdmFunc,
     state0=state0,
     state0_ref=state0_ref,
     jaxoptargs=dict(tol=1e-14),  # secret sauce
+)
+
+autohf_to_afqmc(
+    dataHFC2,
+    output_fname = scratch_dir / wfn_fname
 )
 ```
 
@@ -334,21 +338,21 @@ dataHFC = autohf.solver.lattice_hf(
 :id: 1a7cd7e0-e3b2-404b-9fbf-27a2effea563
 :outputId: e1c36aad-d05a-47f2-e5b4-9dcb49bf3561
 
-dataHFC2["state"]
+dataHFC2[0]["state"]
 ```
 
 ```{code-cell} ipython3
 :id: 53b7ce8c-b10a-4376-ba29-bfaabbf18024
 :outputId: 69f5278f-29f3-403b-8a76-5ba41ed39688
 
-checkPH(dataHFC2["state"])
+checkPH(dataHFC2[0]["state"])
 ```
 
 ```{code-cell} ipython3
 :id: 1818b009-35b7-497f-b3bb-2fee961a09cd
 :outputId: c8e409c6-a625-440d-ccaa-644ddee64dc4
 
-plt.imshow(dataHFC2["state"].reshape(4,4))
+plt.imshow(dataHFC2[0]["state"].reshape(4,4))
 ```
 
 +++ {"id": "0bbfe20c-66db-4b99-9f69-dfa45a29f0d1"}
@@ -359,7 +363,7 @@ Let's check that this is a better energy than the previous energy
 :id: c489bd73-3ae7-4943-b8a6-90705f5e3654
 :outputId: 64057b24-c950-4eea-8870-709650f095cc
 
-dataHFC2["E_final"] < dataHFC["E_final"]
+dataHFC2[0]["E"] < dataHFC[0]["E"]
 ```
 
 +++ {"id": "d7142e2a-a771-496a-8300-8547e0eec68d"}
@@ -372,15 +376,15 @@ Now let's check if we can guess a better state, by removing translation invarian
 :id: 8f623772-48d7-4b53-a629-70d668e830c1
 :outputId: 00efbe7f-e45a-48bd-f6ec-77c17b0813b1
 
-dataHFC2["energy_func"](dataHFC2["state"]) < dataHFC2["energy_func"](dataHFC2["state"]/np.abs(dataHFC2["state"]))
+dataHFC2[1]["energy_func"](dataHFC2[0]["state"]) < dataHFC2[1]["energy_func"](dataHFC2[0]["state"]/np.abs(dataHFC2[0]["state"]))
 ```
 
 ```{code-cell} ipython3
 :id: b02b905f-2789-4a5d-bac2-5847467d31a4
 :outputId: 693f28ca-8e55-4eb7-e17e-1a95e26d77ad
 
-uni_state = np.ones(lattice.N_sites)*np.mean(np.abs(dataHFC2["state"]))
-dataHFC2["energy_func"](dataHFC2["state"]) < dataHFC2["energy_func"](uni_state)
+uni_state = np.ones(lattice.N_sites)*np.mean(np.abs(dataHFC2[0]["state"]))
+np.isclose(dataHFC2[1]["energy_func"](dataHFC2[0]["state"]),dataHFC2[1]["energy_func"](uni_state))
 ```
 
 +++ {"id": "8944c9a6-fc6c-4cb0-9e07-8b8712bb5f45"}
@@ -399,65 +403,53 @@ First we'll manually create a non-interacting state as our RHF initial state for
 :id: 85b8e2f7-d035-4a12-bd53-a2eccf5ae40e
 
 ham_fname = f"hamU{U}_afqmc.h5"
-io.write_model_hamiltonian(builder.hamiltonian, ham_fname,
+io.write_model_hamiltonian(builder.hamiltonian, scratch_dir / ham_fname,
                         nelec=nelec,spin_symm="collinear")
 ```
 
 ```{code-cell} ipython3
 :id: 10617b29-48f0-4a65-9cd2-40f6199035c1
 
-def getInputJson(series,wf_fname,h_fname=None):
-    if h_fname is None:
-        h_fname = wf_fname
-    return f'''{{
-  "afqmc": {{
-    "project": {{
-      "id": "qmc",
-      "series": {series},
-      "mixed_precision": false
-    }},
-    "execute": {{
-      "walker_set": {{
-        "walker_type": "NONCOLLINEAR"
-      }},
-      "wavefunction": {{
-        "filename": "{wf_fname}"
-      }},
-      "hamiltonian": {{
-        "filename": "{h_fname}"
-      }},
-      "timestep": 0.005,
-      "steps": 20000,
-      "accumlate_interval": 2,
-      "measure_interval": 2,
-      "population" : 10,
-      "n_walkers_per_mpi_task": 100
-    }}
-  }}
-}}
-'''
-```
+afqmc_params = {
+        "timestep": 0.005,
+        "steps": 10000,
+        "population_control_interval": 2,
+        "walker_ortho_interval": 2,
+        "n_walkers_per_mpi_task": 40,
+        "measure_interval_multiplier": 1,    
+        "estimator": {
+            "name": "energy",
+            "overwrite": True,
+            "print_components": True
+        },
+    }
 
-```{code-cell} ipython3
-:id: 7645d79c-7c45-4a13-89c4-46f96ec29f86
-
-with open("afqmc.json","w") as f:
-    lines = getInputJson(0,wfn_fname,ham_fname)
-    f.write(lines)
+write_json(
+    scratch_dir / "afqmc.json",
+    fwfn0=scratch_dir / wfn_fname,
+    fham0=scratch_dir / ham_fname,
+    exec_opts=afqmc_params,
+    series=0
+)
 ```
 
 ```{code-cell} ipython3
 :id: 33a63a5d-ea54-4b9c-bbdd-14a281bb5d73
 :outputId: cc66b225-6079-444f-d976-160bae2fe148
 
-!sbatch --wait run_afqmc.sh afqmc.json
+run_afqmc(
+    run_dir = scratch_dir,
+    input_file = "afqmc.json",
+    np = 16,
+    output_file = None,
+)
 ```
 
 ```{code-cell} ipython3
 :id: 66d213fc-1f02-41e4-adc3-e1449a04b403
 :outputId: b9242712-fde9-4c91-a990-61cc5cf271f0
 
-!energy_stats qmc.s000.scalar.dat -x time -t -e 20.0 --savefig energy_fe.png
+!energy_stats {scratch_dir / "qmc.s000.scalar.dat"} -t -e 20.0
 ```
 
 ```{code-cell} ipython3
@@ -465,17 +457,16 @@ with open("afqmc.json","w") as f:
 :outputId: 02f67500-9f6f-4c12-a4d9-a5a206ddc890
 
 settings = dict(
-fname = "qmc.s000.scalar.dat",
-xaxis = "time",
-nequil = 50,
-trace = True,
-return_data= True,
-verbose = False,
-# column = "weight"
+    fname = scratch_dir / "qmc.s000.scalar.dat",
+    nequil = 14,
+    trace = True,
+    return_data= True,
+    verbose = False,
 )
 
 data = analyze_scalar_data(settings)
-E,err = data["mean"],data["error"]
+E = data["mean_real"]
+err = data["error_real"]
 ```
 
 ```{code-cell} ipython3

--- a/docs/examples/models/04_pair_correlators/index.md
+++ b/docs/examples/models/04_pair_correlators/index.md
@@ -23,12 +23,6 @@ At the end of this tutorial, you will know how to measure pair correlation funct
 1. How to set up the HDF5 and json input files to request pair correlation functions
 2. how to post process the correlation functions
 
-## Prerequisites
-
-In this tutorial, we assume that you have already completed all of the basic SAFIRE tutorials, but especially the following tutorials:
-
-1. ...
-
 +++ {"id": "7FBZ0COY-NIw"}
 
 ## Introduction
@@ -102,6 +96,39 @@ lattice = get_lattice(
 # plot the lattice for reality checks!
 plot_lattice(lattice)
 
+params = dict(
+    hamiltonian=dict(
+        t=1.0,
+        U=4.0
+    )
+)
+
+hamiltonian = HamiltonianDirector(source=params, lattice=lattice).build()
+
+from afqmctools.utils.io import write_model_hamiltonian
+
+write_model_hamiltonian(
+    hamiltonian=hamiltonian,
+    fname=scratch_dir/"afqmc.h5"
+)
+```
+
++++ {"id": "Np-zIkGusNIP"}
+
+## Saving index offsets in the HDF5 input
+
+The Lattice class from afqmctools can be directly used to find the pairs that we need via the `.get_directed_pairs()` function.
+`.get_directed_pairs()` needs a list of "directions", and it will return a dictionary where the keys are the requested directions, and the values are a list of index offsets, $\bar{i}_\alpha [i]$, such that $\bar{i}_{\alpha} [i] = i + e_\alpha$.
+
+```{code-cell} ipython3
+---
+colab:
+  base_uri: https://localhost:8080/
+  height: 907
+id: VjaOtDOltPAj
+outputId: 30ac79d1-e76e-4b8e-8c2c-6341210f4b4f
+---
+
 pairs_dict=lattice.get_directed_pairs(
   directions=["s","+x","-x","+y","-y"]
 )
@@ -110,38 +137,28 @@ for key,value in pairs_dict.items():
   print(key, value)
 ```
 
-+++ {"id": "lkkZMHMWvFAU"}
-
 afqmctools also provides a function for saving these pairs to HDF5 in the appropriate format.
 
-```python
+```{code-cell} ipython3
+%load_ext autoreload
+%autoreload
 from afqmctools.utils.io import write_pair_correlators
 
-write_pair_correlators("afqmc.h5",pair_dict)
+write_pair_correlators(scratch_dir / "afqmc.h5",pairs_dict)
 ```
+
++++ {"id": "lkkZMHMWvFAU"}
 
 ### Adding Custom Pairings
 
 We note that custom pairings can be added by simply inserting a list of offsets with a new key.
 For example, we can manually add "+x+y" pairing to the `pairs_dict` dictionary as
 
-```python
-pairs_dict["xy"] = [ 5, 6 , 7, 4, 9, 10, 11, 8, 13, 14, 15, 12, 1, 2, 3, 0]
-```
-
-As we are about to see, this will allow us to request "xy" pairing by name in the json input file. First, let's add this type of pairing to the dictionary by running the following code block.
-
 ```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: pQ6VQxOfwflK
-outputId: 87a8a569-ffd2-4e9b-9269-bf159742ea5a
----
 pairs_dict["xy"] = [ 5, 6 , 7, 4, 9, 10, 11, 8, 13, 14, 15, 12, 1, 2, 3, 0]
 
-for key,value in pairs_dict.items():
-  print(key, value)
+# update hdf5
+write_pair_correlators(scratch_dir / "afqmc.h5",pairs_dict)
 ```
 
 +++ {"id": "iwp3CeLownyV"}
@@ -158,7 +175,7 @@ They are:
 <div class="alert alert-block alert-info">
 <b>Note:</b>
   SAFIRE will measure all combinations of pairings that you request.
-  i.e. it will compute :math:`P^{\alpha \beta}_{ij}` where both :math:`\alpha` and :math:`\beta` run over the full set of pairing definitions.
+  i.e. it will compute $P^{\alpha \beta}_{ij}$ where both $\alpha$ and $\beta$ run over the full set of pairing definitions.
 </div>
 
 Since the pair correlation functions do not generally commute with the Hamiltonian, we should use a back-propagated estimator.
@@ -235,16 +252,84 @@ instead of the above.
 }
 ```
 
-+++ {"id": "SrM8syoYzUeS"}
+```{code-cell} ipython3
+from afqmctools.inputs.from_hdf import write_json
+from afqmctools.inputs.from_autohf import autohf_to_afqmc
+import autohf
 
-## Your Turn
-Run SAFIRE on a 4x4 Hubbard model with :math:`U=4`, and :math:`N_{\uparrow}=N_{⇓} = 7` using the full sample input file above.
+nelec = (8, 8)
+
+hf_settings = {
+    "verbose": False,
+    "plot": False,
+    "steps": 2000,
+    "seed": 1479,
+    "noncollinear": True,
+    "gpu": False,
+    "ansatz": "SD_ROT",
+    "seed": 42,
+    "batch_size": 8,
+    "nelec": nelec,
+}
+    
+wfn = autohf.solver.lattice_hf(
+    hamiltonian=autohf.AutoHFHamiltonian(hamiltonian),
+    lattice=lattice,
+    settings=hf_settings,
+)
+
+autohf_to_afqmc(
+    wfn,
+    output_fname = scratch_dir / "afqmc.h5"
+)
+
+
+afqmc_params = {
+    "timestep": 0.005,
+    "steps": 10000,
+    "population_control_interval": 2,
+    "walker_ortho_interval": 2,
+    "n_walkers_per_mpi_task": 40,
+    "measure_interval_multiplier": 1,    
+    "estimator": {
+        "name": "back_propagation",
+        "path_restoration": True,
+        "bp_walker_ortho_interval": 10,
+        "nsteps": 200,
+        "naverages": 4,
+        "equil": 200,
+        "pair_correlators" : {
+            "name" : "my_pair_correlators",
+            "filename" : "afqmc.h5",
+            "pair_type" : ["s","+x","-x","+y","-y","xy"]
+        }
+    }
+}
+
+write_json(
+    scratch_dir / "afqmc.json",
+    fwfn0=scratch_dir / "afqmc.h5",
+    fham0=scratch_dir / "afqmc.h5",
+    exec_opts=afqmc_params,
+    series=0
+)
+```
+
+```{code-cell} ipython3
+:id: SrM8syoYzUeS
+
+from tutorial_utils import run_afqmc
+run_afqmc(
+        run_dir = scratch_dir,
+        input_file = "afqmc.json",
+        np = 16,
+        output_file = None
+    )   
+```
 
 +++ {"id": "WIxdjnH-zopo"}
 
 ## Post-processing pair correlations functions
-
-...
 
 ```{code-cell} ipython3
 :id: eh8JuNVdag-o
@@ -258,15 +343,6 @@ from afqmctools.analysis.average import average_pair_correlation
 
 
 P,dP,correlator_names = average_pair_correlation("qmc.s000.stat.h5")
-
-lattice = get_lattice(
-    params={
-        'L1' : 4,
-        'L2' : 4,
-        'boundary1' : "pbc",
-        'boundary2' : "pbc"
-    }
-)
 
 for i in range(len(correlator_names)):
     print(f"correlator name: {correlator_names[i]}")
@@ -300,4 +376,3 @@ plot_lattice(
 
 1. How to set up the HDF5 and json input files to request pair correlation functions
 2. how to post process the correlation functions
-

--- a/docs/examples/models/04_pair_correlators/index.md
+++ b/docs/examples/models/04_pair_correlators/index.md
@@ -77,23 +77,18 @@ Additionally, specific pairings may be selected in the json input file.
 This allows the user to skip some of the offsets saved in the HDF5 file if desired.
 We will explore this in more detail below.
 
-+++ {"id": "Np-zIkGusNIP"}
++++
 
-## Saving index offsets in the HDF5 input
-
-The Lattice class from afqmctools can be directly used to find the pairs that we need via the `.get_directed_pairs()` function.
-`.get_directed_pairs()` needs a list of "directions", and it will return a dictionary where the keys are the requested directions, and the values are a list of index offsets, $\bar{i}_\alpha [i]$, such that $\bar{i}_{\alpha} [i] = i + e_\alpha$.
+## Defining the Hamiltonian
 
 ```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 907
-id: VjaOtDOltPAj
-outputId: 30ac79d1-e76e-4b8e-8c2c-6341210f4b4f
----
 from afqmctools.systems.lattice import get_lattice
 from afqmctools.utils.visualize import plot_lattice
+from afqmctools.hamiltonian.model.director import HamiltonianDirector
+from pathlib import Path
+
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 lattice = get_lattice(
     params=dict(

--- a/docs/examples/models/05_multi_slater_trial/index.md
+++ b/docs/examples/models/05_multi_slater_trial/index.md
@@ -15,12 +15,10 @@ kernelspec:
 
 # setup scratch dir
 from pathlib import Path
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-home = Path.home()
-scratch_rootdir = home / ".scratch"
-scratch_rootdir.mkdir(exist_ok=True)
-scratch_dir = get_scratch_dir("multi_slater_trial_lattice",scratch_rootdir)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "0WrZ0hFmBbdm"}

--- a/docs/examples/models/06_honeycomb_hubbard/index.md
+++ b/docs/examples/models/06_honeycomb_hubbard/index.md
@@ -22,12 +22,10 @@ kernelspec:
 
 # setup scratch dir
 from pathlib import Path
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-home = Path.home()
-scratch_rootdir = home / ".scratch"
-scratch_rootdir.mkdir(exist_ok=True)
-scratch_dir = get_scratch_dir("honeycomb_hubbard",scratch_rootdir)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 ```{code-cell} ipython3

--- a/docs/examples/models/07_tprime_hubbard/index.md
+++ b/docs/examples/models/07_tprime_hubbard/index.md
@@ -43,14 +43,11 @@ References:
 ```{code-cell} ipython3
 :id: 418bd9e4-4da9-4612-889f-6f365fc667a6
 
-%load_ext autoreload
-%autoreload
 # simple setup
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-#TODO: update this to a good directory for scratch files
-scratch_rootdir="."
-scratch_dir = get_scratch_dir("04_hubbard_tprime",scratch_rootdir)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "b8153eeb-0f28-4151-ad09-af65db81f358"}

--- a/docs/examples/models/08_lieb_lattice_emery/index.md
+++ b/docs/examples/models/08_lieb_lattice_emery/index.md
@@ -24,10 +24,10 @@ Status:
 
 from pathlib import Path
 
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-home = Path.home()
-scratch_dir = get_scratch_dir("ex_emery_model",home/".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "d13e8127-0310-46e7-8546-f7e2d7bed54e"}
@@ -281,7 +281,6 @@ vis.plot_lattice(
     cmap = 'bwr',
     show_labels=False
 )
-
 ```
 
 +++ {"id": "54616d5a-2831-45da-bd5f-b68621efc8f1"}

--- a/docs/examples/models/08_lieb_lattice_emery/index.md
+++ b/docs/examples/models/08_lieb_lattice_emery/index.md
@@ -383,7 +383,7 @@ hamiltonian_params = {
 }
 
 hamiltonian = HamiltonianDirector(
-    lattice=lattice,e
+    lattice=lattice,
     source=hamiltonian_params
 ).build()
 

--- a/docs/examples/molecules/03_n2-phmsd/03_nitrogen_dimer_pec.md
+++ b/docs/examples/molecules/03_n2-phmsd/03_nitrogen_dimer_pec.md
@@ -39,7 +39,6 @@ from afqmctools.utils.pyscf_utils import load_from_pyscf_chk_mol
 from afqmctools.hamiltonian.mol import write_hamil_mol
 from afqmctools.wavefunction.mol import write_cas_wfn
 from afqmctools.inputs.from_hdf import write_json
-from afqmctools.hamiltonian.io import write_to_hdf5
 
 from stats.scalar_dat import analyze_scalar_data
 

--- a/docs/examples/molecules/03_n2-phmsd/03_nitrogen_dimer_pec.md
+++ b/docs/examples/molecules/03_n2-phmsd/03_nitrogen_dimer_pec.md
@@ -24,17 +24,16 @@ using an appropriate trial wavefunction.
 1. How to select the number of Slater determinants to include in the trial wavefunction, balancing computational cost and accuracy
 2. How to automate the computation of a potential energy curve using afqmctools within Python
 
-## Run the code block below (shift+enter or click the play button) to set up the example
+## Run the code block below to set up the example
 
 ```{code-cell} ipython3
 :id: ljFeTy3vE6ls
 
-# Run me (shift+enter or click the play button) to setup the example!
 from pathlib import Path
 
 import h5py as h5
 import numpy as np
-from pyscf import gto,scf,mcscf
+from pyscf import gto,scf,mcscf,lib
 
 from afqmctools.utils.pyscf_utils import load_from_pyscf_chk_mol
 from afqmctools.hamiltonian.mol import write_hamil_mol
@@ -44,11 +43,12 @@ from afqmctools.hamiltonian.io import write_to_hdf5
 
 from stats.scalar_dat import analyze_scalar_data
 
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-# Note: set a scratch directory for the files that will be generated
-home = Path.home()
-scratch_dir = get_scratch_dir("n2_pec",home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
+
+num_mpi_tasks = 16 # adjust based on your resources
 ```
 
 +++ {"id": "6ZBVQf-6E6lv"}
@@ -87,7 +87,7 @@ Next, we will reproduce the PEC of the Nitrogen dimer using AFQMC / CASSCF(12o,6
 
 ### References:
 
-[1] W. A. Al-Saidi, S. Zhang, H. Krakauer. "Bond breaking with auxiliary-field quantum Monte Carlo." *J. Chem. Phys.* **127**, 144101 (2007).  
+[1] W. A. Al-Saidi, S. Zhang, H. Krakauer. "Bond breaking with auxiliary-field quantum Monte Carlo." *J. Chem. Phys.* **127**, 144101 (2007).
 
 +++ {"id": "ESezCWGWE6lv"}
 
@@ -156,12 +156,6 @@ as a basis.
 (alternatively, run your favorite Quantum Chemistry code, and save the CASSCF wavefunction in the wavefunction HDF5 file).
 
 ```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: banZfkP9E6lv
-outputId: f22826a2-4673-46ae-d474-e205edbf34b7
----
 # Here, we'll generate the mol object
 
 delta = 3.0 # Bohr
@@ -177,27 +171,23 @@ mol = gto.M(
 )
 
 # run CASSCF to get an orbital basis AND a CAS wavefunction
-casscf_chkfile = 'rhf_chkfile.h5'
+casscf_chkfile = scratch_dir / 'rhf_chkfile.h5'
+casscf_chkfile.unlink(missing_ok=True) # delete if already exists
 
 rhf = scf.RHF(mol)
-rhf.chkfile = scratch_dir / casscf_chkfile
+rhf.chkfile = casscf_chkfile
 rhf.run()
-
 mc = mcscf.CASSCF(rhf, 12, 6).run() # (12o,6e)
-
-# save some extra data to the checkpoint file
-with h5.File(scratch_dir/casscf_chkfile, 'a') as fp:
-    write_to_hdf5(fp,'mcscf/ci', data=mc.ci)
-    write_to_hdf5(fp,'mcscf/ncore', data=mc.ncore)
-    write_to_hdf5(fp,'mcscf/ncas', data=mc.ncas)
+# save the ci to the chkfile too
+lib.chkfile.save(mc.chkfile, 'mcscf/ci', mc.ci)
 
 # write the CAS wavefunction to a file
 write_cas_wfn(
     mol=mol,
-    cas_chkfile=scratch_dir / casscf_chkfile,
-    tol_trunc=1.0e-4, # use a small value to save *many* determinants.
+    cas_chkfile= casscf_chkfile,
+    tol_trunc=1.0e-3, # use a small value to save *many* determinants.
     outname=scratch_dir / 'afqmc.h5',
-    max_det=10000
+    max_det=2000
 )
 ```
 
@@ -225,15 +215,9 @@ afqmctools provides a helper function, `load_from_pyscf_chk_mol()`,  to read all
 </div>
 
 ```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: HsY52mSwHNUP
-outputId: 203092b0-1f3c-4c78-91a8-f4ea6a7e71e5
----
 # Save the Hamiltonian
 basis_scf_data = load_from_pyscf_chk_mol(
-    chkfile = scratch_dir / casscf_chkfile,
+    chkfile = casscf_chkfile,
     base = 'mcscf'
 )
 
@@ -308,15 +292,6 @@ will generate a "wavefunction" block that points to the wavefunction file, with 
 Note: This might take some time. You might want to run this on a computing cluster instead.
 
 ```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 1000
-id: LHnnxCprE6lv
-outputId: c1d0381b-92bd-43d2-b9eb-9b7d0a42aeeb
----
-num_mpi_tasks = 64
-
 # some shared parameters for the AFQMC run
 execute_options = {
     "timestep": 0.01,
@@ -329,7 +304,7 @@ execute_options = {
 }
 
 
-ndets = [14,50,200,500,1000] # list of Ndet values to run
+ndets = [50,250,500,750] # list of Ndet values to run
 energies = []
 stochastic_uncertainties = []
 # compute E(N_det) for the CAS trial wavefunction
@@ -342,11 +317,10 @@ for ndet in ndets:
     execute_options["wavefunction"] = { "ndets_to_read" : ndet }
 
     write_json(
-        scratch_dir_local/ "afqmc.json",
+        scratch_dir_local / "afqmc.json",
         fwfn0=scratch_dir / "afqmc.h5",
         exec_opts=execute_options
     )
-
     # run AFQMC
     run_afqmc(
         run_dir=scratch_dir_local,
@@ -377,13 +351,6 @@ for ndet in ndets:
 ### Plot $E_{AFQMC}$ vs $N_{det}$
 
 ```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 487
-id: wvlfZ8AJns9f
-outputId: b1f69758-5328-45bd-a247-810893ba95a8
----
 # plot the results
 import matplotlib.pyplot as plt
 
@@ -398,7 +365,7 @@ plt.show()
 
 ### Result
 
-From the plot of energy vs $N_{det}$, we have converged the AFQMC energy to within our target stochastic uncertainty of less than 1.6 $mE_{Ha}$ at about $N_{det} = 500$.
+From the plot of energy vs $N_{det}$, we have converged the AFQMC energy to within our target stochastic uncertainty of less than 1.6 m$E_\text{Ha}$ at about $N_{det} = 500$.
 Since we performed this test at a point on the PEC where there are strong static correlation effects, we expect this
 value to provide converged results across the PEC.
 Now, we can automate the calculation of the PEC using this value for $N_{det}$.
@@ -424,12 +391,12 @@ Run the cell block below in order to load the "run_afqmc_on_dimer()" function in
 ```{code-cell} ipython3
 :id: 8u68vNTFE6lw
 
-def run_afqmc_on_dimer(delta,ndets_to_read=None,scratch_root_dir=home / ".scratch", num_mpi_tasks=16):
+def run_afqmc_on_dimer(delta,ndets_to_read=None, num_mpi_tasks=16):
 
-    scratch_dir = get_scratch_dir(f"N2_bondlength_{delta:.4f}", scratch_root_dir)
+    scratch_dir = Path("data") / f"N2_bondlength_{delta:.4f}"
+    scratch_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"Running AFQMC on dimer with bond length {delta:.4f} Angstroms")
-    print("  [+] scratch_dir: ", scratch_dir)
 
     # 1. run CASSCF to get a basis and a trial wavefunction
     atom = f'''
@@ -450,12 +417,7 @@ def run_afqmc_on_dimer(delta,ndets_to_read=None,scratch_root_dir=home / ".scratc
     rhf.run()
 
     mc = mcscf.CASSCF(rhf, 12, 6).run() # (12o,6e)
-
-    # save some extra data to the checkpoint file
-    with h5.File(scratch_dir/casscf_chkfile, 'a') as fp:
-        write_to_hdf5(fp,'mcscf/ci', data=mc.ci)
-        write_to_hdf5(fp,'mcscf/ncore', data=mc.ncore)
-        write_to_hdf5(fp,'mcscf/ncas', data=mc.ncas)
+    lib.chkfile.save(mc.chkfile, 'mcscf/ci', mc.ci)
 
     # write the CAS wavefunction to a file
     fout = scratch_dir / 'afqmc.h5'
@@ -537,15 +499,19 @@ Now we can use the `run_afqmc_on_dimer()` function to compute the PEC of the $N_
 
 # we can simply use the automation function above to compute the PEC
 
-num_mpi_tasks = 64 # set this based on your resources!
+num_mpi_tasks = 16 # set this based on your resources!
 
-bondlengths = [2.118,2.4,2.7,3.0,3.6,4.2]
+# full dataset from the paper
+# bondlengths = [2.118,2.4,2.7,3.0,3.6,4.2]
+# reduced dataset for the example
+bondlengths = [2.118,2.7,3.6]
+
 ndets_to_read = 500
 
 energies = []
 stochastic_uncertainties = []
 for delta in bondlengths:
-  _, E, dE = run_afqmc_on_dimer(delta,ndets_to_read,scratch_root_dir=home / ".scratch",num_mpi_tasks=num_mpi_tasks)
+  _, E, dE = run_afqmc_on_dimer(delta,ndets_to_read, num_mpi_tasks=num_mpi_tasks)
   energies.append(E)
   stochastic_uncertainties.append(dE)
 ```
@@ -565,6 +531,7 @@ plt.errorbar(bondlengths, energies, yerr=stochastic_uncertainties, fmt='o:', lab
 plt.xlabel("Bond length (Bohr)")
 plt.ylabel("Energy (Ha)")
 plt.title(r"$N_2$ molecule PEC")
+plt.grid(True)
 plt.tight_layout()
 plt.show()
 ```
@@ -585,5 +552,3 @@ You have computed the potential energy curve (PEC) of the $N_2$ molecule, which 
 
 1. How to select the number of Slater determinants to include in the trial wavefunction, balancing computational cost and accuracy
 2. How to automate the computation of a potential energy curve using afqmctools within Python
-3. (optional) How to perform task 2 using bash and afqmctools instead
-

--- a/docs/examples/molecules/06_Pb-spin-orbit/06_Electron_affinity_of_Pb.md
+++ b/docs/examples/molecules/06_Pb-spin-orbit/06_Electron_affinity_of_Pb.md
@@ -55,7 +55,7 @@ well as the corresponding augmented cGTO basis sets [2-5].
 
 # setup the tutorials by runnig this block
 from pathlib import Path
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
 scratch_dir = Path("data")
 scratch_dir.mkdir(parents=True, exist_ok=True)

--- a/docs/examples/molecules/06_Pb-spin-orbit/06_Electron_affinity_of_Pb.md
+++ b/docs/examples/molecules/06_Pb-spin-orbit/06_Electron_affinity_of_Pb.md
@@ -25,8 +25,9 @@ The $Pb^-$ ion has a spin-quartet $6s^26p^3$ electron configuration with zero or
 much SOC effects than the neutral atom.
 Accounting for SOC is, of course, critical to achieve quantitative accuracy.
 
-AFQMC is able to exactly include SOC it is formulated in second quantization for a general orbital
-basis - i.e. versus real space methods in which non-local terms in the Hamiltonian such as SOC
+In contrast to real space methods in which non-local terms in the Hamiltonian, such as SOC, must be sampled,
+AFQMC is able to exactly include SOC because it is formulated in second quantization for a general orbital
+basis. This makes it an ideal tool for the study of systems and observables, where SOC effects are important.
 must be sampled - making it an ideal tool for the study of systems and observables
 where SOC effects are important.
 
@@ -36,7 +37,7 @@ where SOC effects are important.
 [2] K. A. Peterson, D. Figgen, E. Goll, H. Stoll, and M. Dolg, J. Chem. Phys. 119, 11113 (2003). https://doi.org/10.1063/1.1622924   
 [3] K. A. Peterson, B. C. Shepler, D. Figgen, and H. Stoll, J. Phys. Chem. A 110, 13877 (2006). https://doi.org/10.1021/jp065887l    
 [4] B. Metz, H. Stoll, and M. Dolg, J. Chem. Phys. 113, 2563 (2000). https://doi.org/10.1063/1.1305880    
-[5] K. A. Peterson, J. Chem. Phys. 119, 11099 (2003). https://doi.org/10.1063/1.1622923    
+[5] K. A. Peterson, J. Chem. Phys. 119, 11099 (2003). https://doi.org/10.1063/1.1622923
 
 +++ {"id": "PjMcWau9i2Xa"}
 
@@ -52,14 +53,12 @@ well as the corresponding augmented cGTO basis sets [2-5].
 :id: XSXP8e2IYxFb
 :outputId: 6c4e562d-b891-4890-fe3c-45c7898cfbfd
 
-%load_ext autoreload
 # setup the tutorials by runnig this block
 from pathlib import Path
 from tutorial_utils import run_afqmc, get_scratch_dir
 
-# For you TODO: set a scratch directory for the files that will be generated
-home = Path.home()
-scratch_dir = get_scratch_dir("03_ex_ea_of_Pb", home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 ecp_soc = {
     'Pb' : '''
@@ -211,7 +210,6 @@ the SOC-GHF or ROHF solution for the initial wavefunction.
 :id: 8I_FH4jPi2Xc
 :outputId: 308f3c0b-a95a-4fac-bb4f-10a6a5c45241
 
-%autoreload
 import h5py as h5
 import numpy as np
 
@@ -248,7 +246,6 @@ write_hamil_mol(
     chol_tol,
     dense=True,
     real_chol=True,
-    verbose=True,
     walker_type='ghf',
     with_soc=True
 )
@@ -284,11 +281,11 @@ from stats.scalar_dat import analyze_scalar_data
 # Write json input file
 execute_options = {
     "timestep": 0.005,
-    "steps": 20000,
+    "steps": 7000,
     "measure_interval_multiplier": 1,
     "population_control_interval" : 5,
     "walker_ortho_interval" : 10 ,
-    "n_walkers_per_mpi_task": 100,
+    "n_walkers_per_mpi_task": 80,
     "seed" : 42
 }
 write_json(
@@ -304,13 +301,12 @@ run_afqmc(
     timeout_mins=100,
     input_file="afqmc.json",
     np=16,             # number of MPI tasks
-    output_file=None, #"afqmc.out"   # optionally direct output to file instead of here
 )
 
 settings = dict(
     fname = local_scratch_dir/"qmc.s000.scalar.dat",
     xaxis = "time",
-    nequil = 20,
+    nequil = 8,
     trace = True
 )
 
@@ -399,7 +395,6 @@ colab:
 id: gAqSvXG3aB8I
 outputId: 8a825787-6626-44d1-97c4-ee738d109252
 ---
-%autoreload
 ### import h5py as h5
 import numpy as np
 
@@ -437,7 +432,6 @@ write_hamil_mol(
     chol_tol,
     dense=True,
     real_chol=True,
-    verbose=True,
     walker_type='ghf',
     with_soc=True
 )
@@ -481,11 +475,11 @@ from stats.scalar_dat import analyze_scalar_data
 # Write json input file
 execute_options = {
     "timestep": 0.005,
-    "steps": 20000,
+    "steps": 7000,
     "measure_interval_multiplier": 1,
     "population_control_interval" : 5,
     "walker_ortho_interval" : 10 ,
-    "n_walkers_per_mpi_task": 100,
+    "n_walkers_per_mpi_task": 70,
     "seed" : 42
 }
 write_json(
@@ -500,14 +494,13 @@ run_afqmc(
     run_mode="local_cpu",
     timeout_mins=100,
     input_file="afqmc.json",
-    np=16,             # number of MPI tasks
-    output_file=None, #"afqmc.out"   # optionally direct output to file instead of here
+    np=16,
 )
 
 settings = dict(
     fname = local_scratch_dir/"qmc.s000.scalar.dat",
     xaxis = "time",
-    nequil = 20,
+    nequil = 8,
     trace = True
 )
 

--- a/docs/examples/molecules/07_3d_TMO_benchmark/06_TMO_benchmark.py
+++ b/docs/examples/molecules/07_3d_TMO_benchmark/06_TMO_benchmark.py
@@ -71,7 +71,7 @@ import time
 
 import h5py as h5
 import numpy as np
-from pyscf import gto,scf,mcscf
+from pyscf import gto,scf,mcscf,lib
 import jax
 import jax.numpy as jnp
 
@@ -82,7 +82,6 @@ from afqmctools.utils.pyscf_utils import load_from_pyscf_chk_mol
 from afqmctools.hamiltonian.mol import write_hamil_mol
 from afqmctools.wavefunction.mol import write_cas_wfn
 from afqmctools.inputs.from_hdf import write_json
-from afqmctools.hamiltonian.io import write_to_hdf5
 
 from tutorial_utils import get_scratch_dir
 
@@ -258,12 +257,7 @@ def setup_benchmark(key:str, case:dict):
 
     # run CASSCF to get a basis / trial wavefunction
     mc = mcscf.CASSCF(rhf, ncas, nelec_cas).run()
-
-    # save some extra data to the checkpoint file
-    with h5.File(casscf_chkfile, 'a') as fp:
-        write_to_hdf5(fp,'mcscf/ci', data=mc.ci)
-        write_to_hdf5(fp,'mcscf/ncore', data=mc.ncore)
-        write_to_hdf5(fp,'mcscf/ncas', data=mc.ncas)
+    lib.chkfile.save(mc.chkfile, 'mcscf/ci', mc.ci)
     
     # write the CAS wavefunction to a file
     write_cas_wfn(

--- a/docs/examples/molecules/07_3d_TMO_benchmark/06_TMO_benchmark.py
+++ b/docs/examples/molecules/07_3d_TMO_benchmark/06_TMO_benchmark.py
@@ -83,10 +83,8 @@ from afqmctools.hamiltonian.mol import write_hamil_mol
 from afqmctools.wavefunction.mol import write_cas_wfn
 from afqmctools.inputs.from_hdf import write_json
 
-from tutorial_utils import get_scratch_dir
-
-home = Path.home()
-scratch_dir = get_scratch_dir("06_3d_tm_oxides",home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ecp_dir = Path("./files").resolve()
 
 # load the ECP and basis

--- a/docs/examples/molecules/07_3d_TMO_benchmark/get_results.py
+++ b/docs/examples/molecules/07_3d_TMO_benchmark/get_results.py
@@ -4,12 +4,7 @@ from warnings import warn
 import numpy as np
 
 from stats.scalar_dat import analyze_scalar_data
-from tutorial_utils import get_scratch_dir
-
-
-# For you TODO: set a scratch directory for the files that will be generated
-home = Path.home()
-scratch_dir = get_scratch_dir("3d_tm_oxides",home / ".scratch")
+scratch_dir = Path("data")
 ecp_dir = Path("./files").resolve()
 
 

--- a/docs/examples/molecules/08_local_embedding/08_local_embedding.md
+++ b/docs/examples/molecules/08_local_embedding/08_local_embedding.md
@@ -31,19 +31,18 @@ which, among other things, provides tools to analyze the locality of a set of or
 
 # Some setup
 from pathlib import Path
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
 # from embeddingAFQMC
 from embedding.orbital.assign import euclid_nd, gen_orbital_stats, print_stats
 
-# For you TODO: set a scratch directory for the files that will be generated
-home = Path.home()
-scratch_dir = get_scratch_dir("08_local_embedding", home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 Hartree = 27.211407953 # eV
 Bohr = 0.529177        # Angstrom
 
-MPI_TASKS = 64
+MPI_TASKS = 16
 ```
 
 +++ {"id": "vDrFukfq5u0t"}
@@ -81,7 +80,7 @@ from afqmctools.wavefunction.mol import write_wfn
 from afqmctools.inputs.from_hdf import write_json
 from stats.scalar_dat import analyze_scalar_data
 
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
 
 # custom metric to take the projection of the orbital position onto the xy plane
@@ -96,7 +95,7 @@ def get_afqmc_energy(h, Ro=np.inf, Rv=np.inf, N_energetic_core=0, rhf_guess_rdm=
     # run initial HF calculation to generate basis
 
     local_scratch = scratch_dir / f"h={h:5.5f}"
-    local_scratch.mkdir(exist_ok=True)
+    local_scratch.mkdir(parents=True, exist_ok=True)
     atom_chkfile = local_scratch / f"rhf_h={h:5.5f}.chk"
 
     def get_atomic_positions(h):
@@ -241,9 +240,9 @@ def get_afqmc_energy(h, Ro=np.inf, Rv=np.inf, N_energetic_core=0, rhf_guess_rdm=
     # 6. write json input file
     execute_options = {
         "timestep": 0.01,
-        "steps": 10000,
+        "steps": 6000,
         "population_control_interval" : 10,
-        "measure_interval_multiplier": 1, # will measure at interval of `measure_interval_multiplier*population_control_interval`
+        "measure_interval_multiplier": 1,
         "walker_ortho_interval" : 10,
         "n_walkers_per_mpi_task": 20,
         "seed" : 42,

--- a/docs/examples/molecules/tbd_H2O_charge_density/index.md
+++ b/docs/examples/molecules/tbd_H2O_charge_density/index.md
@@ -39,7 +39,6 @@ from afqmctools.utils.pyscf_utils import load_from_pyscf_chk_mol
 from afqmctools.hamiltonian.mol import write_hamil_mol
 from afqmctools.wavefunction.mol import write_cas_wfn
 from afqmctools.inputs.from_hdf import write_json
-from afqmctools.hamiltonian.io import write_to_hdf5
 
 from stats.scalar_dat import analyze_scalar_data
 

--- a/docs/examples/molecules/tbd_H2O_charge_density/index.md
+++ b/docs/examples/molecules/tbd_H2O_charge_density/index.md
@@ -42,11 +42,10 @@ from afqmctools.inputs.from_hdf import write_json
 
 from stats.scalar_dat import analyze_scalar_data
 
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-# For you TODO: set a scratch directory for the files that will be generated
-home = Path.home()
-scratch_dir = get_scratch_dir("example_h2o_density",home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "6ZBVQf-6E6lv"}

--- a/docs/examples/solids/06_magnetization/index.md
+++ b/docs/examples/solids/06_magnetization/index.md
@@ -532,9 +532,8 @@ If you are running remotely, you can add the `--savefig [filename].png` option t
 Note, you must still use `-t` to generate the plot.
 
 ```{code-cell} ipython3
----
-id: pmR1rRGJAenu
----
+:id: pmR1rRGJAenu
+
 !scalar_stats 3_afqmc/qmc.s000.scalar.dat -s time -t -e 5.0 --savefig 3_afqmc/energy_vs_beta.png
 ```
 

--- a/docs/snippets/02_running_afqmc/01_basic_ground_state_energy/readme.rst
+++ b/docs/snippets/02_running_afqmc/01_basic_ground_state_energy/readme.rst
@@ -38,7 +38,7 @@ A CPU-only build of SAFIRE can be invoked on rusty using the following runscript
     source $AFQMC_PATH/env.bash
 
     # Launch MPI code...
-    srun --cpu-bind=cores $AFQMC_PATH/bin/qmcapp --filenames afqmc.json &> afqmc.out
+    srun --cpu-bind=cores $AFQMC_PATH/bin/safire --filenames afqmc.json &> afqmc.out
 
 If the Hamiltonian and trial wavefunction file from :ref:`setup_ex_1` (called "afqmc.h5") is used with the input file above, then we will see output similar to this (perhaps with differences in the timing)
 

--- a/docs/snippets/02_running_afqmc/02_basic_back_propagation/readme.rst
+++ b/docs/snippets/02_running_afqmc/02_basic_back_propagation/readme.rst
@@ -49,7 +49,7 @@ A CPU-only build of SAFIRE can be invoked on rusty using the following runscript
     source $AFQMC_PATH/env.bash
 
     # Launch MPI code...
-    srun --cpu-bind=cores $AFQMC_PATH/bin/qmcapp --filenames afqmc.json &> afqmc.out
+    srun --cpu-bind=cores $AFQMC_PATH/bin/safire --filenames afqmc.json &> afqmc.out
 
 If the Hamiltonian and trial wavefunction file from :ref:`setup_ex_1` (called "afqmc.h5") is used with the input file above,
  then we will see output similar to this (perhaps with differences in the timing)

--- a/docs/tutorials/models/01_hello_safire/01_hello_safire.md
+++ b/docs/tutorials/models/01_hello_safire/01_hello_safire.md
@@ -562,7 +562,7 @@ Here is a typical example of using `run_afqmc()`.
 ```
 
 Where the `np` parameter is forwarded directly to `-np [np]` and
-`input_file` is passed to `qmcapp --filenames [input_file]`.
+`input_file` is passed to `safire --filenames [input_file]`.
 
 <div class="alert alert-block alert-info">
 <b>Note:</b>

--- a/docs/tutorials/models/01_hello_safire/01_hello_safire.md
+++ b/docs/tutorials/models/01_hello_safire/01_hello_safire.md
@@ -430,10 +430,10 @@ Try running SAFIRE with MPI! To get the same numbers as us, you will need to use
 
 ## Basic post-processing
 
-Now that we've learned how to invoke the SAIFRE executable from the command line in serial, using MPI, and using GPU(s),
-we are ready to learn how to extract the AFQMC energy from the outputs of SAIFRE using afqmctools.
+Now that we've learned how to invoke the SAFIRE executable from the command line in serial, using MPI, and using GPU(s),
+we are ready to learn how to extract the AFQMC energy from the outputs of SAFIRE using afqmctools.
 
-We previously ran SAIFRE on the Hamiltonian of the Hubbard model on a 4x4 lattice with periodic boundary conditions
+We previously ran SAFIRE on the Hamiltonian of the Hubbard model on a 4x4 lattice with periodic boundary conditions
 and $U/t = 4$, and using a UHF trial wavefunction.
 This generated a scalar data file, "qmc.s000.scalar.dat", which contains
 the scalar data that was accumulated during the AFQMC calculation, including the AFQMC energy.

--- a/docs/tutorials/models/01_hello_safire/01_hello_safire.md
+++ b/docs/tutorials/models/01_hello_safire/01_hello_safire.md
@@ -532,43 +532,7 @@ Now that we have learned how to extract the AFQMC energy from the outputs of SAF
 we are ready to how to use the tutorial helper functions to invoke SAFIRE and extract the AFQMC energy
 from within an interactive Python notebook.
 
-For convenience, we provide two helper functions in the `tutorials_utils` Python package.
-
-1. The `run_afqmc()` function runs the SAFIRE executable in one of the several ways that
-we described previously, depending on the `run_mode` parameter.
-2. the `get_scratch_dir()` function, will generate a scratch directory and return a Path pointing to the scratch directory.
-
-Together, these functions make it possible to complete the tutorials without leaving the interactive Python notebooks.
-We explain each function below.
-
-### get_scratch_dir()
-
-`get_scratch_dir()` will return a reference to the Path of a scratch directory that you get to set.
-By default, it will create the directory if it does not already exits.
-You can either specify the full path to the scratch directory as,
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire')
-```
-
-or, you can pass a scratch root directory and scratch directory name as
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('hello_safire', root_dir='/path/to/my/scratch/')
-```
-
-You can tell `get_scratch_dir()` to not attempt to create the directory with
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire',create=False)
-```
-
-+++ {"id": "N9bQJxCM-NIz"}
-
-### The run AFQMC convenience function
+For convenience, we provide the `run_afqmc()` helper function in the `tutorial_utils` Python package.
 
 `run_afqmc(input_file=input_file, np=np)` runs the SAFIRE executable as
 
@@ -585,9 +549,9 @@ You can tell `get_scratch_dir()` to not attempt to create the directory with
 Here is a typical example of using `run_afqmc()`.
 
 ```python
-    from tutorial_utils import run_afqmc, get_scratch_dir
+    from tutorial_utils import run_afqmc
 
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire')
+    scratch_dir = Path("data")
     
     run_afqmc(
         run_dir=scratch_dir,                # directory to run SAFIRE in - output files will be there
@@ -605,18 +569,6 @@ Where the `np` parameter is forwarded directly to `-np [np]` and
     There is no difference between running SAFIRE via `run_afqmc()` or
     directly in the command line other than convenience.
 </div>
-
-### (afqmctools) the analyze scalar data function
-
-The same functionality as `$ energy_stats`, from `afqmctools`, can
-be accessed directly in a Python script via the `analyze_scalar_data()` function.
-This is a standard component of `afqmctools`, and not just a part of these tutorials.
-
-For convenience, we will favor the use of `analyze_scalar_data()` within interactive Python
-notebooks; however, this is invoking exactly the same code as using `$ energy_stats` from
-the CLI.
-`energy_stats` can generate plots of the data, both from the CLI and from within Python.
-We will make use of this feature during the tutorials to visualize the results.
 
 ### Exercise: Run the full sample calculation using the convenience wrappers.
 
@@ -644,19 +596,18 @@ import numpy as np
 from afqmctools.hamiltonian.mol import write_hamiltonian_generic
 from afqmctools.wavefunction.mol import write_wfn
 from afqmctools.inputs.from_hdf import write_json
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 from stats.scalar_dat import analyze_scalar_data
 
-# For you TODO: set a scratch directory for the files that will be generated
-home = Path.home()
-scratch_dir = get_scratch_dir("hello_safire",home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 # copy the provided files
 files_dir = scratch_dir / "files"
 files_dir.mkdir(exist_ok=True)
-shutil.copy("files/input.json", scratch_dir / "files" )
-shutil.copy("files/hamil.h5", scratch_dir / "files" )
-shutil.copy("files/wfn.h5", scratch_dir / "files" )
+shutil.copy("files/input.json", files_dir)
+shutil.copy("files/wfn.h5", files_dir)
+shutil.copy("files/hamil.h5", files_dir)
 
 run_afqmc(
     run_dir=scratch_dir,

--- a/docs/tutorials/models/04_building_and_writing_a_hamiltonian/04_building_and_writing_a_hamiltonian.md
+++ b/docs/tutorials/models/04_building_and_writing_a_hamiltonian/04_building_and_writing_a_hamiltonian.md
@@ -82,12 +82,10 @@ Run the cell below to setup a scratch directory.
 
 # setup scratch dir
 from pathlib import Path
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-home = Path.home()
-scratch_rootdir = home / ".scratch"
-scratch_rootdir.mkdir(exist_ok=True)
-scratch_dir = get_scratch_dir("lattice_04_hamiltonian_director",scratch_rootdir)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "WcOH6y7xOK_V"}

--- a/docs/tutorials/models/05_hamiltonian_builder/05_hamiltonian_builder.md
+++ b/docs/tutorials/models/05_hamiltonian_builder/05_hamiltonian_builder.md
@@ -116,7 +116,11 @@ are included.
 
 from afqmctools.systems.lattice import get_lattice
 from afqmctools.hamiltonian.model.builder import HamiltonianBuilder
-from afqmctools.utils.io import write_model_hamiltion
+from afqmctools.utils.io import write_model_hamiltonian
+from pathlib import Path
+
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 lattice = get_lattice(
     params={
@@ -137,9 +141,9 @@ builder.onsite_hubbard(4.0)
 builder.finalize()
 
 # save for latter use
-write_model_hamiltion(
+write_model_hamiltonian(
     hamiltonian=builder.hamiltonian,
-    fname='hamiltonian.h5'
+    fname=scratch_dir / 'hamiltonian.h5'
 )
 ```
 

--- a/docs/tutorials/models/05_hamiltonian_builder/05_hamiltonian_builder.md
+++ b/docs/tutorials/models/05_hamiltonian_builder/05_hamiltonian_builder.md
@@ -225,7 +225,6 @@ to cover
     - uniform
     - band/sublattice degrees of freedom (individual and combined)
 - hst over-rides (expert-mode)
-  
 
 ```{code-cell} ipython3
 :id: 91b862e0-881c-4e53-a5ee-cd23ede58378

--- a/docs/tutorials/models/06_writing_a_trial_wavefunction/06_writing_a_trial_wavefunction.md
+++ b/docs/tutorials/models/06_writing_a_trial_wavefunction/06_writing_a_trial_wavefunction.md
@@ -50,6 +50,11 @@ Generate a wavefunction of the form $\Psi = \Psi^\uparrow \otimes \Psi^\downarro
 ```{code-cell} ipython3
 :id: TdBbEZh8TeCS
 
+import numpy as np
+from pathlib import Path
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
+
 nx = 2
 ny = 2
 nelec = (2,2)

--- a/docs/tutorials/models/06_writing_a_trial_wavefunction/06_writing_a_trial_wavefunction.md
+++ b/docs/tutorials/models/06_writing_a_trial_wavefunction/06_writing_a_trial_wavefunction.md
@@ -60,11 +60,11 @@ ny = 2
 nelec = (2,2)
 assert (nelec[0]==nelec[1])
 norb = nx * ny
-wfn_input_filename = "wfn_rhf_test.h5"
+wfn_input_filename = scratch_dir / "wfn_rhf_test.h5"
 sd_rhf = np.arange(0,norb * sum(nelec)//2, 1).reshape([1, norb, sum(nelec)//2])
 ci = np.ones([1],dtype = np.float64)
 write_wfn(filename=wfn_input_filename, wfn=[ci,sd_rhf],
-          walker_type='rhf',
+          walker_type='closed',
           nelec=nelec,
           norb=norb)
 ```
@@ -76,7 +76,7 @@ If you use `!h5dump wfn_rhf_test.h5` to inspect the output file, you'll see the 
 In summary, to generate an RHF wavefunction, you need to provide an array `A[0, i, j]` = $\Psi_{ij}^↑$ with shape `(1, norb, nelec // 2)` as input. Setting walker_type='rhf' ensures the wavefunction is constructed in a spin-identical manner, meaning the same orbitals are used for both spin components.
 
 ```{code-cell} ipython3
-!h5dump wfn_rhf_test.h5 | head
+!h5dump wfn_rhf_test.h5 | head -n 20
 ```
 
 +++ {"id": "o6ZmCwG4XFM_"}
@@ -92,11 +92,12 @@ nx = 2
 ny = 2
 nelec = (2, 3)
 norb = nx * ny
-wfn_input_filename = "wfn_uhf_test.h5"
-sd_uhf = np.arange(0, norb * sum(nelec), 1).reshape([1, norb, sum(nelec)])
+wfn_input_filename = scratch_dir / "wfn_uhf_test.h5"
+sd_uhf = (np.arange(0, norb * sum(nelec), 1)**1.2).reshape([1, norb, sum(nelec)])
+
 ci = np.ones([1], dtype = np.float64)
 write_wfn(filename=wfn_input_filename, wfn=[ci, sd_uhf],
-          walker_type='uhf',
+          walker_type='collinear',
           nelec=nelec,
           norb=norb)
 ```
@@ -129,11 +130,12 @@ nelec = (4, 0)
 # as long as the total number of electrons is the same
 # This is because the GHF wavefunction does not distinguish between spin-up and spin-down components.
 norb = nx * ny
-wfn_input_filename = "wfn_ghf_test.h5"
-sd_uhf = np.arange(0, 2 * norb * sum(nelec), 1).reshape([1, 2 * norb, sum(nelec)])
+wfn_input_filename = scratch_dir / "wfn_ghf_test.h5"
+sd_ghf = (np.arange(0, 2 * norb * sum(nelec), 1)**1.2).reshape([1, 2 * norb, sum(nelec)])
+
 ci = np.ones([1], dtype = np.float64)
 write_wfn(filename=wfn_input_filename, wfn=[ci, sd_uhf],
-          walker_type='ghf',
+          walker_type='noncollinear',
           nelec=nelec,
           norb=norb)
 ```
@@ -155,18 +157,18 @@ In summary, to generate a GHF wavefunction, you need to provide an array `A[0, i
 
 Multi-Slater trial wavefunctions are also supported in lattice models. To enable this, the input variable `ci` is provided, which is a 1D array representing the coefficients of the Slater determinants. Correspondingly, the Slater determinant inputs include an extra dimension to stack multiple Slater matrices. To generate a multi-Slater trial wavefunction, simply supply the `ci` array as the list of coefficients and stack the individual Slater matrices along the first dimension—everything else will be handled automatically.
 
-```{code-cell}
+```{code-cell} ipython3
 :id: gchHR_d5jhPN
 
 nx = 2
 ny = 2
 nelec = (4, 0) # (3, 1) or (2, 2) or (1, 3) or (0,4) are equivalent as long as sum(nelec) is the same
 norb = nx * ny
-wfn_input_filename = "wfn_multi_ghf_test.h5"
-sd_uhf = np.arange(0, 3 * 2 * norb * sum(nelec), 1).reshape([3, 2 * norb, sum(nelec)])
+wfn_input_filename = scratch_dir / "wfn_multi_ghf_test.h5"
+sd_uhf = (np.arange(0, 3 * 2 * norb * sum(nelec), 1)**1.4).reshape([3, 2 * norb, sum(nelec)])
 ci = np.array([1, -1, 4], dtype = np.float64)
 write_wfn(filename=wfn_input_filename, wfn=[ci, sd_uhf],
-          walker_type='ghf',
+          walker_type='noncollinear',
           nelec=nelec,
           norb=norb)
 ```
@@ -197,7 +199,7 @@ We can generate a free-electron trial wavefunction using the `free_electron` fun
 :id: XDDPCMhvHKRc
 
 from afqmctools.systems.lattice import get_lattice
-from afqmctools.hamiltonian.model.builder import HamiltonianBuilder
+from afqmctools.hamiltonian.model.director import HamiltonianDirector
 from afqmctools.hamiltonian.model.ham_class import HamiltonianComponent, SpinSymm
 from afqmctools.utils.io import write_model_hamiltonian
 from afqmctools.wavefunction.free_electron import free_electron
@@ -222,23 +224,19 @@ Uhubb = 4.0
 #    hopping[n-1] is 't^{n}'
 hopping = [1.0,0.0]
 
-builder = HamiltonianBuilder(
-    lattice=lattice,
-    spin_symm=SpinSymm.COLLINEAR
-)
-# add standard Hubbard terms
-builder.nth_neighbor_hopping(t=hopping)
-builder.onsite_hubbard(U=Uhubb)
+hamiltonian = HamiltonianDirector(source=dict(
+    hamiltonian=dict(
+        t=hopping,
+        U=Uhubb,
+    )),
+    lattice=lattice
+).build()
 
 nbasis = lattice.N_sites
 
-builder.finalize()
-
-hamiltonian = builder.hamiltonian
-
 write_model_hamiltonian(
     hamiltonian=hamiltonian,
-    fname="hamil.h5",
+    fname=scratch_dir / "hamil.h5",
     nelec=nelec
 )
 
@@ -251,7 +249,7 @@ wfn,spin_symm = free_electron(
 
 # and write the wavefunction for use in SAFIRE
 write_wfn(
-    filename="wfn.h5",
+    filename=scratch_dir / "wfn.h5",
     wfn=wfn,
     walker_type=spin_symm,
     nelec=nelec,

--- a/docs/tutorials/models/07_autohf_crash_course/07_autohf_crash_course.md
+++ b/docs/tutorials/models/07_autohf_crash_course/07_autohf_crash_course.md
@@ -231,7 +231,6 @@ results = lattice_hf(
     hamiltonian=hamiltonian_autohf,
     settings=hf_settings
 )
-
 ```
 
 +++ {"id": "wGm8ARSAYhms"}
@@ -249,8 +248,6 @@ You should have gotten a HF energy of -17.7499999549238 $t$ (to within about $1 
 
 ```{code-cell} ipython3
 :id: fFMgfc_zU4oW
-
-autohf_to_afqmc
 
 autohf_to_afqmc(
     results,

--- a/docs/tutorials/models/07_autohf_crash_course/07_autohf_crash_course.md
+++ b/docs/tutorials/models/07_autohf_crash_course/07_autohf_crash_course.md
@@ -49,10 +49,10 @@ outputId: ababa026-ef02-445e-cde1-fc1d1c20b9f5
 %autoreload
 from pathlib import Path
 # simple setup
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-home = Path.home()
-scratch_dir = get_scratch_dir("07_hubbard_model_autohf",home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "dfgyQ5OC5xcn"}

--- a/docs/tutorials/models/08_computing_observables/08_computing_observables.md
+++ b/docs/tutorials/models/08_computing_observables/08_computing_observables.md
@@ -83,11 +83,10 @@ i.e. the propagator is applied to different Slater determinants when moving in t
 from pathlib import Path
 
 # simple setup
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-#TODO: update this to a good directory for scratch files
-home = Path.home() / ".scratch"
-scratch_dir = get_scratch_dir("08_observables_lattice", home)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "4d4d8135-bc2d-4caa-bbaf-c88ab045176c"}
@@ -870,7 +869,8 @@ outputId: adbb5a65-99ad-49a9-d8a9-3e9b0a166bad
 from afqmctools.inputs.from_hdf import write_json
 
 # Create a scratch directory for BP calculations
-scratch_dir_bp = get_scratch_dir("observables_mols_bp", home)
+scratch_dir_bp = Path("data/bp")
+scratch_dir_bp.mkdir(parents=True, exist_ok=True)
 
 # Set up AFQMC parameters with back-propagation
 execute_options_bp = {

--- a/docs/tutorials/molecules/01_hello_safire/01_hello_safire.md
+++ b/docs/tutorials/molecules/01_hello_safire/01_hello_safire.md
@@ -524,46 +524,10 @@ On the other hand, the average energy should be stable if you use too large of a
 ## Some Tutorial Helper Python Functions
 
 Now that we have learned how to extract the AFQMC energy from the outputs of SAFIRE using afqmctools,
-we will introduce several tutorial helper functions to invoke SAFIRE and extract the AFQMC energy
+we are ready to how to use the tutorial helper functions to invoke SAFIRE and extract the AFQMC energy
 from within an interactive Python notebook.
 
-For convenience, we provide two helper functions in the `tutorials_utils` Python package.
-
-1. The `run_afqmc()` function runs the SAFIRE executable in one of the several ways that
-we described previously, depending on the `run_mode` parameter.
-2. the `get_scratch_dir()` function, will generate a scratch directory and return a Path pointing to the scratch directory.
-
-Together, these functions make it possible to complete the tutorials without leaving the interactive Python notebooks.
-We explain each function below.
-
-### get_scratch_dir()
-
-`get_scratch_dir()` will return a reference to the Path of a scratch directory that you get to set.
-By default, it will create the directory if it does not already exits.
-You can either specify the full path to the scratch directory as,
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire')
-```
-
-or, you can pass a scratch root directory and scratch directory name as
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('hello_safire', root_dir='/path/to/my/scratch/')
-```
-
-You can tell `get_scratch_dir()` to not attempt to create the directory with
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire',create=False)
-```
-
-+++ {"id": "N9bQJxCM-NIz"}
-
-### The run AFQMC convenience function
+For convenience, we provide the `run_afqmc()` helper function in the `tutorial_utils` Python package.
 
 `run_afqmc(input_file=input_file, np=np)` runs the SAFIRE executable as
 
@@ -573,16 +537,14 @@ You can tell `get_scratch_dir()` to not attempt to create the directory with
 
 <div class="alert alert-block alert-warning">
 <b>CAUTION:</b>
-    The `AFQMC_EXEC` environment variable must be set to the path to the SAFIRE executable
+    The AFQMC_EXEC environment variable must be set to the path to the SAFIRE executable
     in order to use `run_afqmc()`.
 </div>
 
 Here is a typical example of using `run_afqmc()`.
 
 ```python
-    from tutorial_utils import run_afqmc, get_scratch_dir
-
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire')
+    scratch_dir = Path("data")
     
     run_afqmc(
         run_dir=scratch_dir,                # directory to run SAFIRE in - output files will be there
@@ -600,18 +562,6 @@ Where the `np` parameter is forwarded directly to `-np [np]` and
     There is no difference between running SAFIRE via `run_afqmc()` or
     directly in the command line other than convenience.
 </div>
-
-### (afqmctools) the analyze scalar data function
-
-The same functionality as `$ scalar_stats`, from `afqmctools`, can
-be accessed directly in a Python script via the `analyze_scalar_data()` function.
-This is a standard component of `afqmctools`, and not just a part of these tutorials.
-
-For convenience, we will favor the use of `analyze_scalar_data()` within interactive Python
-notebooks; however, this invokes exactly the same code as using `$ scalar_stats` from
-the CLI.
-`scalar_stats` can generate plots of the data, both from the CLI and from within Python.
-We will make use of this feature during the tutorials to visualize results.
 
 ### Exercise: Run the full sample calculation using the convenience wrappers.
 

--- a/docs/tutorials/molecules/01_hello_safire/01_hello_safire.md
+++ b/docs/tutorials/molecules/01_hello_safire/01_hello_safire.md
@@ -643,12 +643,11 @@ import numpy as np
 from afqmctools.hamiltonian.mol import write_hamiltonian_generic
 from afqmctools.wavefunction.mol import write_wfn
 from afqmctools.inputs.from_hdf import write_json
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 from stats.scalar_dat import analyze_scalar_data
 
-# For you TODO: set a scratch directory for the files that will be generated
-home = Path.home()
-scratch_dir = get_scratch_dir("hello_safire",home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 # copy the provided files
 files_dir = scratch_dir / "files"
@@ -683,4 +682,3 @@ In this tutorial we have learned,
 2. how to invoke the SAFIRE executable from the command line in serial, using MPI, and using GPU(s)
 3. how to extract the AFQMC energy from the outputs of SAFIRE using afqmctools
 4. how to use the tutorial helper functions to perform 2 and 3 from within an interactive Python notebook
-

--- a/docs/tutorials/molecules/03_writing_a_hamiltonian/03_writing_a_hamiltonian.md
+++ b/docs/tutorials/molecules/03_writing_a_hamiltonian/03_writing_a_hamiltonian.md
@@ -572,12 +572,10 @@ from afqmctools.wavefunction.mol import write_wfn
 from afqmctools.inputs.from_hdf import write_json
 from stats.scalar_dat import analyze_scalar_data
 
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-home = Path.home()
-scratch_rootdir = home / ".scratch"
-scratch_rootdir.mkdir(exist_ok=True)
-scratch_dir = get_scratch_dir("hello_mols",scratch_rootdir)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 number_of_electrons = (1,1) # up, down
 number_of_orbitals = 2

--- a/docs/tutorials/molecules/03_writing_a_hamiltonian/03_writing_a_hamiltonian.md
+++ b/docs/tutorials/molecules/03_writing_a_hamiltonian/03_writing_a_hamiltonian.md
@@ -296,12 +296,10 @@ colab:
 id: VhPYIHxeyCNf
 outputId: f8c272ce-fe42-4727-be4e-2abd163c3a79
 ---
-from tutorial_utils import run_afqmc, get_scratch_dir
-
 # Use this to run SAFIRE
 run_afqmc(
     run_dir=scratch_dir,
-    input_file =  "afqmc.json",#"your_input_file.json",
+    input_file = "afqmc.json",#"your_input_file.json",
     np=16,             # number of MPI tasks
 )
 ```
@@ -330,10 +328,10 @@ _ = analyze_scalar_data(settings)
 
 ### Check your result
 
-Your AFQMC energy should agree with $-1.137024 \pm 0.000195 Ha$
+Your AFQMC energy should agree with $-1.137024 \pm 0.000195$ Ha
 to within 1-2 $\sigma$.
 
-For comparison, the FCI energy is $-1.1372759436170439 Ha$.
+For comparison, the FCI energy is $-1.1372759436170439$ Ha.
 
 Our AFQMC result agrees FCI to within 0.0003(2) Ha which
 is well within chemical accuracy.

--- a/docs/tutorials/molecules/03_writing_a_hamiltonian/03_writing_a_hamiltonian.md
+++ b/docs/tutorials/molecules/03_writing_a_hamiltonian/03_writing_a_hamiltonian.md
@@ -68,12 +68,10 @@ from afqmctools.hamiltonian.mol import write_hamiltonian_generic
 from afqmctools.wavefunction.mol import write_wfn
 from afqmctools.inputs.from_hdf import write_json
 
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-home = Path.home()
-scratch_rootdir = home / ".scratch"
-scratch_rootdir.mkdir(exist_ok=True)
-scratch_dir = get_scratch_dir("writing_a_hamiltonian",scratch_rootdir)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "J8ieYi3YyCNe"}
@@ -85,7 +83,7 @@ Before we can run an AFQMC calculation, we must generate:
 
 1. A Hamiltonian
 2. A trial wavefunction
-3. a json input file
+3. A json input file
 
 Implicit in items 1. and 2. is the need for an orthonormal basis in
 which to compute matrix elements of the Hamiltonian,
@@ -304,7 +302,7 @@ from tutorial_utils import run_afqmc, get_scratch_dir
 run_afqmc(
     run_dir=scratch_dir,
     input_file =  "afqmc.json",#"your_input_file.json",
-    np=12,             # number of MPI tasks
+    np=16,             # number of MPI tasks
 )
 ```
 
@@ -332,12 +330,12 @@ _ = analyze_scalar_data(settings)
 
 ### Check your result
 
-Your AFQMC energy should agree with $-1.137024 \pm 0.000195 E_{Hartree}$
+Your AFQMC energy should agree with $-1.137024 \pm 0.000195 Ha$
 to within 1-2 $\sigma$.
 
-For comparison, the FCI energy is $-1.1372759436170439 E_{Hartree}$.
+For comparison, the FCI energy is $-1.1372759436170439 Ha$.
 
-Our AFQMC result agrees FCI to within 0.0003(2) $E_{Hartree}$ which
+Our AFQMC result agrees FCI to within 0.0003(2) Ha which
 is well within chemical accuracy.
 
 +++ {"id": "jnupX3Uz1l4q"}
@@ -651,9 +649,8 @@ write_wfn(
 afqmc_execution_options = {
     "timestep": 0.01,
     "steps": 10000,
-    "accumlate_interval": 10,           # in units of steps
-    "measure_interval": 10,             # in units of steps
     "population_control_interval" : 10, # in units of steps
+    "measure_interval_multiplier": 1,   # in units of population_control_interval
     "walker_ortho_interval" : 10 ,      # in units of steps
     "n_walkers_per_mpi_task": 200,
     "seed" : 42

--- a/docs/tutorials/molecules/03_writing_a_hamiltonian/03_writing_a_hamiltonian.md
+++ b/docs/tutorials/molecules/03_writing_a_hamiltonian/03_writing_a_hamiltonian.md
@@ -281,7 +281,7 @@ and use `afqmctools` to obtain the AFQMC energy.
 As a reminder, you can run SAFIRE in any of the following ways:
 
 1. the `run_afqmc()` convenience wrapper - we've included a template in the next code cell.
-2. run from the command line as `$ mpirun -np [number of MPI tasks] qmcapp --filenames [input file].json`
+2. run from the command line as `$ mpirun -np [number of MPI tasks] safire --filenames [input file].json`
 3. (if you are running on a computing cluster) submit a job via a runscript.
 
 As an additional reminder, the `analyze_scalar_data` tool can be invoked by either

--- a/docs/tutorials/molecules/04_writing_a_trial_wavefunction/04_writing_a_trial_wavefunction.md
+++ b/docs/tutorials/molecules/04_writing_a_trial_wavefunction/04_writing_a_trial_wavefunction.md
@@ -33,11 +33,10 @@ Become acquainted with how to write a Trial wavefunction to the SAFIRE HDF5 form
 from pathlib import Path
 
 # simple setup
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-#TODO: update this to a good directory for scratch files
-home = Path.home() / ".scratch"
-scratch_dir = get_scratch_dir("04_mols_writing_a_trial", home)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "vt9PbuQhpw4u"}

--- a/docs/tutorials/molecules/05_computing_observables/05_computing_observables.md
+++ b/docs/tutorials/molecules/05_computing_observables/05_computing_observables.md
@@ -129,7 +129,6 @@ from pyscf import gto,scf,mcscf
 from afqmctools.utils.pyscf_utils import load_from_pyscf_chk_mol
 from afqmctools.hamiltonian.mol import write_hamil_mol
 from afqmctools.inputs.from_hdf import write_json
-from afqmctools.hamiltonian.io import write_to_hdf5
 
 from stats.scalar_dat import analyze_scalar_data
 

--- a/docs/tutorials/molecules/05_computing_observables/05_computing_observables.md
+++ b/docs/tutorials/molecules/05_computing_observables/05_computing_observables.md
@@ -83,11 +83,10 @@ i.e. the propagator is applied to different Slater determinants when moving in t
 from pathlib import Path
 
 # simple setup
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-#TODO: update this to a good directory for scratch files
-home = Path.home() / ".scratch"
-scratch_dir = get_scratch_dir("observables_mols", home)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 ```
 
 +++ {"id": "4d4d8135-bc2d-4caa-bbaf-c88ab045176c"}
@@ -192,7 +191,6 @@ write_hamil_mol(
     chol_cut = 1e-5,
     verbose=True
 )
-
 ```
 
 +++ {"id": "dSJ9e4tRBxxx"}
@@ -305,7 +303,7 @@ outputId: ce74d680-635b-456e-a468-0e7ada8b10f7
 run_afqmc(
     run_dir=scratch_dir,                # directory to run SAFIRE in - output files will be there as well
     input_file="afqmc.json",
-    np=64,                              # number of MPI tasks
+    np=16,                              # number of MPI tasks
     output_file=None
 )
 ```
@@ -505,7 +503,7 @@ outputId: 47d9ccce-e999-47e9-f36c-2a4005cd87a0
 run_afqmc(
     run_dir=scratch_dir,                # directory to run SAFIRE in - output files will be there as well
     input_file="afqmc_1.json",
-    np=64,                              # number of MPI tasks
+    np=16,                              # number of MPI tasks
     output_file=None
 )
 ```
@@ -833,7 +831,8 @@ outputId: fbf1e8a4-bc84-40c5-9135-0d6a6571b8e8
 from afqmctools.inputs.from_hdf import write_json
 
 # Create a scratch directory for BP calculations
-scratch_dir_bp = get_scratch_dir("observables_mols_bp", home)
+scratch_dir_bp = scratch_dir / "bp"
+scratch_dir_bp.mkdir(parents=True, exist_ok=True)
 
 # Copy the Hamiltonian and wavefunction files
 import shutil
@@ -849,7 +848,7 @@ execute_options_bp = {
     "measure_interval_multiplier": 2,
     "population_control_interval": 5,
     "walker_ortho_interval": 10,
-    "n_walkers_per_mpi_task": 20,
+    "n_walkers_per_mpi_task": 100,
     "seed": 42,
     "estimator": {
         "name": "back_propagation",
@@ -895,7 +894,7 @@ print("This will take longer than mixed estimators due to the additional back-pr
 run_afqmc(
     run_dir=scratch_dir_bp,
     input_file="afqmc_bp.json",
-    np=64,
+    np=16,
     output_file=None
 )
 ```
@@ -925,7 +924,7 @@ hermitize = hermitize_factory(
 # Extract one-RDM data from all BP averages
 print("\nExtracting one-RDM data from back-propagation averages...")
 
-# We specified 3 BP lengths: [60, 70, 80] * population_control_interval
+# We specified 3 BP lengths:
 bp_lengths = bp_metadata["BackPropSteps"]
 bp_onerdm_data = {}
 
@@ -997,16 +996,17 @@ E_mixed, dE_mixed = analyze_scalar_data(dict(
     nequil = 10
 ))
 
+bp_steps = bp_lengths * execute_options_bp['population_control_interval']
 fig, ax = plt.subplots(1, 1, figsize=(8, 5))
 
 # plot reference value from mixed
-ax.fill_between([min(bp_lengths), max(bp_lengths)],
+ax.fill_between([min(bp_steps)-1, max(bp_steps)+1],
                  E_mixed - dE_mixed, E_mixed + dE_mixed,
                  alpha=0.2, color='red')
 ax.axhline(y=E_mixed, color='red', linestyle='--', alpha=0.7, label=f'Mixed Estimator')
 
 # Plot convergence
-ax.errorbar(bp_lengths, bp_energy, yerr=bp_energy_err, marker='o', capsize=5, capthick=2, label='BP Estimator')
+ax.errorbar(bp_steps, bp_energy, yerr=bp_energy_err, marker='o', capsize=5, capthick=2, label='BP Estimator')
 
 ax.set_xlabel('BP Length (steps)')
 ax.set_ylabel('Mean One-body Energy (Ha)')
@@ -1055,4 +1055,3 @@ In this tutorial, you were acquainted with how to compute general observables wi
 1. What a mixed estimator is and when to use one to compute an observable
 2. What a back-propagated estimator is and when to use one to compute an observable
 3. How to compute observables in post-processing with afqmctools
-

--- a/docs/tutorials/solids/01_hello_afqmc_solids/01_hello_afqmc_solids.md
+++ b/docs/tutorials/solids/01_hello_afqmc_solids/01_hello_afqmc_solids.md
@@ -331,7 +331,7 @@ see what changes.
 </div>
 
 ```{code-cell} ipython3
-!safire files/input.json
+!$AFQMC_EXEC files/input.json
 ```
 
 +++ {"id": "eShMF9Ab-NIy"}
@@ -623,13 +623,6 @@ Use the code block below to run the entire calculation again.
 Just as before, at the end, you should get an AFQMC energy of `-1.135742 +/-   0.000286`
 if you did not change any settings.
 
-<div class="alert alert-block alert-info">
-<b>Note:</b>
-    The python `Path` class from `pathlib`, which is a part of the standard cPython distribution,
-    greatly simplifies the process of specifying, and creating directories. We recommend using it
-    in these tutorials. See the code block below.
-</div>
-
 ```{code-cell} ipython3
 ---
 colab:
@@ -638,7 +631,6 @@ colab:
 id: lFXM3f_c-NIz
 outputId: 23c92fb6-6385-46fa-a007-1b019b3bffa5
 ---
-%%time
 from pathlib import Path
 import shutil
 
@@ -650,9 +642,8 @@ from afqmctools.inputs.from_hdf import write_json
 from tutorial_utils import run_afqmc, get_scratch_dir
 from stats.scalar_dat import analyze_scalar_data
 
-# For you TODO: set a scratch directory for the files that will be generated
-home = Path.home()
-scratch_dir = get_scratch_dir("hello_safire",home / ".scratch")
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 # copy the provided files
 files_dir = scratch_dir / "files"
@@ -672,7 +663,7 @@ run_afqmc(
 _ = analyze_scalar_data(dict(
     fname = scratch_dir/"qmc.s000.scalar.dat",
     series_column = "time",
-    nequil = 5,
+    nequil = 10,
     trace = True
 ))
 ```

--- a/docs/tutorials/solids/01_hello_afqmc_solids/01_hello_afqmc_solids.md
+++ b/docs/tutorials/solids/01_hello_afqmc_solids/01_hello_afqmc_solids.md
@@ -527,46 +527,10 @@ On the other hand, the average energy should be stable if you use too large of a
 ## Some Tutorial Helper Python Functions
 
 Now that we have learned how to extract the AFQMC energy from the outputs of SAFIRE using afqmctools,
-we will introduce several tutorial helper functions to invoke SAFIRE and extract the AFQMC energy
+we are ready to how to use the tutorial helper functions to invoke SAFIRE and extract the AFQMC energy
 from within an interactive Python notebook.
 
-For convenience, we provide two helper functions in the `tutorials_utils` Python package.
-
-1. The `run_afqmc()` function runs the SAFIRE executable in one of the several ways that
-we described previously, depending on the `run_mode` parameter.
-2. the `get_scratch_dir()` function, will generate a scratch directory and return a Path pointing to the scratch directory.
-
-Together, these functions make it possible to complete the tutorials without leaving the interactive Python notebooks.
-We explain each function below.
-
-### get_scratch_dir()
-
-`get_scratch_dir()` will return a reference to the Path of a scratch directory that you get to set.
-By default, it will create the directory if it does not already exits.
-You can either specify the full path to the scratch directory as,
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire')
-```
-
-or, you can pass a scratch root directory and scratch directory name as
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('hello_safire', root_dir='/path/to/my/scratch/')
-```
-
-You can tell `get_scratch_dir()` to not attempt to create the directory with
-
-```python
-    from tutorial_utils import get_scratch_dir
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire',create=False)
-```
-
-+++ {"id": "N9bQJxCM-NIz"}
-
-### The run AFQMC convenience function
+For convenience, we provide the `run_afqmc()` helper function in the `tutorial_utils` Python package.
 
 `run_afqmc(input_file=input_file, np=np)` runs the SAFIRE executable as
 
@@ -576,16 +540,16 @@ You can tell `get_scratch_dir()` to not attempt to create the directory with
 
 <div class="alert alert-block alert-warning">
 <b>CAUTION:</b>
-    The `AFQMC_EXEC` environment variable must be set to the path to the SAFIRE executable
+    The AFQMC_EXEC environment variable must be set to the path to the SAFIRE executable
     in order to use `run_afqmc()`.
 </div>
 
 Here is a typical example of using `run_afqmc()`.
 
 ```python
-    from tutorial_utils import run_afqmc, get_scratch_dir
+    from tutorial_utils import run_afqmc
 
-    scratch_dir = get_scratch_dir('/path/to/my/scratch/hello_safire')
+    scratch_dir = Path("data")
     
     run_afqmc(
         run_dir=scratch_dir,                # directory to run SAFIRE in - output files will be there
@@ -603,18 +567,6 @@ Where the `np` parameter is forwarded directly to `-np [np]` and
     There is no difference between running SAFIRE via `run_afqmc()` or
     directly in the command line other than convenience.
 </div>
-
-### (afqmctools) the analyze scalar data function
-
-The same functionality as `$ scalar_stats`, from `afqmctools`, can
-be accessed directly in a Python script via the `analyze_scalar_data()` function.
-This is a standard component of `afqmctools`, and not just a part of these tutorials.
-
-For convenience, we will favor the use of `analyze_scalar_data()` within interactive Python
-notebooks; however, this invokes exactly the same code as using `$ scalar_stats` from
-the CLI.
-`scalar_stats` can generate plots of the data, both from the CLI and from within Python.
-We will make use of this feature during the tutorials to visualize results.
 
 ### Exercise: Run the full sample calculation using the convenience wrappers.
 
@@ -639,7 +591,7 @@ import numpy as np
 from afqmctools.hamiltonian.mol import write_hamiltonian_generic
 from afqmctools.wavefunction.mol import write_wfn
 from afqmctools.inputs.from_hdf import write_json
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 from stats.scalar_dat import analyze_scalar_data
 
 scratch_dir = Path("data")
@@ -648,9 +600,9 @@ scratch_dir.mkdir(parents=True, exist_ok=True)
 # copy the provided files
 files_dir = scratch_dir / "files"
 files_dir.mkdir(exist_ok=True)
-shutil.copy("files/input.json", scratch_dir / "files" )
-shutil.copy("files/wfn.h5", scratch_dir / "files" )
-shutil.copy("files/hamil.h5", scratch_dir / "files")
+shutil.copy("files/input.json", files_dir)
+shutil.copy("files/wfn.h5", files_dir)
+shutil.copy("files/hamil.h5", files_dir)
 
 run_afqmc(
     run_dir=scratch_dir,

--- a/docs/tutorials/solids/03_Si_writing_H_and_wfn_coqui/03_Si_writing_H_and_wfn_coqui.md
+++ b/docs/tutorials/solids/03_Si_writing_H_and_wfn_coqui/03_Si_writing_H_and_wfn_coqui.md
@@ -551,7 +551,7 @@ Your steps:
 In this tutorial we have learned,
 
 1.  How to write a Hamiltonian to the SAFIRE HDF5 format, using CoQui, starting from a Quantum Espresso calculation 
-2.  How to write a Trial wavefunction to the SAFIRE HDF5 format, using CoQui, starting from a Quantum Espresso calculation 
+2.  How to write a Trial wavefunction to the SAFIRE HDF5 format, using CoQui, starting from a Quantum Espresso calculation
 
 ```{code-cell} ipython3
 :id: wF2XOkh7-D5X

--- a/docs/tutorials/solids/04_computing_observables/04_computing_observables.md
+++ b/docs/tutorials/solids/04_computing_observables/04_computing_observables.md
@@ -65,7 +65,7 @@ where $| \Phi_{n,k} \rangle$ are the usual forward-projected Slater determinant 
 and $| \tilde{\Phi}_{m,k} \rangle$ are the back-propagated walkers given by,
 $$
 | \tilde{\Phi}_{m,k} \rangle = \hat{B}^\dagger( (x - \bar{x})_{n,k} ) ... \hat{B}^\dagger( (x - \bar{x})_{n+m-1,k} ) | \Psi_T \rangle
-$$.
+$$
 The index $n$ corresponds to the current forward projection step,
 and $m$ is the back-propagated step index.
 We note that each random walker has a corresponding back-propagated partner
@@ -79,16 +79,14 @@ i.e. the propagator is applied to different Slater determinants when moving in t
 ```{code-cell} ipython3
 :id: 616ca764-f070-434a-8146-e1511f273342
 
-%load_ext autoreload
 # Run me (shift+enter or click the play button) to setup the tutorial!
 from pathlib import Path
 
 # simple setup
-from tutorial_utils import run_afqmc, get_scratch_dir
+from tutorial_utils import run_afqmc
 
-#TODO: update this to a good directory for scratch files
-home = Path.home() / ".scratch"
-scratch_dir = get_scratch_dir("04_observables_solids", home)
+scratch_dir = Path("data")
+scratch_dir.mkdir(parents=True, exist_ok=True)
 
 # copy files to scratch
 import shutil

--- a/docs/tutorials/solids/04_computing_observables/04_computing_observables.md
+++ b/docs/tutorials/solids/04_computing_observables/04_computing_observables.md
@@ -181,7 +181,7 @@ execute_options = {
         "walker_type" : "COLLINEAR"
     },
     "timestep": 0.01,
-    "steps": 10000,
+    "steps": 7000,
     "population_control_interval" : 10,
     "measure_interval_multiplier": 1,
     "walker_ortho_interval" : 10 ,
@@ -376,11 +376,11 @@ execute_options = {
         "walker_type" : "COLLINEAR"
     },
     "timestep": 0.01,
-    "steps": 10000,
+    "steps": 7000,
     "population_control_interval" : 10,
     "measure_interval_multiplier": 1,
     "walker_ortho_interval" : 10 ,
-    "n_walkers_per_mpi_task": 200,
+    "n_walkers_per_mpi_task": 50,
     "seed" : 42,
     "estimator" : {
         "name" : "mixed",
@@ -443,7 +443,6 @@ colab:
 id: c9LgOOxOA_xI
 outputId: b3c1c8c5-e7ac-4ffb-c212-1e7aec371f79
 ---
-%autoreload
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -547,22 +546,20 @@ colab:
 id: afFNaJpQdymb
 outputId: b681facb-f520-49ed-a2c2-cfceff7c2d40
 ---
-%autoreload
 import numpy as np
 import matplotlib.pyplot as plt
 
 from afqmctools.analysis.transform import hermitize_factory,eval_one_body_obs_factory,eval_two_body_obs_factory
 
 ncv_k = H["nchol_pk"]
-k_idk = 0 # gamma only for this tutorial
-ncv = ncv_k[k]
+k_idx = 0 # gamma only for this tutorial
+ncv = ncv_k[k_idx]
 print(ncv)
 
 # taking the k=0 Cholesky vectors!
-#cholesky_vectors = np.transpose(H["chol"][k].reshape((M,M,ncv)),(2,0,1))
 
-cholesky_vectors = np.transpose(H["chol"][k].reshape((M,M,ncv)),(2,0,1))
-cholesky_vectors_dagger = np.transpose(H["chol"][k].reshape((M,M,ncv)),(2,1,0)).conj()
+cholesky_vectors = np.transpose(H["chol"][k_idx].reshape((M,M,ncv)),(2,0,1))
+cholesky_vectors_dagger = np.transpose(H["chol"][k_idx].reshape((M,M,ncv)),(2,1,0)).conj()
 eri = np.einsum("gil,gjk->iljk",cholesky_vectors,cholesky_vectors_dagger).flatten()
 
 eval_two_body_energy = eval_two_body_obs_factory(
@@ -665,7 +662,7 @@ from stats.scalar_dat import analyze_scalar_data
 _ = analyze_scalar_data(dict(
     fname = scratch_dir/"qmc.s000.scalar.dat",
     series_column = "time",
-    nequil = 5,
+    nequil = 15,
     trace = True
 ))
 ```
@@ -703,7 +700,7 @@ Since BP involves an additional projection, the measurement interval controls th
 Just as in the execute block or a mixed estimator block, the input file includes a measurement interval "multiplier", and the actual measurement interval, $m$, is determined as:
 
 $$
-m = (\textrm{measure_interval_multiplier}) \times (\textrm{population_control_interval})
+m = \text{measure\_interval\_multiplier} \times \text{population\_control\_interval}
 $$
 
 ### Multiple BP Lengths
@@ -734,7 +731,7 @@ The BP estimator implements an equilibration phase at the beginning of the AFQMC
 This is recommended since computing observables is expensive and since AFQMC needs to equilibrate before samples can meaningfully contribute to the average.
 Similarly to the measure_interval_multiplier, the equilibration time is specified as an equilibration multiplier (`"equil_multiplier"`) and the actual equilibration time is given by:
 
-$$\text{equil_time} = (\text{equil_multiplier}) \times (\text{population_control_interval})$$
+$$\text{equil\_time} = \text{equil\_multiplier} \times \text{population\_control\_interval}$$
 
 ### All Settings
 
@@ -746,8 +743,8 @@ td, th {
   
 |<b>setting</b>|<b>default</b>|<b>description</b>|
 |--:|:-:|:--|
-| <b>        measure_interval_multiplier</b> |   1  |  controls the number of back propagation steps which are determined as $$(\text{number of BP steps}) = (\text{measure_interval_multiplier}) \times (\text{population_control_interval})$$. Can be either a single value or multiple values. If multiple values are provided, BP will be performed with each corresponding number of BP steps and observables are accumulated and saved for each distinct BP length.  |
-| <b> equil_multiplier </b> | 0 |  The multiplier that determines the length of the equilibration phase. The equilibration phase length is computed as $(equilibration\_length) = (equil\_multiplier) * (population\_control\_inveral)$ where the population control interval is defined in the execute block. During the equilibration phase, observables are not computed. |
+| <b>        measure_interval_multiplier</b> |   1  |  controls the number of back propagation steps which are determined as $$\text{number\_of\_BP\_steps} = \text{measure\_interval\_multiplier} \times \text{population\_control\_interval}$$. Can be either a single value or multiple values. If multiple values are provided, BP will be performed with each corresponding number of BP steps and observables are accumulated and saved for each distinct BP length.  |
+| <b> equil_multiplier </b> | 0 |  The multiplier that determines the length of the equilibration phase. The equilibration phase length is computed as $\text{equilibration\_length} = \text{equil\_multiplier} \times \text{population\_control\_inveral}$ where the population control interval is defined in the execute block. During the equilibration phase, observables are not computed. |
 | <b>        bp_walker_ortho_interval</b> |   1  |   interval for performing walker orthonormalization during back-propagation (i.e. for the left-hand side Walkers)  |
 | <b>        path_restoration</b> |   false  |  If true, perform path restoration.  |
 | <b>        extra_path_restoration</b> |   false  |   If true, perform an extra path restoration.  |
@@ -778,7 +775,7 @@ execute_options_bp = {
     "measure_interval_multiplier": 1,
     "population_control_interval": 10,
     "walker_ortho_interval": 10,
-    "n_walkers_per_mpi_task": 200,
+    "n_walkers_per_mpi_task": 100,
     "seed": 42,
     "estimator": {
         "name": "back_propagation",
@@ -947,4 +944,3 @@ In this tutorial, you were acquainted with how to compute general observables wi
 1. What a mixed estimator is and when to use one to compute an observable
 2. What a back-propagated estimator is and when to use one to compute an observable
 3. How to compute observables in post-processing with afqmctools
-

--- a/utils/afqmctools/hamiltonian/converter.py
+++ b/utils/afqmctools/hamiltonian/converter.py
@@ -239,8 +239,6 @@ def read_hamil_type(filename:str) -> str:
             return 'sparse'
         elif 'Hamiltonian/KPFactorized/L0' in fh5:
             return 'kpoint'
-        elif '/Interaction/Vq0' in fh5:
-            return 'coqui_kpoint'
         elif 'Interaction/Vq0' in fh5:
             return 'kpoint_coqui'
         elif 'Hamiltonian/THC/Luv' in fh5:
@@ -323,7 +321,7 @@ def read_hamiltonian(filename, get_chol=True, walker_type=1):
         hamil = read_model(filename)
     else:
         hamil = None
-        raise TypeError("Unknown Hamiltonian type.")
+        raise TypeError(f"Unknown Hamiltonian type '{ham_type}'.")
     return hamil
 
 
@@ -998,132 +996,6 @@ def get_kpoint_chol(filename, nchol_pk, minus_k, i, qk_k2, nmo_pk):
               Lk1[k1] = cmat.transpose(1, 0, 2).conj().ravel()
             Lk = Lk1
     return Lk
-
-
-def read_cholesky_kpoint_coqui(filename, get_chol=True):
-    r"""Read in integrals from internal hdf5 format. kpoint dependent case.
-
-    Parameters
-    ----------
-    filename : str
-        Path to the internal-format HDF5 file.
-    get_chol : bool, optional
-        If True, read and return per-Q Cholesky vectors (default True).
-
-    Returns
-    -------
-    hcore : list[np.ndarray]
-        List of one-body Hamiltonians per k-point; each `(nmo_k, nmo_k)` complex.
-    chol_vecs : list[np.ndarray] or None
-        If `get_chol` is True, list over Q of arrays with shape
-        `(nkp, nmo_k*nmo_k*nchol_Q)` containing flattened `L[K][i,k,n]` per K.
-        Otherwise `None`.
-    enuc : float
-        Core (nuclear) energy contribution read from `Hamiltonian/Energies`.
-    nmo_tot : int
-        Total number of orbitals across all k-points.
-    nelec : tuple[int, int]
-        `(nalpha, nbeta)` electron counts.
-    nmo_pk : np.ndarray
-        Orbitals per k-point; shape `(nkp,)`.
-    qk_k2 : np.ndarray
-        Momentum mapping `(Q, K) -> K'`; shape `(nkp, nkp)`.
-    nchol_pk : np.ndarray
-        Number of Cholesky vectors per Q; shape `(nkp,)`, after time-reversal tie-in.
-    minus_k : np.ndarray
-        Time-reversal partner map `Q -> -Q`; shape `(nkp,)`.
-    """
-    enuc, dims, hcore, real_ints = read_common_input(filename, get_hcore=False)
-    with h5.File(filename, 'r') as fh5:
-        nmo_pk = fh5['Hamiltonian/NMOPerKP'][:]
-        nchol_pk = fh5['Hamiltonian/NCholPerKP'][:]
-        qk_k2 = fh5['Hamiltonian/QKTok2'][:]
-        minus_k = fh5['Hamiltonian/MinusK'][:]
-        hcore = []
-        nkp = dims[2]
-        nmo_tot = dims[3]
-        nalpha = dims[4]
-        nbeta = dims[5]
-        if nmo_pk is None:
-            raise KeyError("Could not read NMOPerKP dataset.")
-        for i in range(0, nkp):
-            hk = fh5['Hamiltonian/H1_kp{}'.format(i)][:]
-            if hk is None:
-                raise KeyError("Could not read one-body hamiltonian.")
-            nmo = nmo_pk[i]
-            hcore.append(hk.view(np.complex128).reshape(nmo,nmo))
-        chol_vecs = []
-        if nmo_pk is None:
-            raise KeyError("Error nmo_pk dataset does not exist.")
-        nmo_max = max(nmo_pk)
-    if minus_k is None:
-        raise KeyError("Error MinusK dataset does not exist.")
-    if nchol_pk is None:
-        raise KeyError("Error NCholPerKP dataset does not exist.")
-    # unpack chol
-    for i, nc in enumerate(nchol_pk):
-      j = minus_k[i]
-      if j<i:  # apply (Q, -Q) trick
-        nchol_pk[i] = nchol_pk[j]
-    if get_chol:
-        for i in range(0, nkp):
-            chol_vecs.append(get_kpoint_chol(filename, nchol_pk, minus_k, i, qk_k2, nmo_pk))
-    else:
-        chol_vecs = None
-
-    return (hcore, chol_vecs, enuc, int(nmo_tot), (int(nalpha), int(nbeta)),
-            nmo_pk, qk_k2, nchol_pk, minus_k)
-
-
-def get_kpoint_chol_coqui(filename, nchol_pk, minus_k, i, qk_k2, nmo_pk):
-    r"""
-    Read standard-format Cholesky vectors for Q = i with time-reversal handling.
-
-    Loads `Hamiltonian/KPFactorized/L{min(i, -i)}` and returns per-k-point
-    Cholesky factors in a flattened `(nkp, nmo_i*nmo_i*nchol)` layout. If `-i < i`
-    (time-reversal pairing), applies the `(Q, -Q)` trick: remap `K' = qk_k2[i, K]`
-    and conjugate-transpose from the stored partner to obtain the `Q` data.
-
-    Parameters
-    ----------
-    filename : str
-        Path to the internal-format HDF5 file.
-    nchol_pk : np.ndarray
-        Number of Cholesky vectors per Q; shape `(nkp,)`.
-    minus_k : np.ndarray
-        Time-reversal partner map; shape `(nkp,)`.
-    i : int
-        Q-vector index to read.
-    qk_k2 : np.ndarray
-        Momentum mapping `(Q, K) -> K'`; shape `(nkp, nkp)`.
-    nmo_pk : np.ndarray
-        Orbitals per k-point; shape `(nkp,)`.
-
-    Returns
-    -------
-    Lk : np.ndarray
-        Cholesky vectors for Q `i`, shape `(nkp, nmo_i*nmo_i*nchol)`, complex128.
-    """
-    with h5.File(filename, 'r') as fh5:
-        j = minus_k[i]
-        Lk = fh5['Hamiltonian/KPFactorized/L{}'.format(min(i, j))][:]
-        if Lk is None:
-            msg = "Could not read Cholesky kpoint %d, with -Q %d." % (i, j)
-            raise TypeError(msg)
-        Lk = Lk.view(np.complex128)[:,:,0]
-        if j<i:  # apply (Q, -Q) trick
-            nchol = nchol_pk[j]
-            # remap k-Q, then conjugate-transpose
-            nmo = nmo_pk[i]
-            assert nmo_pk[j] == nmo
-            Lk1 = Lk.copy()
-            for k1, k2 in enumerate(qk_k2[i]):
-              cmat = Lk[k2].reshape(nmo, nmo, nchol)
-              Lk1[k1] = cmat.transpose(1, 0, 2).conj().ravel()
-            Lk = Lk1
-    return Lk
-
-
 
 def read_dense(filename,walker_type=None):
     r"""Read in integrals from internal hdf5 format.

--- a/utils/afqmctools/inputs/from_hdf.py
+++ b/utils/afqmctools/inputs/from_hdf.py
@@ -19,7 +19,7 @@ JSON_EXECUTE_INPUT_BLOCKS = ("walker_set", "wavefunction", "hamiltonian", "proje
 def get_estimator_settings(exec_opts,args=None):
 
     if args is None:
-        return 0
+        return sum(k.startswith("estimator") for k in exec_opts.keys())
 
     if isinstance(args,dict):
         args = SimpleNamespace(args)
@@ -172,11 +172,11 @@ def write_json(fout, fwfn0, fham0=None, relpath=True, exec_opts=None, args_names
     #   KE: in principle, one could use a custom class based on dict along
     #      with a custom json.JSONEncoder class to do this "correctly"
     if num_est > 1:
-        with open(args_namespace.fout, 'r') as f:
+        with open(fout, 'r') as f:
             text = f.read()
-        for i in range(1, num_est):
+        for i in range(1, num_est+1):
             text = text.replace('estimator%d' % i, 'estimator')
-        with open(args_namespace.fout, 'w') as f:
+        with open(fout, 'w') as f:
             f.write(text)
 
 def read_info(fwfn):

--- a/utils/afqmctools/utils/io.py
+++ b/utils/afqmctools/utils/io.py
@@ -473,7 +473,10 @@ def write_pair_correlators(fname:str=None, pairs_dict=None):
     num_correlators = len(pairs_dict.keys())
 
     with h5.File(fname,"a") as f:
-        g = f.create_group("PairCorrelator/orbital_map")
+        group_name = "PairCorrelator/orbital_map"
+        if group_name in f:
+            del f[group_name]
+        g = f.create_group(group_name)
         g.create_dataset("num_pair",data=max_num_pairs)
         g.create_dataset("num_corr",data=num_correlators)
         for direction,pair in pairs_dict.items():

--- a/utils/afqmctools/wavefunction/common.py
+++ b/utils/afqmctools/wavefunction/common.py
@@ -55,7 +55,8 @@ def modified_gram_schmidt(mat, tol=1.0e-12):
   ValueError
     If a column is (near) linearly dependent on the previous ones.
   """
-  print("Orthonormalizing Slater matrix using modified Gram-Schmidt...")
+  if mat.ndim != 2:
+      raise ValueError(f"Expected 2D array, got {mat.ndim}D")
   q = np.zeros_like(mat, dtype=np.complex128)
 
   for j in range(mat.shape[1]):
@@ -280,7 +281,7 @@ def write_wfn(
         wfn_group['dims'] = np.array(dims, dtype=np.int32)
 
 
-def write_nomsd_old(fh5, wfn, uhf, nelec, thresh=1e-8, init=None, orthonormalize=True):
+def write_nomsd(fh5, wfn, uhf, nelec, thresh=1e-8, init=None, orthonormalize=True):
     """Write NOMSD to HDF.
 
     Parameters
@@ -302,21 +303,24 @@ def write_nomsd_old(fh5, wfn, uhf, nelec, thresh=1e-8, init=None, orthonormalize
     """
     nalpha, nbeta = nelec
 
+    # copy and ensure floatness
+    wfn = wfn.copy() + 0.0
+
     wfn[abs(wfn) < thresh] = 0.0
     
     # Check and optionally orthonormalize wfn Slater matrices
     for idet, w in enumerate(wfn):
         # Check alpha block
         norm_a, is_ortho_a = check_slater_matrix_orthonormality(
-            w[:,:nalpha], nelec=nalpha, matrix_type=f'wfn[{idet}] alpha'
+            w[:,:nalpha], nelec=nalpha, matrix_type=f'wfn[{idet}] alpha', verbose=not orthonormalize
         )
         if not is_ortho_a and orthonormalize:
             wfn[idet, :, :nalpha] = modified_gram_schmidt(w[:,:nalpha])
-        
+
         # Check beta block if present
         if uhf and nbeta > 0:
             norm_b, is_ortho_b = check_slater_matrix_orthonormality(
-                w[:,nalpha:nalpha+nbeta], nelec=nbeta, matrix_type=f'wfn[{idet}] beta'
+                w[:,nalpha:nalpha+nbeta], nelec=nbeta, matrix_type=f'wfn[{idet}] beta', verbose=not orthonormalize,
             )
             if not is_ortho_b and orthonormalize:
                 wfn[idet, :, nalpha:nalpha+nbeta] = modified_gram_schmidt(w[:,nalpha:nalpha+nbeta])
@@ -326,14 +330,14 @@ def write_nomsd_old(fh5, wfn, uhf, nelec, thresh=1e-8, init=None, orthonormalize
         if isinstance(init, (tuple, list)) and len(init) == 2:
             init_alpha, init_beta = init
             norm_a, is_ortho_a = check_slater_matrix_orthonormality(
-                init_alpha, nelec=nalpha, matrix_type='init alpha'
+                init_alpha, nelec=nalpha, matrix_type='init alpha', verbose=not orthonormalize
             )
             if not is_ortho_a and orthonormalize:
                 init[0] = modified_gram_schmidt(init_alpha)
             
             if uhf and nbeta > 0:
                 norm_b, is_ortho_b = check_slater_matrix_orthonormality(
-                    init_beta, nelec=nbeta, matrix_type='init beta'
+                    init_beta, nelec=nbeta, matrix_type='init beta', verbose=not orthonormalize
                 )
                 if not is_ortho_b and orthonormalize:
                     init[1] = modified_gram_schmidt(init_beta)
@@ -343,18 +347,17 @@ def write_nomsd_old(fh5, wfn, uhf, nelec, thresh=1e-8, init=None, orthonormalize
     else:
         # Check and optionally orthonormalize wfn[0] for use as init
         norm_a, is_ortho_a = check_slater_matrix_orthonormality(
-            wfn[0,:,:nalpha], nelec=nalpha, matrix_type='wfn[0] alpha (used as init)'
+            wfn[0,:,:nalpha], nelec=nalpha, matrix_type='wfn[0] alpha (used as init)', verbose=not orthonormalize
         )
         if not is_ortho_a and orthonormalize:
             wfn[0, :, :nalpha] = modified_gram_schmidt(wfn[0,:,:nalpha])
-        
         add_dataset(fh5, 'Psi0_alpha',
                     to_complex(wfn[0,:,:nalpha].copy()))  
         if uhf:
             warn(
                 "Using UHF Slater determinant for initial Walkers with a Collinear Trial Wavefunction. " 
                 "This can lead to very slow equilibration in AFQMC calculations. " 
-                "using ROHF Slater determinants for intiail Walkers is recommended."
+                "using ROHF Slater determinants for initial Walkers is recommended."
             )
             norm_b, is_ortho_b = check_slater_matrix_orthonormality(
                 wfn[0,:,nalpha:nalpha+nbeta], nelec=nbeta, matrix_type='wfn[0] beta (used as init)'
@@ -405,14 +408,13 @@ def write_nomsd_ghf(fh5, wfn, nelec, thresh=1e-8, init=None, orthonormalize=True
             " NONCOLLINER or FULLYPOLARIZED Slater determinants."
         )
 
+    wfn = wfn.copy() + 0.0j
     wfn[abs(wfn) < thresh] = 0.0
-    
-    wfn = np.array(wfn,dtype=np.complex128) 
     
     # Check and optionally orthonormalize wfn Slater matrices
     for idet, w in enumerate(wfn):
         norm, is_ortho = check_slater_matrix_orthonormality(
-            w[:,:nalpha], nelec=nalpha, matrix_type=f'wfn[{idet}] noncollinear'
+            w[:,:nalpha], nelec=nalpha, matrix_type=f'wfn[{idet}] noncollinear', verbose=not orthonormalize
         )
         if not is_ortho and orthonormalize:
             wfn[idet, :, :nalpha] = modified_gram_schmidt(w[:,:nalpha])
@@ -420,7 +422,7 @@ def write_nomsd_ghf(fh5, wfn, nelec, thresh=1e-8, init=None, orthonormalize=True
     if init is not None:
         # Check and optionally orthonormalize init parameter
         norm, is_ortho = check_slater_matrix_orthonormality(
-            init[0], nelec=nalpha, matrix_type='init (noncollinear)'
+            init[0], nelec=nalpha, matrix_type='init (noncollinear)', verbose=not orthonormalize
         )
         if not is_ortho and orthonormalize:
             init[0] = modified_gram_schmidt(init[0])
@@ -429,7 +431,7 @@ def write_nomsd_ghf(fh5, wfn, nelec, thresh=1e-8, init=None, orthonormalize=True
     else:
         # Check and optionally orthonormalize wfn[0] for use as init
         norm, is_ortho = check_slater_matrix_orthonormality(
-            wfn[0,:,:nalpha], nelec=nalpha, matrix_type='wfn[0] (used as init)'
+            wfn[0,:,:nalpha], nelec=nalpha, matrix_type='wfn[0] (used as init)', verbose=not orthonormalize
         )
         if not is_ortho and orthonormalize:
             wfn[0, :, :nalpha] = modified_gram_schmidt(wfn[0,:,:nalpha])
@@ -440,8 +442,6 @@ def write_nomsd_ghf(fh5, wfn, nelec, thresh=1e-8, init=None, orthonormalize=True
         psia = scipy.sparse.csr_array(w[:,:nalpha].conj().T)
         write_nomsd_single(fh5, psia, idet)
 
-
-write_nomsd = write_nomsd_old
 
 def write_nomsd_single(fh5, psi, idet):
     """Write single component of NOMSD to hdf.

--- a/utils/tutorial_utils/helper.py
+++ b/utils/tutorial_utils/helper.py
@@ -20,31 +20,6 @@ if not Path(AFQMC_EXEC).exists():
         "Set it to the path to the AFQMC executable."
     )
 
-def get_scratch_dir(run_name:str,root_dir:Path=AFQMC_SCRATCH_DIR_ROOT,create:bool=True):
-    """
-    Get the scratch directory for a given run name. The scratch directory is
-    root_dir/run_name.
-
-    Parameters
-    ----------
-    run_name: str
-        The name of the run.
-    root_dir: Path
-        The root directory for the scratch directory. Defaults to the value of
-        the environment variable AFQMC_SCRATCH_DIR.
-    create: bool
-        Whether to create the scratch directory if it does not exist. Defaults
-        to True.
-    """
-    scratch_dir = Path(root_dir) / run_name
-    scratch_dir.mkdir(parents=True, exist_ok=create)
-    if not os.access(scratch_dir, os.W_OK):
-        warn(
-            f"You don't have write to scratch directory {scratch_dir} "
-            "Please use a different scratch directory."
-        )
-    return scratch_dir
-
 def run_afqmc(run_dir:Path=None,timeout_mins=None,run_mode="local_cpu",output_file="afqmc.out",**kwargs):
     """
     Run AFQMC in a given directory. The directory is changed to run_dir before


### PR DESCRIPTION
- docs/examples: fix models/01
- docs/examples: fix first half of models/02
- docs/tutorials: fix typo
