### PR TITLE
Fix #71 & #72

### DIFF
--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -90,23 +90,23 @@ public:
     int nspin  = (walker_type == COLLINEAR) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int NMO = nkpts*nbnd;  
-    int nstot = hij.extent(0);
-    int nptot = hij.extent(2)/nbnd;
+    int nspin_in_H = hij.extent(0);
+    int npol_in_H = hij.extent(2)/nbnd;
     int ndet = haj.extent(0);
     
     // check sizes
-    utils::check( hij.shape()==std::array<long,4>{nstot,nkpts,nptot*nbnd,nptot*nbnd},
+    utils::check( hij.shape()==std::array<long,4>{nspin_in_H,nkpts,npol_in_H*nbnd,npol_in_H*nbnd},
       "KP3IndexFactorization: Size mismatch.");
     utils::check( haj.shape()==std::array<long,3>{ndet,nup+ndown,npol*NMO},
       "KP3IndexFactorization: Size mismatch.");
-    utils::check( vexx.shape()==std::array<long,4>{nstot*nptot,nkpts,nbnd,nbnd},
+    utils::check( vexx.shape()==std::array<long,4>{nspin_in_H*npol_in_H,nkpts,nbnd,nbnd},
       "KP3IndexFactorization: Size mismatch.");
     utils::check( LQ.extent(0)==nkpts, "KP3IndexFactorization: Size mismatch.");
     utils::check( Lank.extent(0)==nkpts, "KP3IndexFactorization: Size mismatch.");
     for(int iq=0; iq<nkpts; ++iq) {
       if(iq<=minusq(iq)) {
         int nc = LQ(iq).extent(5); 
-        utils::check( LQ(iq).shape()==std::array<long,6>{nstot,nptot,nkpts,nbnd,nbnd,nc},
+        utils::check( LQ(iq).shape()==std::array<long,6>{nspin_in_H,npol_in_H,nkpts,nbnd,nbnd,nc},
           "KP3IndexFactorization: Size mismatch.");
       } 
       {
@@ -169,26 +169,26 @@ public:
     int nspin  = (walker_type == COLLINEAR) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int NMO = nkpts*nbnd;
-    int nstot = hij.extent(0);
-    int nptot = hij.extent(2)/nbnd;
+    int nspin_in_H = hij.extent(0);
+    int npol_in_H = hij.extent(2)/nbnd;
 
     nda::array<ComplexType, 3> H1(nspin, npol*NMO, npol*NMO);
     H1() = ComplexType(0.0);
 
-    // v[nstot][nwalk=1][nptot*NMO][NMO]
+    // v[nspin_in_H][nwalk=1][npol_in_H*NMO][NMO]
     nda::array<ComplexType, 4> v;
     {
       memory::buffered_array<MEM,ComplexType,2> vMF_2d(1,vMF.size());
       vMF_2d(0,all) = vMF();
       v = std::move(nda::to_host(vHS(vMF_2d, dt)));
-      utils::check(v.shape() == std::array<long,4>{nstot,1,nptot*NMO,NMO}, "Size mismatch");
+      utils::check(v.shape() == std::array<long,4>{nspin_in_H,1,npol_in_H*NMO,NMO}, "Size mismatch");
     }
 
     //
     for (int is = 0; is < nspin; is++) {
-      int is_ = is%nstot;
+      int is_ = is%nspin_in_H;
       for (int p1 = 0; p1 < npol; p1++) {
-        int p1_ = p1%nptot;
+        int p1_ = p1%npol_in_H;
         // vHS finite 'q' contributions (full NMO*NMO) 
         for (int I = 0; I < NMO; I++)
           for (int J = 0 ; J < NMO; J++)
@@ -196,13 +196,13 @@ public:
 
         // hij and vexx only have q=0 contributions  
         for (int p2 = 0; p2 < npol; p2++) {
-          int p2_ = p2%nptot;
+          int p2_ = p2%npol_in_H;
           for(int ik=0, i0=0; ik<nkpts; ik++, i0+=nbnd) {
             for (int i = 0; i < nbnd; i++) {
               for (int j = 0 ; j < nbnd; j++) {
                 if(p1==p2) {
                   H1(is,p1*NMO+i0+i,p2*NMO+i0+j) +=
-                     dt * (hij()(is_,ik,p1_*NMO+i,p2_*NMO+j) + vexx()(is_*nptot+p1_,ik,i,j));
+                     dt * (hij()(is_,ik,p1_*NMO+i,p2_*NMO+j) + vexx()(is_*npol_in_H+p1_,ik,i,j));
                 } else {
                   // only spin-orbit terms here coming from hij
                   H1(is,p1*NMO+i0+i,p2*NMO+i0+j) += dt * hij()(is_,ik,p1_*NMO+i,p2_*NMO+j);
@@ -709,13 +709,13 @@ public:
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int nwalk = X.extent(0);
     int NMO   = nkpts*nbnd;
-    int nstot = hij.extent(0);
-    int nptot = hij.extent(2)/nbnd;
+    int nspin_in_H = hij.extent(0);
+    int npol_in_H = hij.extent(2)/nbnd;
 
     // Note: Allocate first, to make better use of memory pool
     // vHS[nspin_in_vHS][nwalk][npol_in_vHS*NMO][NMO]
-    memory::buffered_array<MEM_X,ComplexType,4> v(nstot,nwalk,nptot*NMO,NMO);
-    auto v7d = nda::reshape(v,std::array<long,7>{nstot,nwalk,nptot,nkpts,nbnd,nkpts,nbnd});
+    memory::buffered_array<MEM_X,ComplexType,4> v(nspin_in_H,nwalk,npol_in_H*NMO,NMO);
+    auto v7d = nda::reshape(v,std::array<long,7>{nspin_in_H,nwalk,npol_in_H,nkpts,nbnd,nkpts,nbnd});
     v() = ComplexType(0.0);
 
     auto X3d = nda::reshape(X,std::array<long,3>{nwalk,2,ncvecs});
@@ -743,10 +743,10 @@ public:
     if constexpr (MEM==HOST_MEMORY) {
       memory::buffered_array<MEM,ComplexType,3> vKK(nwalk,nbnd,nbnd);
       auto v2d = nda::reshape(vKK,std::array<long,2>{nwalk,nbnd*nbnd});
-      for(int is=0; is<nstot; ++is) {
+      for(int is=0; is<nspin_in_H; ++is) {
         for (int Q = 0; Q < nkpts; ++Q) {
           int nchol = Lank(Q).extent(4);
-          for (int ip = 0; ip < nptot; ++ip) {
+          for (int ip = 0; ip < npol_in_H; ++ip) {
             for (int ik = 0; ik < nkpts; ++ik) 
             { 
               // v[nw][i(in K)][k(in Q(K))] += sum_n LQK[i][k][n] X[Q][0][n][nw]
@@ -758,7 +758,7 @@ public:
                 nda::blas::gemm(one,X3d(all,0,range(ncv0(Q),ncv0(Q)+nchol)),
                       nda::transpose(Lq_(ik,all,all)),zero,v2d);
 
-                // accumulate on v7d(nwalk,nstot,nptot,nkpts,nbnd,nkpts,nbnd)
+                // accumulate on v7d(nwalk,nspin_in_H,npol_in_H,nkpts,nbnd,nkpts,nbnd)
                 int k2 = qk_to_k2(Q,ik);
                 nda::tensor::add(one,vKK,"wij",one,v7d(is,all,ip,ik,all,k2,all),"wij");
               } else {
@@ -769,7 +769,7 @@ public:
                 nda::blas::gemm(one,X3d(all,0,range(ncv0(Q),ncv0(Q)+nchol)),
                       nda::dagger(Lqm_(k2,all,all)),zero,v2d);
 
-                // accumulate on v7d(nwalk,nstot,nptot,nkpts,nbnd,nkpts,nbnd)
+                // accumulate on v7d(nwalk,nspin_in_H,npol_in_H,nkpts,nbnd,nkpts,nbnd)
                 nda::tensor::add(one,vKK,"wij",one,v7d(is,all,ip,ik,all,k2,all),"wij");
               }
               // v[nw][k(in Q(K))][i(in K)] += sum_n conj(LQK[i][k][n]) X[Q][n-][nw]
@@ -780,7 +780,7 @@ public:
                 nda::blas::gemm(one,X3d(all,1,range(ncv0(Q),ncv0(Q)+nchol)),
                       nda::dagger(Lq_(ik,all,all)),zero,v2d);
 
-                // accumulate on v7d(nwalk,nstot,nptot,nkpts,nbnd,nkpts,nbnd)
+                // accumulate on v7d(nwalk,nspin_in_H,npol_in_H,nkpts,nbnd,nkpts,nbnd)
                 int k2 = qk_to_k2(Q,ik);
                 nda::tensor::add(one,vKK,"wij",one,v7d(is,all,ip,k2,all,ik,all),"wji");
               }
@@ -789,9 +789,9 @@ public:
         } // Q
       } // is
     } else {
-      memory::buffered_array<MEM,ComplexType,5> vKK(nwalk,nptot,nkpts,nbnd,nbnd);
-      auto v2d = nda::reshape(vKK,std::array<long,2>{nwalk,nptot*nkpts*nbnd*nbnd});
-      for(int is=0; is<nstot; ++is) {
+      memory::buffered_array<MEM,ComplexType,5> vKK(nwalk,npol_in_H,nkpts,nbnd,nbnd);
+      auto v2d = nda::reshape(vKK,std::array<long,2>{nwalk,npol_in_H*nkpts*nbnd*nbnd});
+      for(int is=0; is<nspin_in_H; ++is) {
         for (int Q = 0; Q < nkpts; ++Q)
         { 
           int nchol = Lank(Q).extent(4);
@@ -800,30 +800,30 @@ public:
           {
             // ci^dagger cj term
             // LQ(Q)(ispin, ipol, ik, i, j, nchol) 
-            auto Lq_ = nda::reshape(LQ(Q)()(is,nda::ellipsis{}),std::array<long,2>{nptot*nkpts*nbnd*nbnd,nchol});
+            auto Lq_ = nda::reshape(LQ(Q)()(is,nda::ellipsis{}),std::array<long,2>{npol_in_H*nkpts*nbnd*nbnd,nchol});
             nda::blas::gemm(one,X3d(all,0,range(ncv0(Q),ncv0(Q)+nchol)),
                   nda::transpose(Lq_),zero,v2d);
 
-            // accumulate on v7d(nwalk,nstot,nptot,nkpts,nbnd,nkpts,nbnd)
+            // accumulate on v7d(nwalk,nspin_in_H,npol_in_H,nkpts,nbnd,nkpts,nbnd)
             arch::set_device_synchronization(false);
             for(int ik=0; ik<nkpts; ++ik) {
               int k2 = qk_to_k2(Q,ik);
-              for(int ip=0; ip<nptot; ++ip)
+              for(int ip=0; ip<npol_in_H; ++ip)
                 math::accumulate(one,vKK(all,ip,ik,all,all),v7d(is,all,ip,ik,all,k2,all));
             }
             arch::set_device_synchronization(true);
           } else {
             // cj^dagger ci term
             // the kpoint index of LQ(Qm) refers to k2 
-            auto Lq_ = nda::reshape(LQ(minusq(Q))()(is,nda::ellipsis{}),std::array<long,2>{nptot*nkpts*nbnd*nbnd,nchol});
+            auto Lq_ = nda::reshape(LQ(minusq(Q))()(is,nda::ellipsis{}),std::array<long,2>{npol_in_H*nkpts*nbnd*nbnd,nchol});
             nda::blas::gemm(one,X3d(all,0,range(ncv0(Q),ncv0(Q)+nchol)),
                   nda::dagger(Lq_),zero,v2d);
 
-            // accumulate on v7d(nwalk,nstot,nptot,nkpts,nbnd,nkpts,nbnd)
+            // accumulate on v7d(nwalk,nspin_in_H,npol_in_H,nkpts,nbnd,nkpts,nbnd)
             arch::set_device_synchronization(false);
             for(int ik=0; ik<nkpts; ++ik) {
               int k2 = qk_to_k2(Q,ik);
-              for(int ip=0; ip<nptot; ++ip) {
+              for(int ip=0; ip<npol_in_H; ++ip) {
                 auto v_wji = nda::permuted_indices_view<nda::encode(std::array<int, 3>{0, 2, 1})>(v7d(is,all,ip,ik,all,k2,all));
                 math::accumulate(one,vKK(all,ip,k2,all,all),v_wji);
               }
@@ -834,15 +834,15 @@ public:
           if(Q == minusq(Q)) {
             // cj^dagger ci term for Q==minusq(Q)
             // the kpoint index refers to k2 
-            auto Lq_ = nda::reshape(LQ(Q)()(is,nda::ellipsis{}),std::array<long,2>{nptot*nkpts*nbnd*nbnd,nchol});
+            auto Lq_ = nda::reshape(LQ(Q)()(is,nda::ellipsis{}),std::array<long,2>{npol_in_H*nkpts*nbnd*nbnd,nchol});
             nda::blas::gemm(one,X3d(all,1,range(ncv0(Q),ncv0(Q)+nchol)),
                   nda::dagger(Lq_),zero,v2d);
 
-            // accumulate on v7d(nwalk,nstot,nptot,nkpts,nbnd,nkpts,nbnd)
+            // accumulate on v7d(nwalk,nspin_in_H,npol_in_H,nkpts,nbnd,nkpts,nbnd)
             arch::set_device_synchronization(false);
             for(int ik=0; ik<nkpts; ++ik) {
               int k2 = qk_to_k2(Q,ik);
-              for(int ip=0; ip<nptot; ++ip) {
+              for(int ip=0; ip<npol_in_H; ++ip) {
                 auto v_wji = nda::permuted_indices_view<nda::encode(std::array<int, 3>{0, 2, 1})>(v7d(is,all,ip,k2,all,ik,all));
                 math::accumulate(one,vKK(all,ip,ik,all,all),v_wji);
               }

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -181,7 +181,7 @@ public:
       memory::buffered_array<MEM,ComplexType,2> vMF_2d(1,vMF.size());
       vMF_2d(0,all) = vMF();
       v = std::move(nda::to_host(vHS(vMF_2d, dt)));
-      utils::check(v.shape() == std::array<long,4>{nstot,1,npol*NMO,NMO}, "Size mismatch");
+      utils::check(v.shape() == std::array<long,4>{nstot,1,nptot*NMO,NMO}, "Size mismatch");
     }
 
     //
@@ -608,7 +608,7 @@ public:
               // only scale if Q!=Qm, otherwise full tensor is scaled below 
               if(Q!=Qm)
                 for(auto i: kdiag)
-                  math::scale(ComplexType(0.5),Tl3d(i,all,all));
+                  nda::tensor::scale(ComplexType(0.5),Tl3d(i,all,all));
               arch::set_device_synchronization(true);
               if(Q==Qm) nda::tensor::scale(ComplexType(0.5),Tl3d);
               nda::tensor::contract(-scl,Tl5d(range(batch_cnt),nda::ellipsis{}),"lwabn",
@@ -746,7 +746,7 @@ public:
       for(int is=0; is<nstot; ++is) {
         for (int Q = 0; Q < nkpts; ++Q) {
           int nchol = Lank(Q).extent(4);
-          for (int ip = 0; ip < npol; ++ip) {
+          for (int ip = 0; ip < nptot; ++ip) {
             for (int ik = 0; ik < nkpts; ++ik) 
             { 
               // v[nw][i(in K)][k(in Q(K))] += sum_n LQK[i][k][n] X[Q][0][n][nw]
@@ -789,8 +789,8 @@ public:
         } // Q
       } // is
     } else {
-      memory::buffered_array<MEM,ComplexType,5> vKK(nwalk,npol,nkpts,nbnd,nbnd);
-      auto v2d = nda::reshape(vKK,std::array<long,2>{nwalk,npol*nkpts*nbnd*nbnd});
+      memory::buffered_array<MEM,ComplexType,5> vKK(nwalk,nptot,nkpts,nbnd,nbnd);
+      auto v2d = nda::reshape(vKK,std::array<long,2>{nwalk,nptot*nkpts*nbnd*nbnd});
       for(int is=0; is<nstot; ++is) {
         for (int Q = 0; Q < nkpts; ++Q)
         { 
@@ -800,7 +800,7 @@ public:
           {
             // ci^dagger cj term
             // LQ(Q)(ispin, ipol, ik, i, j, nchol) 
-            auto Lq_ = nda::reshape(LQ(Q)()(is,nda::ellipsis{}),std::array<long,2>{npol*nkpts*nbnd*nbnd,nchol});
+            auto Lq_ = nda::reshape(LQ(Q)()(is,nda::ellipsis{}),std::array<long,2>{nptot*nkpts*nbnd*nbnd,nchol});
             nda::blas::gemm(one,X3d(all,0,range(ncv0(Q),ncv0(Q)+nchol)),
                   nda::transpose(Lq_),zero,v2d);
 
@@ -808,14 +808,14 @@ public:
             arch::set_device_synchronization(false);
             for(int ik=0; ik<nkpts; ++ik) {
               int k2 = qk_to_k2(Q,ik);
-              for(int ip=0; ip<npol; ++ip)
+              for(int ip=0; ip<nptot; ++ip)
                 math::accumulate(one,vKK(all,ip,ik,all,all),v7d(is,all,ip,ik,all,k2,all));
             }
             arch::set_device_synchronization(true);
           } else {
             // cj^dagger ci term
             // the kpoint index of LQ(Qm) refers to k2 
-            auto Lq_ = nda::reshape(LQ(minusq(Q))()(is,nda::ellipsis{}),std::array<long,2>{npol*nkpts*nbnd*nbnd,nchol});
+            auto Lq_ = nda::reshape(LQ(minusq(Q))()(is,nda::ellipsis{}),std::array<long,2>{nptot*nkpts*nbnd*nbnd,nchol});
             nda::blas::gemm(one,X3d(all,0,range(ncv0(Q),ncv0(Q)+nchol)),
                   nda::dagger(Lq_),zero,v2d);
 
@@ -823,7 +823,7 @@ public:
             arch::set_device_synchronization(false);
             for(int ik=0; ik<nkpts; ++ik) {
               int k2 = qk_to_k2(Q,ik);
-              for(int ip=0; ip<npol; ++ip) {
+              for(int ip=0; ip<nptot; ++ip) {
                 auto v_wji = nda::permuted_indices_view<nda::encode(std::array<int, 3>{0, 2, 1})>(v7d(is,all,ip,ik,all,k2,all));
                 math::accumulate(one,vKK(all,ip,k2,all,all),v_wji);
               }
@@ -834,7 +834,7 @@ public:
           if(Q == minusq(Q)) {
             // cj^dagger ci term for Q==minusq(Q)
             // the kpoint index refers to k2 
-            auto Lq_ = nda::reshape(LQ(Q)()(is,nda::ellipsis{}),std::array<long,2>{npol*nkpts*nbnd*nbnd,nchol});
+            auto Lq_ = nda::reshape(LQ(Q)()(is,nda::ellipsis{}),std::array<long,2>{nptot*nkpts*nbnd*nbnd,nchol});
             nda::blas::gemm(one,X3d(all,1,range(ncv0(Q),ncv0(Q)+nchol)),
                   nda::dagger(Lq_),zero,v2d);
 
@@ -842,7 +842,7 @@ public:
             arch::set_device_synchronization(false);
             for(int ik=0; ik<nkpts; ++ik) {
               int k2 = qk_to_k2(Q,ik);
-              for(int ip=0; ip<npol; ++ip) {
+              for(int ip=0; ip<nptot; ++ip) {
                 auto v_wji = nda::permuted_indices_view<nda::encode(std::array<int, 3>{0, 2, 1})>(v7d(is,all,ip,k2,all,ik,all));
                 math::accumulate(one,vKK(all,ip,ik,all,all),v_wji);
               }

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -391,9 +391,9 @@ public:
                 // only scale if Q!=Qm, otherwise full tensor is scaled below 
                 if(Q!=Qm) 
                   for(auto i: kdiag) 
-                    math::scale(ComplexType(0.5),Tl3d(i,all,all));
+                    nda::tensor::scale(0.5,Tl3d(i,all,all));
                 arch::set_device_synchronization(true);
-                if(Q==Qm) nda::tensor::scale(ComplexType(0.5),Tl3d);
+                if(Q==Qm) nda::tensor::scale(0.5,Tl3d);
 
                 nda::tensor::contract(-scl,Tl5d(range(batch_cnt),nda::ellipsis{}),"lwabn",
                            Tr5d(range(batch_cnt),nda::ellipsis{}),"lwban",one,E(all,1),"w");
@@ -428,7 +428,7 @@ public:
             // only scale if Q!=Qm, otherwise full tensor is scaled below 
             if(Q!=Qm) 
               for(auto i: kdiag) 
-                math::scale(ComplexType(0.5),Tl3d(i,all,all));
+                nda::tensor::scale(0.5,Tl3d(i,all,all));
             arch::set_device_synchronization(true);
             if(Q==Qm) nda::tensor::scale(ComplexType(0.5),Tl3d);
 
@@ -644,7 +644,7 @@ public:
           // only scale if Q!=Qm, otherwise full tensor is scaled below 
           if(Q!=Qm)
             for(auto i: kdiag)
-              math::scale(ComplexType(0.5),Tl3d(i,all,all));
+              nda::tensor::scale(ComplexType(0.5),Tl3d(i,all,all));
           arch::set_device_synchronization(true);
           if(Q==Qm) nda::tensor::scale(ComplexType(0.5),Tl3d);
 

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -30,8 +30,6 @@
 
 #include "nda/h5.hpp"
 #include "nda/tensor.hpp"
-#include <hdf5.h>
-#include <hdf5_hl.h>
 
 #include "KPFactorizedHamiltonian.h"
 #include "AFQMC/Utilities/wfn_utils.hpp"
@@ -82,6 +80,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   int npol_in_file = npol;
   // BZ variables
   int nkpts = 1;
+  int nqpts = 1;
   int nkpts_ibz = 1;
   int nqpts_ibz = 1;
   int nbnd = 1;
@@ -108,26 +107,22 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       // open subgroup
       h5::group hgrp = grp.open_group("System");
       {
-        int n;
         h5::group bz = hgrp.open_group("BZ");
         // read nkpts
-        h5::h5_read_attribute(bz,"number_of_kpoints",n);
-        nkpts = long(n);
-        h5::h5_read_attribute(bz,"number_of_kpoints_ibz",n);
-        nkpts_ibz = long(n);
-        h5::h5_read_attribute(bz,"number_of_qpoints",n);
-        utils::check(n==nkpts, base_error + "nqpts != nkpts, nqpts:{}, nkpts:{}",n,nkpts);
-        h5::h5_read_attribute(bz,"number_of_qpoints_ibz",n);
-        nqpts_ibz = long(n);
+        h5::h5_read_attribute(bz,"number_of_kpoints",nkpts);
+        h5::h5_read_attribute(bz,"number_of_kpoints_ibz",nkpts_ibz);
+        h5::h5_read_attribute(bz,"number_of_qpoints",nqpts);
+        utils::check(nqpts == nkpts, base_error + "nqpts != nkpts, nqpts:{}, nkpts:{}",nqpts,nkpts);
+        h5::h5_read_attribute(bz,"number_of_qpoints_ibz",nqpts_ibz);
         // nbnd
-        h5::h5_read_attribute(hgrp,"number_of_bands",n);  // per kpoint
+        int nbnd_in_file{};
+        h5::h5_read_attribute(hgrp,"number_of_bands",nbnd_in_file);  // per kpoint
         // check nbnd 
-        utils::check(NMO%nkpts==0, base_error + "NMO%nkpts != 0, NMO:{}, nkpts:{}",NMO,nkpts);
-        utils::check((NMO/nkpts)==n, base_error + "nbnd:{} differs from file n:{}",nbnd,n);
         nbnd = long(NMO/nkpts);
+        utils::check(NMO%nkpts==0, base_error + "NMO%nkpts != 0, NMO: {}, nkpts: {}",NMO,nkpts);
+        utils::check((NMO/nkpts)==nbnd_in_file, base_error + "nbnd: {} differs from file: {}",nbnd,nbnd_in_file);
         // read nspin_in_file
-        h5::h5_read_attribute(hgrp,"number_of_spins",n);
-        nspin_in_file = long(n);
+        h5::h5_read_attribute(hgrp,"number_of_spins",nspin_in_file);
         // read npol_in_file
 //        h5::h5_read_attribute(bz,"number_of_polarizations",n);
 //        npol_in_file=long(n);
@@ -165,8 +160,8 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         h5::group igrp = grp.open_group("Interaction");
 
         auto expected_shape = std::to_array<size_t>({nspin_in_file * npol_in_file, nkpts, nbnd, nbnd});
-        nchol.resize(nqpts_ibz); 
-        for(int Q=0; Q<nqpts_ibz; ++Q) {
+        nchol.resize(nkpts); 
+        for(int Q=0; Q<nkpts; ++Q) {
           auto l = h5::array_interface::get_dataset_info(igrp,"Vq"+std::to_string(Q));
           utils::check(l.rank() == 6, "Rank mismatch");
           utils::check(std::ranges::equal(std::span(l.lengths).subspan(1,4), expected_shape),
@@ -203,7 +198,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       nda::h5_read(hgrp,"MinusK",minusq);
       qk_to_k2.resize(nkpts,nkpts);
       nda::h5_read(hgrp,"QKTok2",qk_to_k2);
-      nchol.resize(nqpts_ibz);
+      nchol.resize(nkpts);
       nda::h5_read(hgrp,"NCholPerKP",nchol);
       utils::check(NMO == nbnd*nkpts, " Error: NMO:{}, nkpts:{}, nbnd:{}",NMO,nkpts,nbnd); 
       Q0_index=-1;
@@ -241,17 +236,15 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   if(not mpi->comm.root()) {
     minusq.resize(nkpts);
     qk_to_k2.resize(nkpts,nkpts);
-    nchol.resize(nqpts_ibz);
+    nchol.resize(nkpts);
   }
   mpi->broadcast(nchol);
   mpi->broadcast(minusq);
   mpi->broadcast(qk_to_k2);
 
-  utils::check(nqpts_ibz==nkpts, "Error: Symmetry not yet implemented.");
-
   int nchol_av = nda::sum(nchol)/double(nchol.extent(0));
-  app_log(1," # k-points: {}", nkpts);
-  app_log(1," # Q-points (IBZ): {}", nqpts_ibz);
+  app_log(1," # k-points (IBZ): {} ({})", nkpts, nkpts_ibz);
+  app_log(1," # Q-points (IBZ): {} ({})", nqpts, nqpts_ibz);
   app_log(1," Average # of cholesky vectors {}", nchol_av);
 
   // If q==minusq(q), qmap(q) has the position of q in Lbnk.
@@ -297,7 +290,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       for (int K = 0; K < nkpts; K++)
       {
         auto h_ = H1()(0,K,all,all);
-        utils::h5_read(hgrp,std::string("H1_kp") + std::to_string(K), h_);
+        utils::h5_read(hgrp, "H1_kp" + std::to_string(K), h_);
       }
 
       // now read KPFactorized/L
@@ -306,15 +299,34 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         if(Q <= minusq(Q)) {
           auto L2d = nda::reshape(LQ(Q)()(0,0,nda::ellipsis{}),
                                   std::array<long,2>{nkpts,nbnd*nbnd*nchol(Q)});
-          utils::h5_read(lgrp,std::string("L") + std::to_string(Q),L2d);
+          utils::h5_read(lgrp, "L" + std::to_string(Q), L2d);
         }
       }
       // normalization (1/sqrt(nkpts)) assummed to be included
 
     } else if(format == "coqui") {
       h5::group sgrp = grp.open_group("System");
-      auto h_ = H1();
-      utils::h5_read(sgrp,"H0",h_);
+
+      if(nkpts_ibz == nkpts) {
+        utils::h5_read(sgrp,"H0",H1());
+      } else {
+        nda::array<ComplexType,4> H1_ibz(nspin_in_file, nkpts_ibz, npol_in_file*nbnd, npol_in_file*nbnd);
+        utils::h5_read(sgrp,"H0",H1_ibz());
+
+        nda::vector<int> kp_to_ibz(nkpts);
+        utils::h5_read(sgrp, "BZ/kp_to_ibz", kp_to_ibz());
+        nda::vector<bool> kp_trev(nkpts);
+        utils::h5_read(sgrp, "BZ/kp_trev", kp_trev());
+
+        for(int k = 0; k < nkpts; k++) {
+          bool inversion_symmetry = kp_trev(k);
+          if(inversion_symmetry) {
+            H1()(all, k, all, all) = nda::conj(H1_ibz(all, kp_to_ibz[k], all, all));
+          } else {
+            H1()(all, k, all, all) = H1_ibz(all, kp_to_ibz[k], all, all);
+          }
+        }
+      }
 
       h5::group igrp = grp.open_group("Interaction");
       for(int Q=0; Q<nkpts; ++Q) {

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -63,17 +63,18 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   long ndet = PsiT.extent(0);
   long nel_up = PsiT(0,0).extent(0);
   long NMO = PsiT(0,0).extent(1)/npol;
-  utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.size(1)%npol != 0");
+  utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.extent(1)%npol != 0");
   utils::check(nspin_in_PsiT==1 or nspin_in_PsiT==nspin, "Size mismatch");
   utils::check(ndet==1, "Error: ndet > 1 not yet implemented in KPFactorizedHamiltonian::getHamiltonianOperations.");
   long nel_dn = ( type == FULLYPOLARIZED or type == NONCOLLINEAR ? 0l :
               (type == CLOSED ? nel_up : PsiT(0,nspin_in_PsiT-1).extent(0) ) );
-  for(int i=0; i<ndet; ++i)
+  for(int i=0; i<ndet; ++i) {
     for(int ip=0; ip<npol; ++ip) {
-      utils::check(PsiT(i,0).shape() == std::array<long,2>{nel_up,NMO},"PsiT shape mismatch.");
+      utils::check(PsiT(i,0).shape() == std::array<long,2>{nel_up,npol*NMO}, "PsiT shape mismatch.");
       if(type == COLLINEAR)
         utils::check(PsiT(i,nspin_in_PsiT-1).shape() == std::array<long,2>{nel_dn,NMO},"PsiT shape mismatch.");
     }
+  }
   utils::check(nel_up >= nel_dn, base_error + "nel_up:{} < nel_dn:{} not allowed.",nel_up,nel_dn);
 
   // Hamiltonian variables
@@ -130,6 +131,9 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         // read npol_in_file
 //        h5::h5_read_attribute(bz,"number_of_polarizations",n);
 //        npol_in_file=long(n);
+        // TODO: does this format even support polarizations?
+        npol_in_file = 1;
+
         utils::check((nspin_in_file==1) or (nspin_in_file==nspin),
                      base_error + " Incompatible nspin:{} in h5 file.",nspin_in_file);
 //        utils::check((npol_in_file==1) or (npol_in_file==npol), 
@@ -159,23 +163,14 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       {
         // interaction
         h5::group igrp = grp.open_group("Interaction");
+
+        auto expected_shape = std::to_array<size_t>({nspin_in_file * npol_in_file, nkpts, nbnd, nbnd});
         nchol.resize(nqpts_ibz); 
-        {
-          auto l = h5::array_interface::get_dataset_info(igrp,"Vq0");
-          utils::check(l.rank() == 6, "Rank mismatch");
-          utils::check(l.lengths[1] == nspin_in_file*npol_in_file and
-                       l.lengths[2] == nkpts and
-                       l.lengths[3] == nbnd and
-                       l.lengths[4] == nbnd, "Size mismatch");
-          nchol(0) = l.lengths[0];
-        }
         for(int Q=0; Q<nqpts_ibz; ++Q) {
           auto l = h5::array_interface::get_dataset_info(igrp,"Vq"+std::to_string(Q));
           utils::check(l.rank() == 6, "Rank mismatch");
-          utils::check(l.lengths[1] == nspin_in_file*npol_in_file and
-                       l.lengths[2] == nkpts and
-                       l.lengths[3] == nbnd and
-                       l.lengths[4] == nbnd, "Size mismatch");
+          utils::check(std::ranges::equal(std::span(l.lengths).subspan(1,4), expected_shape),
+                       "Interaction/Vq{} size mismatch: {} != {} ", Q, std::span(l.lengths).subspan(1,4), expected_shape);
           if(Q <= minusq(Q))
             nchol(Q) = l.lengths[0];
           else
@@ -232,7 +227,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       }  
       utils::check(Q0_index>=0, "Error: Problems finding Q=0");
     } else {
-      utils::check(false,"Unknown file format:",format);
+      utils::check(false,"Unknown file format: {}",format);
     }
   } // root
 
@@ -317,7 +312,6 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       // normalization (1/sqrt(nkpts)) assummed to be included
 
     } else if(format == "coqui") {
-
       h5::group sgrp = grp.open_group("System");
       auto h_ = H1();
       utils::h5_read(sgrp,"H0",h_);
@@ -328,7 +322,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
           // too much memory???
           nda::array<ComplexType,5> L(nchol(Q),nspin_in_file*npol_in_file,nkpts,nbnd,nbnd);
           utils::h5_read(igrp,"Vq"+std::to_string(Q),L);
-          utils::check( L.shape() == std::array<long,5>{nchol(Q),nspin_in_file*npol_in_file,nkpts,nbnd,nbnd}, "Size mismatch from h5 dataset.");
+          utils::check(L.shape() == std::array<long,5>{nchol(Q),nspin_in_file*npol_in_file,nkpts,nbnd,nbnd}, "Size mismatch from h5 dataset.");
           auto L2d = nda::reshape(L,std::array<long,2>{nchol(Q),nspin_in_file*npol_in_file*nkpts*nbnd*nbnd});
           if constexpr (MEM==HOST_MEMORY) {
             auto LQ2d = nda::reshape(LQ(Q)(),std::array<long,2>{nspin_in_file*npol_in_file*nkpts*nbnd*nbnd,nchol(Q)});

--- a/src/IO/fmt_extensions.hpp
+++ b/src/IO/fmt_extensions.hpp
@@ -20,6 +20,7 @@
 #if defined(ENABLE_SPDLOG)
 
 #include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ranges.h>
 
 template <> struct fmt::formatter<std::complex<double>> {
   constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
@@ -59,68 +60,6 @@ template <> struct fmt::formatter<std::complex<float>> {
   }
 };
 
-template<typename T> struct fmt::formatter<std::vector<T>>
-{
-
-  template<typename ParseContext>
-  constexpr auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it == end || *it == '}') return it;
-    if (*it == 'f') ++it;
-    if (it != end && *it != '}')
-      throw format_error("invalid format");
-    return it;
-  }
-
-  template <typename FormatContext>
-  auto format(std::vector<T> const& p, FormatContext& ctx) const -> decltype(ctx.out()) {
-    *ctx.out()++ = '[';
-    bool first = true;
-    for(auto const& v : p) {
-      if (!first) {
-        *ctx.out()++ = ',';
-      }
-      format_to(ctx.out(), "{}", v);
-      first = false;
-    }
-    *ctx.out()++ = ']';
-    return ctx.out();
-  }
-
-};
-
-/*
-template <nda::Array Arr>
-struct fmt::formatter<Arr>
-{
-
-  template<typename ParseContext>
-  constexpr auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it == end || *it == '}') return it;
-    if (*it == 'f') ++it;
-    if (it != end && *it != '}')
-      throw format_error("invalid format");
-    return it;
-  }
-
-  template <typename FormatContext>
-  auto format(Arr const& p, FormatContext& ctx) const -> decltype(ctx.out()) {
-    *ctx.out()++ = '[';
-    bool first = true;
-    for(auto const& v : p) {
-      if (!first) {
-        *ctx.out()++ = ',';
-      }
-      format_to(ctx.out(), "{}", v);
-      first = false;
-    }
-    *ctx.out()++ = ']';
-    return ctx.out();
-  }
-
-};
-*/
 
 #else
 

--- a/src/numerics/operations/tensor.hpp
+++ b/src/numerics/operations/tensor.hpp
@@ -51,16 +51,6 @@ void accumulate(nda::get_value_t<A_t> alpha, A_t const& A, B_t && B) {
   }
 }
 
-template<nda::MemoryArray A_t>
-void scale(nda::get_value_t<A_t> alpha, A_t && A) {
-#if defined(ENABLE_DEVICE)
-    if constexpr (nda::mem::have_device_compatible_addr_space<A_t> and nda::get_rank<A_t> < 5) {
-      kernels::device::scale(alpha,A);
-    } else
-#endif
-      nda::tensor::scale(alpha,A); 
-}
-
 template<nda::MemoryArray Arr>
 void zero_imag(Arr && A)
 {


### PR DESCRIPTION
- c++/KP3IndexFactorization: fix noncollinear case
- c++/KP3IndexFactorization: remove math::scale
- c++/fmt_extensions: use the default range formaters for fmt.
- c++/KPFactorizedHamiltonian: implement one-body IBZ unfolding

