### PR TITLE
Enable and fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,26 +170,23 @@ if(DEFINED NDA)
   set(FETCHCONTENT_SOURCE_DIR_NDA ${NDA})
 endif()
 # set nda options before FetchContent_Declare
-#set(CutensorSupport ${ENABLE_CUTENSOR} CACHE INTERNAL "")
-set(CutensorSupport ${ENABLE_CUDA} CACHE INTERNAL "")
-set(CudaSupport ${ENABLE_CUDA} CACHE INTERNAL "")
-set(TblisSupport ON CACHE INTERNAL "")
-set(Build_Tests ${COMPILE_NDA_TESTS} CACHE INTERNAL "")
-if(COQUI_PYTHON_SUPPORT)
-  # nda_py library is needed in CoQui python version
-  set(PythonSupport ON CACHE INTERNAL "")
-else()
-  set(PythonSupport ${NDA_PYTHON_SUPPORT} CACHE INTERNAL "")
-endif()
-FetchContent_Declare(
-        nda
-        GIT_REPOSITORY "https://github.com/triqs/nda.git"
-        GIT_TAG        tensor 
-)
-FetchContent_MakeAvailable(nda)
+block()
+  set(CutensorSupport ${ENABLE_CUDA})
+  set(Cutensor_USE_STATIC ON)
+  set(CudaSupport ${ENABLE_CUDA})
+  set(TblisSupport ON)
+  set(Build_Tests ${COMPILE_NDA_TESTS})
+  set(PythonSupport OFF)
+  FetchContent_Declare(
+          nda
+          GIT_REPOSITORY "https://github.com/triqs/nda.git"
+          GIT_TAG        tensor
+  )
+  FetchContent_MakeAvailable(nda)
+endblock()
 
 ######################################################################
-# CCCL from github (useful if CudaToolkit is old 
+# CCCL from github (useful if CudaToolkit is old)
 ######################################################################
 if(ENABLE_CUDA AND FETCH_CCCL)
   # set nevanlinna options before FetchContent_Declare
@@ -231,12 +228,15 @@ endif()
 # cpptrace 
 ######################################################################
 if(ENABLE_CPPTRACE)
-  FetchContent_Declare(
-    cpptrace
-    GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-    GIT_TAG        v0.8.2
-  )
-  FetchContent_MakeAvailable(cpptrace)
+  block()
+    set(CMAKE_SKIP_INSTALL_RULES ON)
+    FetchContent_Declare(
+      cpptrace
+      GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+      GIT_TAG        v0.8.2
+    )
+    FetchContent_MakeAvailable(cpptrace)
+  endblock()
 endif(ENABLE_CPPTRACE)
 
 ######################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.25.0)
 
 project(safire VERSION 1.0.0 LANGUAGES CXX)
 
@@ -181,6 +181,7 @@ block()
           nda
           GIT_REPOSITORY "https://github.com/triqs/nda.git"
           GIT_TAG        tensor
+          SYSTEM
   )
   FetchContent_MakeAvailable(nda)
 endblock()
@@ -194,6 +195,7 @@ if(ENABLE_CUDA AND FETCH_CCCL)
         cccl
         GIT_REPOSITORY "https://github.com/NVIDIA/cccl.git"
         GIT_TAG        v3.3.3
+        SYSTEM
   )
   FetchContent_MakeAvailable(cccl)
 endif()
@@ -234,6 +236,7 @@ if(ENABLE_CPPTRACE)
       cpptrace
       GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
       GIT_TAG        v0.8.2
+      SYSTEM
     )
     FetchContent_MakeAvailable(cpptrace)
   endblock()
@@ -248,6 +251,7 @@ if(NOT cxxopts_FOUND)
     cxxopts
     GIT_REPOSITORY https://github.com/jarro2783/cxxopts.git
     GIT_TAG v3.3.1
+    SYSTEM
   )
   FetchContent_MakeAvailable(cxxopts)
 endif()
@@ -295,21 +299,17 @@ install(FILES ${PROJECT_BINARY_DIR}/bin/safire.settings DESTINATION bin)
 add_library(${PROJECT_NAME}_warnings INTERFACE)
 target_compile_options(${PROJECT_NAME}_warnings
   INTERFACE
-#    -Wall
-#    -Wextra
-#    -Wfloat-conversion
-#    -Wpedantic
-#    -Wno-sign-compare
-    $<$<CXX_COMPILER_ID:GNU>:-Wno-comma-subscript>
-    $<$<CXX_COMPILER_ID:GNU>:-Wno-psabi> # Disable notes about ABI changes
-#    $<$<CXX_COMPILER_ID:GNU>:-Wshadow=local>
+   -Wall
+   -Wextra
+   -Wfloat-conversion
+   -Wpedantic
+   -Wno-sign-compare
+   -Wno-unused-parameter
     $<$<CXX_COMPILER_ID:GNU>:-Wno-attributes>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-deprecated-comma-subscript>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-deprecated-declarations>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-unknown-warning-option>
-#    $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wshadow>
-#    $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wimplicit-float-conversion>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-gcc-compat>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-c++20-extensions>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-c++20-compat>

--- a/src/AFQMC/Drivers/DriverFactory.cpp
+++ b/src/AFQMC/Drivers/DriverFactory.cpp
@@ -207,8 +207,6 @@ bool DriverFactory<MEM>::executeAFQMCDriver(std::string title, int m_series, ptr
     return false;
   }
   auto& AFinfo = InfoMap[system];
-  int NMO      = AFinfo.NMO;
-  int ndown     = AFinfo.ndown;
 
   std::string hdf_read_restart;
   bool set_nWalker_target;

--- a/src/AFQMC/Drivers/tests/test_driver_factory.cpp
+++ b/src/AFQMC/Drivers/tests/test_driver_factory.cpp
@@ -67,7 +67,6 @@ void driver_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
     hamil_file, wfn_file
   );
   using nda::range;
-  auto all = range::all;
   utils::check(utils::file_exists(hamil_file),
                " Hamiltonian file not found: {}. \n Run unit test with --hamil /path/to/hamil.h5 ", hamil_file);
   utils::check(utils::file_exists(wfn_file),

--- a/src/AFQMC/Estimators/BPWithTimeEvolvedOperators.hpp
+++ b/src/AFQMC/Estimators/BPWithTimeEvolvedOperators.hpp
@@ -214,9 +214,6 @@ public:
     accumulated_in_last_block = false;
     int bp_step               = wset.getBPPos();
     int nwalk = wset.size();
-    int nel = nup + (walker_type == COLLINEAR ? ndown : 0);
-    int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
-    int nspin = (walker_type == COLLINEAR ? 2 : 1);
     utils::check(bp_step>0," Error: Found bp_step <=0 in ~BPWithTimeEvolvedOperators::accumulate_block. ");
     utils::check(bp_step<=max_nback_prop, " Error: max_nback_prop in back propagation estimator must be commensurate with measure_interval.");
     utils::check(max_nback_prop <= wset.NumBackProp()," Error: max_nback_prop > wset.NumBackProp() ");

--- a/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
@@ -197,7 +197,6 @@ public:
     int nwalk = wset.size();
     int nel = nup + (walker_type == COLLINEAR ? ndown : 0);
     int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
-    int nspin = (walker_type == COLLINEAR ? 2 : 1);
     utils::check(bp_step>0," Error: Found bp_step <=0 in BackPropagate::accumulate_block. ");
     utils::check(bp_step<=max_nback_prop, " Error: max_nback_prop in back propagation estimator must be commensurate with measure_interval.");
     utils::check(max_nback_prop <= wset.NumBackProp()," Error: max_nback_prop > wset.NumBackProp() ");

--- a/src/AFQMC/Estimators/Observables/diagonal2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/diagonal2rdm.hpp
@@ -64,9 +64,6 @@ public:
     // assumes G[nwalk][spin][M][M]
     ncalls++;
 
-    int nspin = walker_type == COLLINEAR ? 2 : 1;
-    int npol = walker_type == NONCOLLINEAR ? 2 : 1;
-
     memory::buffered_array<MEM, ComplexType,4> XwG(G.shape());
     nda::tensor::contract(memory::to_memory_space<MEM>(Xw), "w", G, "wsij", XwG, "wsij");
     

--- a/src/AFQMC/Estimators/Observables/full1rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full1rdm.hpp
@@ -156,7 +156,6 @@ public:
 
        utils::check(walker_type != NONCOLLINEAR,"Error: Not yet implemented: acc_with_rotation && noncollinear.");
 
-      int nw = G_host.extent(0);  
       int nX   = XRot().extent(0);
       // Grot = Xc * G * H(Xc)
       memory::buffered_array<HOST_MEMORY,ComplexType,4> T1(nwalk,nspin,nX,npol*NMO); 

--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -162,15 +162,9 @@ private:
   auto acc_no_rotation(int iav, nda::MemoryArrayOfRank<4> auto&& G, nda::MemoryVector auto&& Xw)
   {
     using nda::ellipsis;
-    // doing this 1 walker at a time and not worrying about speed
-    int nw(G.shape(0));
-
     // (ikjl) = Gik * Gjl - (same spin) Gil Gjk
     if (walker_type == COLLINEAR)
     {
-      size_t M2(NMO * NMO);
-      size_t M4(M2 * M2);
-
       memory::buffered_array<MEM,ComplexType,2> R(NMO * NMO, NMO * NMO);
       memory::buffered_array<MEM,ComplexType,2> Q(NMO, NMO * NMO * NMO);
     

--- a/src/AFQMC/Estimators/Observables/pair_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/pair_correlators.hpp
@@ -130,7 +130,6 @@ public:
         for (int beta = 0; beta < num_correlators; beta++)
         {
           const auto &pair_map_j = this->pair_map.at(beta);
-          int pair_ind = alpha * num_correlators + beta;
 
           auto avg = pair_corr_average(iav, alpha, beta, range::all);
           int idx{};

--- a/src/AFQMC/Estimators/tests/test_estimator_handler.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimator_handler.cpp
@@ -57,7 +57,6 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
 {
   using sfqmc::utils::ARRAY_EQUAL;
   using nda::range;
-  auto all = range::all;
   utils::check(utils::file_exists(hamil_file),
                " Hamiltonian file not found: {}. \n Run unit test with --hamil /path/to/hamil.h5 ", hamil_file);
   utils::check(utils::file_exists(wfn_file),
@@ -92,7 +91,6 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
 
   int nspin            = (type == COLLINEAR) ? 2 : 1;
   int npol             = (type == NONCOLLINEAR) ? 2 : 1;
-  int nel              = (type == COLLINEAR) ? nup+ndown : nup;
 
   ptree wfn_pt;
   wfn_pt.put("name","wfn0");
@@ -234,7 +232,6 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
       }
     
     }
-    int expected_estimator_querries = nStep / test_ptree.get<int>("gcd");
     // Energy estimator uses meas1 as the global measure_interval_multiplier
     int energy_interval = test_ptree.get<int>("meas1") * population_control_interval;
     int expected_measurments = nStep / energy_interval;

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -68,7 +68,6 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
 {
   using sfqmc::utils::ARRAY_EQUAL;
   using nda::range;
-  auto all = range::all;
   utils::check(utils::file_exists(hamil_file),
                " Hamiltonian file not found: {}. \n Run unit test with --hamil /path/to/hamil.h5 ", hamil_file);
   utils::check(utils::file_exists(wfn_file),
@@ -101,7 +100,6 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
 
   int nspin            = (type == COLLINEAR) ? 2 : 1;
   int npol             = (type == NONCOLLINEAR) ? 2 : 1;
-  int nel              = (type == COLLINEAR) ? nup+ndown : nup;
 
   ptree wfn_pt;
   wfn_pt.put("name","wfn0");
@@ -120,7 +118,7 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
 
   PropagatorFactory<MEM> PropgFac(InfoMap);
   PropgFac.push("prop0", prop_pt);
-  auto& prop = PropgFac.getPropagator(mpi, "prop0", wfn, rng_dev);
+  PropgFac.getPropagator(mpi, "prop0", wfn, rng_dev);
 
   auto initial_guess = WfnFac.getInitialGuess("wfn0");
   REQUIRE(initial_guess.shape() == std::array<long,3>{nspin,npol*NMO,nup});

--- a/src/AFQMC/Estimators/tests/test_observables_reference.cpp
+++ b/src/AFQMC/Estimators/tests/test_observables_reference.cpp
@@ -69,8 +69,9 @@ std::array<long, 4> g_shape(int nwalk, int NMO, WALKER_TYPES wt)
     case CLOSED:       return {nwalk, 1, NMO,     NMO};
     case COLLINEAR:    return {nwalk, 2, NMO,     NMO};
     case NONCOLLINEAR: return {nwalk, 1, 2 * NMO, 2 * NMO};
+    default:
+      utils::check(false, "unreachable: unknown walker type");
   }
-  utils::check(false, "unreachable: unknown walker type");
   return {};
 }
 

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -85,7 +85,6 @@ public:
         default_buffer_size_in_MB(bf_size),
         E0(e0_)
   {
-    auto all = nda::range::all;
     // setup
     int nspin  = (walker_type == COLLINEAR) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
@@ -467,7 +466,6 @@ public:
     ComplexType one(1.0), zero(0.0);
     int is = (spin_component == Alpha ? 0 : 1);
     int nwalk = G.extent(0);
-    int nspin  = (walker_type == COLLINEAR) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int nup = nda::sum(nocc(0,all));
     int ndown = (walker_type==COLLINEAR ? nda::sum(nocc(1,all)) : 0);
@@ -705,8 +703,6 @@ public:
     using nda::range;
     auto all  = range::all;
     ComplexType one(1.0), zero(0.0);
-    int nspin  = (walker_type == COLLINEAR) ? 2 : 1;
-    int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int nwalk = X.extent(0);
     int NMO   = nkpts*nbnd;
     int nspin_in_H = hij.extent(0);
@@ -1006,10 +1002,7 @@ protected:
     using nda::range;
     auto all  = range::all;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nspin = (walker_type == COLLINEAR) ? 2 : 1;
     int nwalk = G.extent(0); 
-    int nup   = nda::sum(nocc(0,all));
-    int ndown = (walker_type==COLLINEAR ? nda::sum(nocc(1,all)) : 0);
  
     auto G6d = nda::reshape(GKK,std::array<long,6>{nkpts,nkpts,nwalk,nocc_max,npol,nbnd});
     GKK() = ComplexType(0.0);
@@ -1045,10 +1038,7 @@ protected:
     using nda::range;
     auto all  = range::all;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nspin = (walker_type == COLLINEAR) ? 2 : 1;
     int nwalk = G.extent(0);
-    int nup   = nda::sum(nocc(0,all));
-    int ndown = (walker_type==COLLINEAR ? nda::sum(nocc(1,all)) : 0);
 
     auto G5d = nda::reshape(GQK,std::array<long,5>{nwalk,nkpts,nocc_max,npol,nbnd});
     GQK() = ComplexType(0.0);

--- a/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
@@ -230,8 +230,7 @@ public:
     int nwalk = G.extent(0);
     int nspin  = (walker_type == COLLINEAR) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nel  = (walker_type == COLLINEAR ? nup+ndown : nup); // NONCOLLINEAR has ndown=0 
-    int nocc_max = _Ydsau_.extent(4);
+    int nel  = (walker_type == COLLINEAR ? nup+ndown : nup); // NONCOLLINEAR has ndown=0
     utils::check(E.shape() == std::array<long,2>{nwalk,3}, "THC::energy: Size mismatch.");
     utils::check(G.extent(1) == nel*npol*NMO, "THC::energy: Size mismatch.");
     utils::check_strides(E,G);
@@ -251,21 +250,11 @@ public:
 
     // get array_views to the correct data and correct determinant
     bool has_rot = _Xsiu_rot_.has_value();
-    const auto Xsiu = ( has_rot ? (*_Xsiu_rot_)() : _Xsiu_() );
-    const auto Ysau = ( has_rot ? (*_Ydsau_rot_)()(idet,nda::ellipsis{}) : _Ydsau_()(idet,nda::ellipsis{}) );
     const auto Zuv = ( has_rot ? (*_Zuv_rot_)() : (*_Zuv_)() );
 
     int nu = Zuv.extent(1);
-    int nstot = hij.extent(0);
-    int nptot = hij.extent(2)/nbnd;
 
-    // calculate how many walkers can be done concurrently
-//    long Bytes = default_buffer_size_in_MB * 1024L * 1024L;
-//    Bytes /= long((nu * nu + nu + nu * nup) * sizeof(ComplexType));
-//    int nwmax = std::min(nwalk, std::max(1, int(Bytes)));
-    int nwmax = nwalk;
-
-    utils::check(G.is_contiguous(), "Layout mismatch"); 
+    utils::check(G.is_contiguous(), "Layout mismatch");
     memory::array_view<MEM,const ComplexType,5> G5d(std::array<long,5>{nwalk,nel,npol,nkpts,nbnd},G.data());
 
     if constexpr (MEM==HOST_MEMORY)
@@ -278,10 +267,8 @@ public:
         Guu() = ComplexType(0.0);
         for (int ispin = 0; ispin < nspin; ++ispin)
         {
-          long is_ = long(ispin)%nstot; 
           for (int p1 = 0; p1 < npol; ++p1)
           {
-            long ip1_ = long(p1)%nptot; 
             for (int p2 = 0; p2 < npol; ++p2)
             {
 
@@ -447,7 +434,6 @@ public:
     const auto Xsiu = ( has_rot ? (*_Xsiu_rot_)() : _Xsiu_() );
     const auto Luv = _Luv_(); 
     int nu = Luv.extent(1);
-    int nv = Luv.extent(2);
 
     auto X4d = nda::reshape(X,std::array<long,4>{nwalk,2,nkpts,nu});
 
@@ -892,9 +878,8 @@ protected:
     auto all = range::all;
     int nstot = hij.extent(0);
     int nptot = hij.extent(2)/nbnd;
-    int nspin  = (walker_type == COLLINEAR) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nel  = (walker_type == COLLINEAR ? nup+ndown : nup); // NONCOLLINEAR has ndown=0 
+    int nel  = (walker_type == COLLINEAR ? nup+ndown : nup); // NONCOLLINEAR has ndown=0
     bool has_rot = _Xsiu_rot_.has_value();
     // [nstot][nkpts][nptot*nbnd][nu]
     const auto Xsiu = ( has_rot ? (*_Xsiu_rot_)() : _Xsiu_());

--- a/src/AFQMC/HamiltonianOperations/ModelComponents/Discrete_GeneralUJ.hpp
+++ b/src/AFQMC/HamiltonianOperations/ModelComponents/Discrete_GeneralUJ.hpp
@@ -244,7 +244,6 @@ private:
     int M = NMO;	
     int M2 = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2*M : M;
     int Madd = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? M : 0;
-    bool head_shared = ( MEM==HOST_MEMORY ? mpi->node_comm.root() : true ); 
 
     if(mpi->comm.root()) {
  

--- a/src/AFQMC/HamiltonianOperations/ModelComponents/SparseEnergy.hpp
+++ b/src/AFQMC/HamiltonianOperations/ModelComponents/SparseEnergy.hpp
@@ -62,7 +62,6 @@ public:
     // expect hij as a sparse Matrix with a single row (to reuse csr_matrix class) 
     int nIJ = n2IJ_host.extent(0);
     int nspin = (type == COLLINEAR or type == COLLINEAR_FT ? 2 : 1);
-    int npol  = (type == NONCOLLINEAR or type == NONCOLLINEAR_FT ? 2 : 1);
     utils::check(SpVJ.size() == 1 + (nspin-1)*2, "Size mismatch");
     utils::check(SpVX.size() == 1 + (nspin-1), "Size mismatch");
     utils::check(hij[0].shape() == std::array<long,2>{1,nIJ}, "Size mismatch");

--- a/src/AFQMC/HamiltonianOperations/ModelHamOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/ModelHamOps.hpp
@@ -80,7 +80,6 @@ public:
       nCV += v.number_of_cholesky_vectors();
     }
 
-    int nspin = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
     int M     = PsiC.extent(2);
     int NMO   = M/npol;
@@ -252,7 +251,6 @@ public:
               bool addEXX = true)
   {
     int npol  = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
-    int nspin = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
     int ispin = ( spin_component==Alpha ? 0 : 1 );
     int NMO   = PsiC.extent(2) / npol;
     int nwalk = G.extent(0);
@@ -487,7 +485,6 @@ private:
     using nda::range;
     auto all = range::all;
     int npol   = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
-    int nspin  = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
     int NMO    = PsiC.extent(2) / npol;
     int nwalk  = Gc.extent(0);
     utils::check( Gc.shape() == std::array<long,3>{nwalk,nel[ispin],npol*NMO}, "Shape mismatch");
@@ -495,7 +492,6 @@ private:
     auto Gfull_3d = nda::reshape(Gfull, std::array<long,3>{npol * NMO, npol * NMO, nwalk});
 
     auto psi = PsiC()(idet,ispin,all,range(nel[ispin]));
-    int n0 = (ispin == 0 ? 0 : nel[0]);
     if constexpr (MEM==HOST_MEMORY) {
       memory::buffered_array<MEM,ComplexType,2> G_(npol * NMO, npol * NMO);
       auto Gfull_2d = nda::reshape(Gfull, std::array<long,2>{npol * NMO * npol * NMO, nwalk});
@@ -550,7 +546,6 @@ private:
     using nda::range;
     auto all = range::all;
     int npol   = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
-    int nspin  = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
     int M      = PsiC.extent(2);
     int NMO    = PsiC.extent(2) / npol;
     int nwalk  = Gc.extent(0);
@@ -596,7 +591,6 @@ private:
     using nda::range;
     auto all = range::all;
     int npol   = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
-    int nspin  = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
     int M      = PsiC.extent(2);
     int NMO    = PsiC.extent(2) / npol;
     int nwalk  = Gc.extent(0);
@@ -718,9 +712,7 @@ private:
   {
     using nda::range;
     auto all = range::all;
-    int npol  = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
     int nspin = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
-    int NMO   = PsiC.extent(2) / npol;
     int nwalk = G3d.extent(0);
     TimerManager Timer;
 

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
@@ -200,7 +200,6 @@ public:
     memory::check_memory_space<MEM>(E,G);
     using nda::range;
     auto all = range::all;
-    RealType scl = (walker_type == CLOSED ? 2.0 : 1.0);
     int nspin = (walker_type == COLLINEAR ? 2 : 1);
     int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
     int nwalk = G.extent(0);
@@ -241,9 +240,7 @@ public:
     memory::check_memory_space<MEM>(E,G,EJn);
     using nda::range;
     auto all = range::all;
-    RealType scl = (walker_type == CLOSED ? 2.0 : 1.0);
     int ispin = ( spin_component == Alpha ? 0 : 1);
-    int nspin = (walker_type == COLLINEAR ? 2 : 1);
     int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
     int nwalk = G.extent(0);
     int nel  = (ispin==0 ? nup : ndown);
@@ -343,8 +340,6 @@ public:
     static_assert(MEM == MEM_X, "Memory space mismatch");
     using nda::range;
     auto all = range::all;
-    int nspin = (walker_type == COLLINEAR) ? 2 : 1;
-    int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int nwalk = X.extent(0);
     int nstot = (walker_type == COLLINEAR) ? Likn.extent(0) : 1;
     int nptot = (walker_type == NONCOLLINEAR) ? Likn.extent(0) : 1;
@@ -837,7 +832,6 @@ private:
     utils::check(idet >= 0 and idet < haj.extent(0), "Invalid idet");
 
     int nwalk = G.extent(0);
-    int nspin = (walker_type == COLLINEAR ? 2 : 1);
     int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
     int nel[2] = {nup,ndown};
     RealType scl = (walker_type == CLOSED ? 2.0 : 1.0);
@@ -953,7 +947,6 @@ private:
     utils::check(haj.extent(0) == 1, "Calling ph_ref_energy_impl with ndet>1.");
 
     int nwalk = G2d.extent(0);
-    int nspin = (walker_type == COLLINEAR ? 2 : 1);
     int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
     int nel = G2d.extent(1)/(npol*NMO);
     int nact[2] = {nup,ndown};

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -268,8 +268,7 @@ public:
           {
             // Buffer space
             memory::buffered_array<MEM,ComplexType,3> Tva(nw,nu,nelec[ispin]);
-            auto T2d = nda::reshape(Tva, std::array<long,2>{nw*nu,nelec[ispin]});
-            Guv_Guu(ispin, p1, p2, G3d(range(iw, iw + nw), range(ispin*nup,nup+ispin*ndown), all), 
+            Guv_Guu(ispin, p1, p2, G3d(range(iw, iw + nw), range(ispin*nup,nup+ispin*ndown), all),
                     Guv, Guu, nda::flatten(Tva), idet);
 
 /*
@@ -302,7 +301,6 @@ public:
 
             // reuse Guv memory
             memory::array_view<MEM,ComplexType,3> Twib(std::array<long,3>{nw,NMO,nelec[ispin]},Guv.data());
-            auto Tb_2d = nda::reshape(Twib, std::array<long,2>{nw*NMO,nelec[ispin]});
 
             // R[w,u][b] = sum_v Guv[w,u][v] * rotcXau[b][v]
             auto Yau = Ysau(ispin,p2,range(nelec[ispin]),all);
@@ -359,7 +357,6 @@ public:
     using nda::range;
     auto all  = range::all;
     int nwalk = G.extent(0);
-    int nspin = (walker_type == COLLINEAR) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int nel   = G.extent(1)/(npol*NMO); 
     int ispin = (spin_component == Alpha ? 0 : 1);
@@ -618,7 +615,6 @@ public:
   {
     memory::check_memory_space<MEM>(G,v);
     using nda::range;
-    auto all = range::all;
     int nchol = ( REAL ? _Luv_().extent(1) : 2 * _Luv_().extent(1) );
     int nwalk = G.extent(0);
     int nspin  = (walker_type == COLLINEAR) ? 2 : 1;

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -56,7 +56,6 @@ void run_hubbard_consistency()
   tests::HubbardSpec spec;
   // Defaults: 4x4 lattice, t=1, U=4, nup=ndown=4, COLLINEAR.
   int NMO   = spec.NMO();
-  int nspin = (spec.walker_type == COLLINEAR) ? 2 : 1;
   int npol  = (spec.walker_type == NONCOLLINEAR) ? 2 : 1;
   int nel   = spec.nel();
   int nwalk = 3;

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -94,7 +94,6 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   nda::array<int,1> kp_trev_pair;
   nda::array<int,1> nchol;
   nda::array<double,2> qpoints;
-  int number_of_trev_kpoint_pairs=0;
 
   h5::file file;
   // Read nbnd, BZ info, etc from h5. Only root reads
@@ -242,10 +241,10 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   mpi->broadcast(minusq);
   mpi->broadcast(qk_to_k2);
 
-  int nchol_av = nda::sum(nchol)/double(nchol.extent(0));
+  double nchol_av = nda::sum(nchol)/double(nchol.extent(0));
   app_log(1," # k-points (IBZ): {} ({})", nkpts, nkpts_ibz);
   app_log(1," # Q-points (IBZ): {} ({})", nqpts, nqpts_ibz);
-  app_log(1," Average # of cholesky vectors {}", nchol_av);
+  app_log(1," Average # of cholesky vectors {:.2g}", nchol_av);
 
   // If q==minusq(q), qmap(q) has the position of q in Lbnk.
   nda::array<int,1> Qmap(nkpts,-1);  

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -105,9 +105,9 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   nda::array<bool,1> kp_trev;  
   nda::array<bool,1> qp_trev;  
   nda::array<int,1> kp_trev_pair;
-  nda::array<double,2> qpoints; 
-  long number_of_trev_kpoint_pairs=0;
-  
+  nda::array<double,2> qpoints;
+
+
   // only root reads
   h5::file file;
   if (mpi->comm.root())
@@ -337,8 +337,7 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
     for(long is=0; is<nspin; ++is) 
       for(long ik=0; ik<nkpts; ++ik, ++itot) 
       {
-        if( itot%mpi->comm.size() != mpi->comm.rank() ) continue; 
-        using matrix_t = memory::buffered_array<MEM,ComplexType,2>;
+        if( itot%mpi->comm.size() != mpi->comm.rank() ) continue;
         long is_ = is%nspin_in_file;
         int n0 = ( ik==0 ? 0 : nda::sum(nocc(is,range(ik))) );
         int nel = nocc(is,ik); 

--- a/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.cpp
+++ b/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.cpp
@@ -276,7 +276,6 @@ ModelHamOpsGenerator::getHamiltonianOperations_impl(WALKER_TYPES type,
         // opposite spin (i<=j)
         auto vals = Jij.values();
         auto cols = Jij.columns();
-        long cnt=0;
         for( int r=0; r<NMO; ++r) {
           for(long i=Jij.row_begin(r); i<Jij.row_end(r); ++i) {
             auto v_ = vals(i);

--- a/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.icc
+++ b/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.icc
@@ -28,7 +28,6 @@ SparseEnergy<MEM,REAL> ModelHamOpsGenerator::make_SparseEnergy(
   using nda::range;
   using csrM = math::sparse::csr_matrix<ValueType, HOST_MEMORY, int, int>;
   auto all = range::all;
-  int nspin = (type == COLLINEAR or type == COLLINEAR_FT ? 2 : 1 );
   int npol = (type == NONCOLLINEAR or type == NONCOLLINEAR_FT ? 2 : 1 );
   long M = NMO;
   long M2 = npol*M; 
@@ -453,13 +452,10 @@ nda::array<long,1> ModelHamOpsGenerator::find_occupied_pairs(WALKER_TYPES type,
 
   utils::check(type != CLOSED, " Error: Model Hamiltonians not allowed with CLOSED walkers. ");
   using nda::range;
-  using csrM = math::sparse::csr_matrix<ValueType, HOST_MEMORY, int, int>;
-  auto all = range::all;
-  int nspin = (type == COLLINEAR or type == COLLINEAR_FT ? 2 : 1 );
   int npol = (type == NONCOLLINEAR or type == NONCOLLINEAR_FT ? 2 : 1 );
   long M = long(NMO);
-  long M2 = npol*M; 
-  long Madd = M2-M; 
+  long M2 = npol*M;
+  long Madd = M2-M;
 
   nda::array<long,1> n2IJ;
   {
@@ -574,8 +570,7 @@ void ModelHamOpsGenerator::addComponent( WALKER_TYPES wtype, PropagatorTypes pty
      nda::array<long,1>& n2IJ, map_t& IJ2n)
 {
   using nda::range;
-  auto all = range::all;
-  utils::check(ptype == ContinuousChargePropagator or 
+  utils::check(ptype == ContinuousChargePropagator or
 	 ptype == ContinuousSpinPropagator or 
 	 ptype == DiscreteChargePropagator or 
 	 ptype == DiscreteSpinPropagator, "Invalid propagator type.");
@@ -645,9 +640,8 @@ void ModelHamOpsGenerator::addComponent( WALKER_TYPES wtype, PropagatorTypes pty
   nFields = 0;
   bool writer = mpi->node_comm.root(); 
 
-  int nspin = (wtype == COLLINEAR or wtype == COLLINEAR_FT ? 2 : 1 );
   int npol = (wtype == NONCOLLINEAR or wtype == NONCOLLINEAR_FT ? 2 : 1 );
-  long M2 = npol*M; 
+  long M2 = npol*M;
   long Madd = M2-M;
   // General formula for COLLINEAR and NONCOLLINEAR
   // IJ = i*M2+j            for up/up

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -72,7 +72,6 @@ RealDenseHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   // MAM: should this be zero with CLOSED shell???
   int nact_dn = ( type == FULLYPOLARIZED or type == NONCOLLINEAR ? 0l :
               (type == CLOSED ? nact_up : PsiT(0,nspin_in_PsiT-1).extent(0) ) );
-  bool head_shared = (MEM==HOST_MEMORY ? mpi->node_comm.root() : true );
 
   std::vector<long> Idata(8);
   ComplexType E0;

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
@@ -66,7 +66,6 @@ void AFQMCBasePropagator<MEM>::generateP1(double dt, WALKER_TYPES walker_type, b
   memory::buffered_array<MEM,ComplexType,1> vMF_discrete(vMF.extent(0)); 
   if(discrete_propg) {
     int npol         = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
-    int nspin        = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
     nda::array<ComplexType,1> nMF(2*NMO, ComplexType(0.0));
     // setup sparse vector to generate <nI>
     auto Gmf_shm = wfn->G_MF();

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -82,7 +82,7 @@ public:
     double external_field_scale;
     i_ = pt.get<int>("i");
     a_ = pt.get<int>("a");
-    order                = pt.get<double>("taylor_n");
+    order                = pt.get<int>("taylor_n");
     vbias_bound          = pt.get<double>("vbias_bound");
     external_field_scale = pt.get<double>("external_field_scale");
     upper_cutoff_scale = pt.get<double>("upper_cutoff_scale");

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -572,7 +572,6 @@ void AFQMCBasePropagator<MEM>::assemble_X(RealType sqrtdt,
      nda::MemoryArrayOfRank<1> auto&& HWs, int nt, bool addRAND)
 {
   using nda::range;
-  auto all = range::all;
   // On entry, X(iw,m) = vbias(iw,m);
   // remember to call vbi = apply_bound_vbias(*vb);
 

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -65,7 +65,6 @@ void propg_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> 
 {
   using sfqmc::utils::ARRAY_EQUAL;
   using nda::range;
-  auto all = range::all;
   utils::check(utils::file_exists(hamil_file),
                " Hamiltonian file not found: {}. \n Run unit test with --hamil /path/to/hamil.h5 ", hamil_file);
   utils::check(utils::file_exists(wfn_file),
@@ -192,7 +191,6 @@ void propg_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> 
       prop.Propagate(wset, Eshift, dt, i+1);
       wfn.Energy(wset, i+1);
       ComplexType eav = 0, ov = 0;
-      int n = 0;
       for (auto it = wset.begin(); it != wset.end(); ++it)
       {
         eav += it->get_property(WEIGHT) * (it->energy());

--- a/src/AFQMC/SlaterDeterminantOperations/density_matrix.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/density_matrix.hpp
@@ -124,7 +124,6 @@ requires( (CSRMatrix<A_t> or nda::MemoryMatrix<A_t>) and
         )
 void log_overlap_impl(A_t const& A, B_t const& B, O_t && ovlp, T_t && TNN, bool herm = true, bool invert = false)
 {
-  auto _ = nda::ellipsis{};
   constexpr MEMORY_SPACE MEM = memory::get_memory_space<A_t>();
   using Type = nda::get_value_t<B_t>;
 
@@ -168,7 +167,6 @@ void log_overlap_impl(A_t const& A, B_t const& B, O_t && ovlp, T_t && TNN, bool 
   constexpr MEMORY_SPACE MEM = memory::get_memory_space<A_t>();
   using Type = nda::get_value_t<B_t>;
 
-  auto _ = nda::ellipsis{};
   auto [nbatch, NMO, NEL] = B.shape();
   utils::check(A.shape() == B.shape(), "Size mismatch");
   utils::check(ovlp.size() >= nbatch, "");
@@ -490,7 +488,6 @@ requires( (CSRMatrix<A_t> or nda::MemoryMatrix<A_t>) and
 void Log_OverlapForWoodbury(A_t const& A, B_t const& B, O_t && ovlp, QQ0_t && QQ0, IVec && ref)
 {
   auto all = nda::range::all;
-  auto _ = nda::ellipsis{};
   utils::check_strides(B,ovlp,QQ0,ref);
   constexpr MEMORY_SPACE MEM = memory::get_memory_space<A_t>();
   using Type = nda::get_value_t<B_t>;
@@ -542,7 +539,6 @@ requires( (CSRMatrix<A_t> or nda::MemoryMatrix<A_t>) and
         )
 void MixedDensityMatrix(A_t const& A, B_t const& B, C_t && C, O_t && ovlp, bool compact = true, bool herm = true)
 {
-  auto _ = nda::ellipsis{};
   utils::check_strides(B,C,ovlp);
   constexpr MEMORY_SPACE MEM = memory::get_memory_space<A_t>();
   using Type = nda::get_value_t<B_t>;
@@ -612,7 +608,6 @@ void MixedDensityMatrix(A_t const& A, B_t const& B, C_t && C, O_t && ovlp, bool 
   constexpr MEMORY_SPACE MEM = memory::get_memory_space<A_t>();
   using Type = nda::get_value_t<B_t>;
 
-  auto _ = nda::ellipsis{};
   auto [nbatch, NMO, NEL] = A.shape();
   utils::check(A.shape() == B.shape(), "Size mismatch");
   utils::check(ovlp.size() >= nbatch, "");
@@ -661,7 +656,6 @@ void MixedDensityMatrixForWoodbury(A_t const& A, B_t const& B, C_t &&C, O_t && o
   constexpr MEMORY_SPACE MEM = memory::get_memory_space<A_t>();
   using Type = nda::get_value_t<B_t>;
 
-  auto _ = nda::ellipsis{};
   auto [nbatch, NMO, NEL] = B.shape();
   auto NACT = A.extent(0);
   utils::check(A.shape() == std::array<long,2>{NACT,NMO}, "Size mismatch");
@@ -731,7 +725,6 @@ void MixedDensityMatrixFromConfiguration(A_t const& A, B_t const& B, C_t &&C, O_
   constexpr MEMORY_SPACE MEM = memory::get_memory_space<A_t>();
   using Type = nda::get_value_t<B_t>;
 
-  auto _ = nda::ellipsis{};
   auto [nbatch, NMO, NEL] = B.shape();
   auto NACT = A.extent(0);
   utils::check(A.shape() == std::array<long,2>{NACT,NMO}, "Size mismatch");

--- a/src/AFQMC/SlaterDeterminantOperations/orthogonalize.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/orthogonalize.hpp
@@ -450,7 +450,6 @@ void orthogonalize(WlkSet &wset, Vec && ldet, bool importance_sampling = true)
   utils::check(MEM == wset.get_memory_space(), "Memory space mismatch");
   memory::check_memory_space<MEM>(ldet);
   auto walker_type = wset.getWalkerType();
-  const int nspin = ( (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1 );
   const int nwalk = wset.size();
   utils::check(ldet.size() >= nwalk, "Size mismatch");
   ldet() = ComplexType(0.0);

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -53,7 +53,6 @@ template<MEMORY_SPACE MEM>
 void SDetOps()
 {
 
-  auto& mpi = utils::make_unit_test_mpi_context();
   auto all = nda::range::all;
   using nda::range;
 
@@ -67,7 +66,6 @@ void SDetOps()
   using matrix       = memory::array<MEM,Type,2>;
   using matrix_view  = memory::array_view<MEM,Type,2>;
   using array       = memory::array<MEM,Type,3>;
-  using array_F     = memory::array<MEM,Type,3,nda::F_layout>;
   using array_view  = memory::array_view<MEM,Type,3>;
   using sfqmc::utils::ARRAY_EQUAL;
 
@@ -210,8 +208,6 @@ void SDetOps()
 
   {
     array G(nwalk, NMO, NMO);
-    auto G_ = G(all,range(3),range(3));
-    auto Gc_ = G(all,range(2),range(3));
     array Gc(nwalk, NEL, NMO);
     memory::array<MEM,Type,1> ovlp(nwalk,Type(0.0));
 

--- a/src/AFQMC/Utilities/readWfn.cpp
+++ b/src/AFQMC/Utilities/readWfn.cpp
@@ -106,7 +106,6 @@ void read_ph_wavefunction_hdf(h5::group& grp,
                               std::string& type)
 {
   int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
-  int nspin = (walker_type == COLLINEAR ? 2 : 1);
   utils::check(walker_type != UNDEFINED_WALKER_TYPE, "Undefined walker type.");
   utils::check(walker_type != CLOSED, " walker_type==CLOSED not yet implemented in read_ph_wavefunction_hdf.");
   bool mixed = false;
@@ -181,7 +180,6 @@ ph_excitations<int, ComplexType, MEM> build_ph_struct(nda::array<ComplexType,1> 
                                                  int ndown)
 {
   using nda::range;
-  auto all = range::all;
   ComplexType ci;
   // count number of k-particle excitations
   // counts[0] has special meaning, it must be equal to nup+ndown.
@@ -299,7 +297,7 @@ ph_excitations<int, ComplexType, MEM> build_ph_struct(nda::array<ComplexType,1> 
 }
 
 
-void checkCommonDims(std::vector<int> const& dims, int NMO, int nup, int ndown, int& ndets_to_read, WALKER_TYPES walker_type) {
+void checkCommonDims(std::vector<int> const& dims, int NMO, int nup, int ndown, int& ndets_to_read) {
   utils::check(NMO==dims[0], "Inconsistent NMO: given {} != {} in file", NMO, dims[0]);
   std::array nels = {nup, ndown};
   utils::check(nels == std::array{dims[1],dims[2]}, "Inconsistent (nup,ndown): given {} != {} in file", nels, std::array{dims[1], dims[2]});
@@ -325,7 +323,7 @@ void getCommonInput(h5::group& grp,
   // check for consistency in parameters
   std::vector<int> dims(5);
   h5::read(grp,"dims",dims);
-  checkCommonDims(dims, NMO, nup, ndown, ndets_to_read, walker_type);
+  checkCommonDims(dims, NMO, nup, ndown, ndets_to_read);
   app_log(1," - Number of determinants in trial wavefunction: {} ", ndets_to_read);
   ci.resize(ndets_to_read);
   nda::array<ComplexType,1> ci_t(dims[4]);

--- a/src/AFQMC/Utilities/readWfn.h
+++ b/src/AFQMC/Utilities/readWfn.h
@@ -53,7 +53,7 @@ ph_excitations<int, ComplexType, MEM> build_ph_struct(nda::array<ComplexType,1> 
                                                  int nup,
                                                  int ndown);
 
-void checkCommonDims(std::vector<int> const& dims, int NMO, int nup, int ndown, int& ndets_to_read, WALKER_TYPES walker_type);
+void checkCommonDims(std::vector<int> const& dims, int NMO, int nup, int ndown, int& ndets_to_read);
 
 void getCommonInput(h5::group& g,
                     int NMO,
@@ -80,7 +80,7 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
 
   std::vector<int> dims(5);
   h5::h5_read(grp,"dims",dims);
-  checkCommonDims(dims, NMO, nup, ndown, ndets, walker_type);
+  checkCommonDims(dims, NMO, nup, ndown, ndets);
 
   // keep in on host at first
   nda::array<csr, 2> psi(ndets,nspin);
@@ -143,8 +143,6 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
 {
   using csr = PsiT_Matrix<MEM>;
   long nspin = (walker_type == COLLINEAR_FT ? 2 : 1);
-  long npol = (walker_type == NONCOLLINEAR_FT ? 2 : 1);
-  long Mtot = npol*NMO;
 
   std::vector<int> dims(5);
   h5::read(grp,"dims",dims);

--- a/src/AFQMC/Utilities/wfn_utils.hpp
+++ b/src/AFQMC/Utilities/wfn_utils.hpp
@@ -49,8 +49,7 @@ auto nocc_per_kpoint(WALKER_TYPES type, int nkpts, nda::array<PsiT_Matrix<MEM>,2
   nocc_per_kp() = 0;
   // 1st det
   {
-    for(int is=0; is<nspin; is++) { 
-      auto vals = nda::to_host(PsiT(0,is%nspin_in_PsiT).values());
+    for(int is=0; is<nspin; is++) {
       auto cols = nda::to_host(PsiT(0,is%nspin_in_PsiT).columns());
       auto row_begin = nda::to_host(PsiT(0,is%nspin_in_PsiT).row_begin());
       auto row_end = nda::to_host(PsiT(0,is%nspin_in_PsiT).row_end());
@@ -70,7 +69,6 @@ auto nocc_per_kpoint(WALKER_TYPES type, int nkpts, nda::array<PsiT_Matrix<MEM>,2
     nda::array<int, 2> nocc(nspin,nkpts);
     nocc() = 0;
     for(int is=0; is<nspin; is++) {
-      auto vals = nda::to_host(PsiT(id,is%nspin_in_PsiT).values());
       auto cols = nda::to_host(PsiT(id,is%nspin_in_PsiT).columns());
       auto row_begin = nda::to_host(PsiT(id,is%nspin_in_PsiT).row_begin());
       auto row_end = nda::to_host(PsiT(id,is%nspin_in_PsiT).row_end());

--- a/src/AFQMC/Walkers/WalkerIO.hpp
+++ b/src/AFQMC/Walkers/WalkerIO.hpp
@@ -266,7 +266,6 @@ bool dumpToHDF5(WalkerSet& wset, h5::file& fh5)
 {
   auto all = nda::range::all;
   auto mpi = wset.get_mpi();
-  auto MEM = wset.get_memory_space();
 
   int nW = wset.size();
   auto nw_per_rank = mpi->comm.all_gather_value(nW);

--- a/src/AFQMC/Walkers/WalkerUtilities.hpp
+++ b/src/AFQMC/Walkers/WalkerUtilities.hpp
@@ -41,7 +41,6 @@ inline void BasicWalkerData(WlkBucket& wlk, DVec&& curData, mpi3::communicator& 
   wlk.getProperty(WEIGHT, w_data(range(0, nW), 0));
   wlk.getProperty(OVLP, w_data(range(0, nW), 1));
   wlk.getProperty(PSEUDO_ELOC_, w_data(range(0, nW), 2));
-  WALKER_TYPES wtype = wlk.getWalkerType();
   bool modified = false;
   for (int iw = 0; iw < nW; iw++)
   {

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -277,7 +277,6 @@ void test_basic_walker_features(std::string wtype)
   REQUIRE(wset.GlobalPopulation() == nwalkers * mpi->comm.size());
   REQUIRE(wset.GlobalPopulation() == wset.get_global_target_population());
   REQUIRE(wset.GlobalWeight() == Approx(static_cast<RealType>(wset.get_global_target_population())));
-  double nx = (wset.getWalkerType() == NONCOLLINEAR or wset.getWalkerType() == FULLYPOLARIZED ? 1.0 : 2.0);
   for (int i = 0; i < wset.size(); i++)
   {
     auto w = wset[i];
@@ -338,12 +337,12 @@ void test_basic_walker_features(std::string wtype)
 template<MEMORY_SPACE MEM>
 void test_walker_io(std::string wtype)
 {
-  using Type = std::complex<double>;
-  using nda::array;
-
-  auto& mpi = utils::make_unit_test_mpi_context();
 
 /*
+  using Type = std::complex<double>;
+  using nda::array;
+  auto& mpi = utils::make_unit_test_mpi_context();
+
   int NMO = 8, nup = 2, ndown = 2, nwalkers = 10;
   if (wtype == "noncollinear")
   {

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -74,8 +74,6 @@ template<MEMORY_SPACE MEM>
 void test_basic_walker_features(std::string wtype)
 {
   using Type = std::complex<double>;
-  using nda::array;
-  using nda::array_view;
 
   auto& mpi = utils::make_unit_test_mpi_context();
 
@@ -96,19 +94,21 @@ void test_basic_walker_features(std::string wtype)
   ptree wlk_pt;
   wlk_pt.put("name","wset0");
   wlk_pt.put("walker_type",wtype);
-  std::shared_ptr<utils::RandomGenerator_t<>> rng = std::make_shared<utils::RandomGenerator_t<>>();
+  auto rng = std::make_shared<utils::RandomGenerator_t<>>();
   auto wset = make_WalkerSet<MEM>(mpi, wlk_pt, info, rng);
   
   if(wtype != "collinear-ft" and wtype != "noncollinear-ft"){
     int M((wtype == "noncollinear") ? 2 * NMO : NMO);
     int nspin = (wtype == "collinear" ? 2 : 1); 
-    array<Type, 3> initA(nspin, M, nup);
-    initA() = Type(0.0);
+    nda::array<Type, 3> initA_h(nspin, M, nup);
+    initA_h() = Type(0.0);
     for (int i = 0; i < nup; i++)
-      initA(0,i,i) = Type(0.22);
+      initA_h(0,i,i) = Type(0.22);
     if(wtype == "collinear")
       for (int i = 0; i < ndown; i++)
-        initA(1,i,i) = Type(0.33);
+        initA_h(1,i,i) = Type(0.33);
+
+    auto initA = memory::to_memory_space<MEM>(initA_h);
 
     wset.resize(nwalkers, initA);
 
@@ -117,15 +117,11 @@ void test_basic_walker_features(std::string wtype)
     //Type tot_weight(0.0);
     for (auto it = wset.begin(); it != wset.end(); ++it)
     {
-      auto sm = it->SlaterMatrix(Alpha);
-      REQUIRE( sm.extent(0) == initA.extent(1) );	
-      REQUIRE( sm.extent(1) == nup );	
-      REQUIRE(nda::to_host(it->SlaterMatrix(Alpha)) == initA(0,nda::ellipsis{}));
-      if( wset.getWalkerType() == COLLINEAR ) { 
-        auto smB = it->SlaterMatrix(Beta);
-        REQUIRE( smB.extent(0) == initA.extent(1) );	
-        REQUIRE( smB.extent(1) == ndown );	
-        REQUIRE( nda::to_host(it->SlaterMatrix(Beta)) == initA(1,nda::range::all,nda::range(ndown)));
+      for(int spin = 0; spin < nspin; spin++) {
+        auto sm = it->SlaterMatrix(static_cast<SpinTypes>(spin));
+        REQUIRE( sm.extent(0) == initA.extent(1) );	
+        REQUIRE( sm.extent(1) == nup );	
+        REQUIRE(nda::to_host(sm) == initA_h(spin, nda::ellipsis{}));
       }
       it->set_property(WEIGHT,base * 1.0 + 0.5);
       it->set_property(OVLP,base * 1.0 + 0.5);
@@ -136,31 +132,34 @@ void test_basic_walker_features(std::string wtype)
       base += Type(1.0);
       cnt++;
     }
-  }
-  else{
+  } else {
     int M((wtype == "noncollinear-ft") ? 2 * NMO : NMO);
     int nspin = (wtype == "collinear-ft" ? 2 : 1); 
-    array<Type, 3> initU(nspin, M, M);
-    array<Type, 2> initD(nspin, M);
-    array<Type, 3> initV(nspin, M, M);
-    initU() = Type(0.0);
+    nda::array<Type, 3> initU_h(nspin, M, M);
+    nda::array<Type, 2> initD_h(nspin, M);
+    nda::array<Type, 3> initV_h(nspin, M, M);
+    initU_h() = Type(0.0);
     for (int i = 0; i < M; i++)
-      initU(0,i,i) = Type(0.22);
+      initU_h(0,i,i) = Type(0.22);
     if(wtype == "collinear-ft")
       for (int i = 0; i < M; i++)
-        initU(1,i,i) = Type(0.33);
-    initD() = Type(0.0);
+        initU_h(1,i,i) = Type(0.33);
+    initD_h() = Type(0.0);
     for (int i = 0; i < M; i++)
-      initD(0,i) = Type(0.44);
+      initD_h(0,i) = Type(0.44);
     if(wtype == "collinear-ft")
       for (int i = 0; i < M; i++)
-        initD(1,i) = Type(0.55);
-    initV() = Type(0.0);
+        initD_h(1,i) = Type(0.55);
+    initV_h() = Type(0.0);
     for (int i = 0; i < M; i++)
-      initV(0,i,i) = Type(0.66);
+      initV_h(0,i,i) = Type(0.66);
     if(wtype == "collinear-ft")
       for (int i = 0; i < M; i++)
-        initV(1,i,i) = Type(0.77);
+        initV_h(1,i,i) = Type(0.77);
+
+    auto initU = memory::to_memory_space<MEM>(initU_h);
+    auto initD = memory::to_memory_space<MEM>(initD_h);
+    auto initV = memory::to_memory_space<MEM>(initV_h);
 
     wset.resize(nwalkers, initU, initD, initV);
 
@@ -338,9 +337,8 @@ template<MEMORY_SPACE MEM>
 void test_walker_io(std::string wtype)
 {
 
-/*
+
   using Type = std::complex<double>;
-  using nda::array;
   auto& mpi = utils::make_unit_test_mpi_context();
 
   int NMO = 8, nup = 2, ndown = 2, nwalkers = 10;
@@ -355,17 +353,19 @@ void test_walker_io(std::string wtype)
   info.nup = nup;
   info.ndown = ndown;
   info.name = "walker";
-  int M((wtype == "noncollinear") ? 2 * NMO : NMO);
-  array<Type, 2> initA(M, nup);
-  array<Type, 2> initB(M, ndown);
-  initA() = Type(0.0);
-  initB() = Type(0.0);
-  for (int i = 0; i < nup; i++)
-    initA(i,i) = Type(0.22);
-  for (int i = 0; i < ndown; i++)
-    initB(i,i) = Type(0.33);
-  std::shared_ptr<utils::RandomGenerator_t> rng = std::make_shared<utils::RandomGenerator_t>();
+  int npol = (wtype == "noncollinear") ? 2 : 1;
+  int nspin = wtype == "collinear" ? 2 : 1;
+  nda::array<Type, 3> initA_h(nspin, npol * NMO, nup);
+  initA_h() = 0.0;
+  for(int spin = 0; spin < nspin; spin++) {
+    for (int i = 0; i < nup; i++) { 
+      initA_h(spin,i,i) = Type(0.11 * (spin + 2));
+    }
+  }
+  auto rng = std::make_shared<utils::RandomGenerator_t<>>();
 
+  auto initA = memory::to_memory_space<MEM>(initA_h);
+  
   ptree pt0;
   pt0.put("WalkerSet.name","wset0");
   pt0.put("WalkerSet.walker_type",wtype);
@@ -378,15 +378,11 @@ void test_walker_io(std::string wtype)
   Type tot_weight(0.0);
   for (auto it = wset.begin(); it != wset.end(); ++it)
   {
-    auto sm = it->SlaterMatrix(Alpha);
-    REQUIRE( sm.extent(0) == initA.extent(0) );
-    REQUIRE( sm.extent(1) == initA.extent(1) ); 
-    REQUIRE( nda::to_host(it->SlaterMatrix(Alpha)) == initA );
-    if( wset.getWalkerType() == COLLINEAR ) {
-      auto smB = it->SlaterMatrix(Beta);
-      REQUIRE( smB.extent(0) == initB.extent(0) );
-      REQUIRE( smB.extent(1) == initB.extent(1) ); 
-      REQUIRE( nda::to_host(it->SlaterMatrix(Beta)) == initB );
+    for(int spin = 0; spin < nspin; spin++) {
+      auto sm = it->SlaterMatrix(static_cast<SpinTypes>(spin));
+      REQUIRE(sm.extent(0) == initA.extent(1));
+      REQUIRE(sm.extent(1) == initA.extent(2)); 
+      REQUIRE(nda::to_host(sm) == nda::to_host(initA(spin,nda::ellipsis{})));
     }
     it->set_property(WEIGHT,base * 1.0 + 0.1);
     it->set_property(OVLP,base * 1.0 + 0.2);
@@ -423,7 +419,7 @@ void test_walker_io(std::string wtype)
   mpi->comm.barrier();
   if (mpi->comm.root())
     remove("dummy_walkers.h5");
-*/
+
 }
 
 // MAM: Tests are not GPU enabled, fix direct access to GPU memory

--- a/src/AFQMC/Wavefunctions/Excitations.hpp
+++ b/src/AFQMC/Wavefunctions/Excitations.hpp
@@ -70,7 +70,6 @@ template<class excitations>
 //std::map<int, int> find_active_space(bool single_list, WALKER_TYPES walker_type, excitations const& abij, int NMO, int nup, int ndown)
 std::vector<long> find_active_space(WALKER_TYPES walker_type, excitations const& abij, int NMO, int nup, int ndown)
 {
-  int npol = ( (walker_type == NONCOLLINEAR) ? 2 : 1 );
   if( walker_type == NONCOLLINEAR ) utils::check(ndown == 0, "ndown>0 with non-collinear");
 //  std::map<int, int> mo2active;
 //  for (int i = 0; i < 2 * NMO; i++)

--- a/src/AFQMC/Wavefunctions/NOMSD.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.hpp
@@ -127,7 +127,6 @@ public:
   {
     const int nw   = wset.size();
     const int nel = (walker_type==COLLINEAR ? nup+ndown : nup );
-    const int nspin = (walker_type==COLLINEAR ? 2 : 1 );
     const int npol = (walker_type==NONCOLLINEAR ? 2 : 1 );
     memory::array<MEM,ComplexType,2> G(nw,nel*npol*NMO);
     // don't use buffered_array!!!
@@ -321,7 +320,6 @@ public:
     memory::check_memory_space<MEM>(Refs);
     int nel = nup + (walker_type == COLLINEAR ? ndown : 0);
     int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
-    int nspin = (walker_type == COLLINEAR ? 2 : 1);
     if(number_of_references==0) return;
     if(number_of_references < 0) number_of_references = OrbMats.extent(0);
     utils::check(number_of_references > 0 and 

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -37,7 +37,6 @@ void NOMSD<MEM,devPsiT>::Energy(const WlkSet& wset, TMat&& E, TVec&& Ov, int nt)
   const int ndet = ci.size();
   const int nw   = wset.size();
   const int nel = (walker_type==COLLINEAR ? nup+ndown : nup ); 
-  const int nspin = (walker_type==COLLINEAR ? 2 : 1 ); 
   const int npol = (walker_type==NONCOLLINEAR ? 2 : 1 ); 
   utils::check(Ov.size() == nw, "Size mismatch");
   utils::check(E.shape() == std::array<long,2>{nw,3}, "Size mismatch");
@@ -463,7 +462,6 @@ auto NOMSD<MEM,devPsiT>::G_MF()
   auto gMF = memory::make_shared_array<HOST_MEMORY,ComplexType,3>(mpi,
                       {nspin,npol*NMO,npol*NMO});
 
-  bool found = false;
   if (ndet == 1)
   {
     if(mpi->comm.root()) {
@@ -571,7 +569,6 @@ void NOMSD<MEM,devPsiT>::vMF(nda::MemoryVector auto&& v, double dt)
   int npol  = (walker_type==NONCOLLINEAR ? 2 : 1);
   int ndet  = ci.size();
 
-  bool found = false;
   if (ndet == 1)
   {
     memory::buffered_array<MEM,ComplexType,1> Ov(1); 

--- a/src/AFQMC/Wavefunctions/NOMSD_FT.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD_FT.hpp
@@ -131,9 +131,8 @@ public:
   void runtime_optimization(WlkSet& wset)
   {
     const int nw   = wset.size();
-    const int nel = (walker_type==COLLINEAR ? nup+ndown : nup );
-    const int nspin = (walker_type==COLLINEAR ? 2 : 1 );
-    const int npol = (walker_type==NONCOLLINEAR ? 2 : 1 );
+    const int nel = (walker_type==COLLINEAR_FT ? nup+ndown : nup );
+    const int npol = (walker_type==NONCOLLINEAR_FT ? 2 : 1 );
     memory::array<MEM,ComplexType,2> G(nw,nel*npol*NMO);
     // don't use buffered_array!!!
     HamOp.runtime_optimization(G);

--- a/src/AFQMC/Wavefunctions/NOMSD_FT.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD_FT.icc
@@ -253,12 +253,9 @@ template<MEMORY_SPACE MEM, class devPsiT>
 template<class WlkSet, nda::MemoryArrayOfRank<1> TVec>
 void NOMSD_FT<MEM,devPsiT>::Log_Overlap(const WlkSet& wset, TVec&& Ov, int nt)
 {
-  auto all = nda::range::all;
   memory::check_memory_space<MEM>(Ov);
   const int ndet = ci.size();
   const int nw   = wset.size();
-  const int nspin = walker_type == COLLINEAR_FT ? 2 : 1;
-  const int npol = walker_type == NONCOLLINEAR_FT ? 2 : 1;
   utils::check(Ov.size() == nw, "Size mismatch");
   // Log_Overlap accumulates!!!
   Ov() = ComplexType(0.0);
@@ -369,7 +366,6 @@ void NOMSD_FT<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Me
   const int ndet   = ci.size();
   const int nw     = wset.size();
   const int neltot = (walker_type==COLLINEAR ? nup+ndown : nup );
-  const int nel[]  = {nup,ndown};
   const int nspin  = (walker_type==COLLINEAR ? 2 : 1 );
   const int npol   = (walker_type==NONCOLLINEAR ? 2 : 1 );
 
@@ -829,7 +825,6 @@ auto NOMSD_FT<MEM,devPsiT>::G_MF()
   using nda::range;
   auto all = range::all;
 
-  int nel   = (walker_type==COLLINEAR_FT ? nup+ndown : nup);
   int nspin = (walker_type==COLLINEAR_FT ? 2 : 1);
   int npol  = (walker_type==NONCOLLINEAR_FT ? 2 : 1);
   int ndet  = ci.size();
@@ -837,7 +832,6 @@ auto NOMSD_FT<MEM,devPsiT>::G_MF()
   auto gMF = memory::make_shared_array<HOST_MEMORY,ComplexType,3>(mpi,
                       {nspin,npol*NMO,npol*NMO});
 
-  bool found = false;
   if (ndet == 1)
   {
     if(mpi->comm.root()) {
@@ -970,7 +964,6 @@ void NOMSD_FT<MEM,devPsiT>::vMF(nda::MemoryVector auto&& v, double dt)
   int npol  = (walker_type==NONCOLLINEAR_FT ? 2 : 1);
   int ndet  = ci.size();
 
-  bool found = false;
   if (ndet == 1)
   {
     memory::buffered_array<MEM,ComplexType,1> Ov(1); 

--- a/src/AFQMC/Wavefunctions/PHMSD.hpp
+++ b/src/AFQMC/Wavefunctions/PHMSD.hpp
@@ -172,7 +172,6 @@ public:
   {
     const int nw   = wset.size();
     const int nel = (walker_type==COLLINEAR ? nup+ndown : nup );
-    const int nspin = (walker_type==COLLINEAR ? 2 : 1 );
     const int npol = (walker_type==NONCOLLINEAR ? 2 : 1 );
     memory::array<MEM,ComplexType,2> G(nw,nel*npol*NMO);
     // don't use buffered_array!!!
@@ -237,7 +236,6 @@ public:
     memory::check_memory_space<MEM>(v);
     AFQMCTimer.start(G_for_vbias_timer);
     int nact  = OrbMats(0).extent(0) + (walker_type==COLLINEAR ? OrbMats(OrbMats.extent(0)-1).extent(0) : 0);
-    int nspin = (walker_type==COLLINEAR ? 2 : 1);
     int npol  = (walker_type==NONCOLLINEAR ? 2 : 1);
     int nw = wset.size();
     utils::check(v.shape() == std::array<long,2>{nw,HamOp.number_of_cholesky_vectors()},
@@ -381,7 +379,6 @@ public:
     memory::check_memory_space<MEM>(Refs);
     int nel = nup + (walker_type == COLLINEAR ? ndown : 0);
     int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
-    int nspin = (walker_type == COLLINEAR ? 2 : 1);
     if(number_of_references==0) return;
     if(number_of_references < 0) number_of_references = total_number_of_references(); 
     utils::check(number_of_references > 0 and

--- a/src/AFQMC/Wavefunctions/PHMSD.icc
+++ b/src/AFQMC/Wavefunctions/PHMSD.icc
@@ -37,7 +37,6 @@ void PHMSD<MEM>::energy_alg0(const WlkSet& wset, Mat&& E, TVec&& Ov)
 {
   using nda::range;
   auto all = range::all;
-  int npol   = (walker_type==NONCOLLINEAR?2:1);
   int nspin = (walker_type==COLLINEAR?2:1);
   long nkev = HamOp.number_of_ke_vectors();
   int nwalk = wset.size();
@@ -295,8 +294,6 @@ void PHMSD<MEM>::energy_alg1(const WlkSet& wset, Mat&& E, TVec&& Ov)
   using nda::range;
   auto all = range::all;
   ComplexType one(1.0),zero(0.0);
-  int npol   = (walker_type==NONCOLLINEAR?2:1);
-  int nspin = (walker_type==COLLINEAR?2:1);
   long nkev = HamOp.number_of_ke_vectors();
   int nwalk = wset.size();
   utils::check(E.extent(0) == nwalk and E.extent(1) == 3, "Size mismatch");
@@ -311,8 +308,6 @@ void PHMSD<MEM>::energy_alg1(const WlkSet& wset, Mat&& E, TVec&& Ov)
   int nspin_in_orbmat = OrbMats.extent(0);
   int nactA = OrbMats(0).extent(0);
   int nactB = (walker_type==COLLINEAR ? OrbMats(nspin_in_orbmat-1).extent(0) : 0);
-  int nact = nactA+nactB;
-  long nel[2] = {nup,(walker_type==COLLINEAR?ndown:0)};
   memory::buffered_array<MEM,ComplexType,1> log_ov(nwalk,zero); 
 
   if (walker_type != COLLINEAR)
@@ -471,7 +466,6 @@ void PHMSD<MEM>::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, boo
   using nda::range;
   auto all = nda::range::all;
   memory::check_memory_space<MEM>(G,Ov);
-  const int nel   = (walker_type==COLLINEAR ? nup+ndown : nup );
   const int nspin = (walker_type==COLLINEAR?2:1);
   const int npol  = (walker_type==NONCOLLINEAR?2:1);
   const int nwalk = wset.size();
@@ -740,8 +734,8 @@ void PHMSD<MEM>::Log_Overlap(const WlkSet& wset, TVec&& Ov, int nt)
   Ov() = ComplexType(0.0);
   if (walker_type == NONCOLLINEAR)
   {
-    long nexcit = long(abij.number_of_unique_excitations()[0]);
 /*
+    long nexcit = long(abij.number_of_unique_excitations()[0]);
     StaticVector ov0(iextensions<1u>{nbatch__}, ComplexType(0.0),
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     StaticMatrix ovlp_list({nexcit, nbatch__}, ComplexType(0.0),
@@ -782,9 +776,10 @@ void PHMSD<MEM>::Log_Overlap(const WlkSet& wset, TVec&& Ov, int nt)
   }
   else
   {
-    long nexcit[2] = {long(abij.number_of_unique_excitations()[0]),
-                      long(abij.number_of_unique_excitations()[1])};
-    long maxn_unique_confg(std::max(nexcit[0],nexcit[1]));
+    auto nexcit = std::to_array<long>({
+      abij.number_of_unique_excitations()[0],
+      abij.number_of_unique_excitations()[1]
+    });
     int nwbatch = nwalk; // tune later
 
     auto SMup=wset.SlaterMatrices(Alpha);
@@ -1281,7 +1276,6 @@ void PHMSD<MEM>::vMF(nda::MemoryVector  auto&& v, double dt)
   mpi->comm.barrier();
 
   int nspin_in_orbmat = OrbMats.extent(0);
-  int nel   = (walker_type==COLLINEAR ? nup+ndown : nup);
   int nspin = (walker_type==COLLINEAR ? 2 : 1);
   int npol  = (walker_type==NONCOLLINEAR ? 2 : 1);
   int nelec[2] = { nup, (walker_type==COLLINEAR ? ndown : 0) };

--- a/src/AFQMC/Wavefunctions/phmsd_helpers.hpp
+++ b/src/AFQMC/Wavefunctions/phmsd_helpers.hpp
@@ -302,7 +302,6 @@ void ph_excited_energies_first_step(ph_excitations<int, ComplexType, memory::get
   memory::check_memory_space<MEM>(wgt,T,E,KE);
   auto [nwalk,nact,nelec] = T.shape();
   int nconfg = KE.extent(0);
-  int nke = KE.extent(2);
   utils::check(E.extent(0) == nwalk and E.extent(1)==3, "Size mismatch");
   utils::check(wgt.extent(0) == nconfg and wgt.extent(1)==nwalk, "Size mismatch");
   utils::check(KE.extent(1) == nwalk, "Size mismatch");

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -57,7 +57,6 @@ void test_read_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communica
 {
   using sfqmc::utils::ARRAY_EQUAL;
   using nda::range;
-  auto all = range::all;
   utils::check(utils::file_exists(hamil_file),
                " Hamiltonian file not found: {}. \n Run unit test with --hamil /path/to/hamil.h5 ", hamil_file);
   utils::check(utils::file_exists(wfn_file),
@@ -72,9 +71,6 @@ void test_read_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communica
   utils::check(NMO == file_data.NMO, "Incompatible NMO.");
 
   WALKER_TYPES type    = afqmc::getWalkerType(wfn_file, "PHMSD");
-  int nspin            = (type == COLLINEAR) ? 2 : 1;
-  int npol             = (type == NONCOLLINEAR) ? 2 : 1;
-  int nel              = (type == COLLINEAR) ? nup+ndown : nup;
 
   h5::file file(wfn_file,'r');
   h5::group grp(file);
@@ -166,8 +162,7 @@ void test_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   WALKER_TYPES type = afqmc::getWalkerType(wfn_file, "PHMSD");
   int nspin         = (type == COLLINEAR) ? 2 : 1;
   int npol          = (type == NONCOLLINEAR) ? 2 : 1;
-  int nel           = (type == COLLINEAR) ? nup+ndown : nup;
-  int nwalk         = 1; 
+  int nwalk         = 1;
   int ndets         = ( MEM == HOST_MEMORY ? 100 : 1000 ); 
   double dt         = 0.01;
   std::shared_ptr<utils::RandomGenerator_t<>> rng = std::make_shared<utils::RandomGenerator_t<>>();

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -245,7 +245,7 @@ void test_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
     h5::group wg = g_.create_group("Wavefunction");
     h5::group ng = wg.create_group("NOMSD");
  
-    nda::vector<int> dims = {NMO,nup,ndown,int(type),coeffs.size()};
+    nda::vector<int> dims = {NMO,nup,ndown,int(type),int(coeffs.size())};
     nda::h5_write(ng,"dims",dims);
     nda::h5_write(ng,"ci_coeffs",coeffs);
 

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -250,7 +250,6 @@ void wfn_fac(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mp
   //std::cout<<"X = "<<X()<<std::endl;
   {
     auto X_h = nda::to_host(X);
-    ComplexType Xsum = 0;
     if (!write_reference) {
       if(reference_data.available) {
         ARRAY_EQUAL(X_h, reference_data.vbias);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,7 +101,7 @@ int main_impl(int argc, char** argv)
   {
     if(root) {
       std::cout << welcome;
-      print_version(3);  // print everything
+      print_version();  // print everything
     }
     return 0;
   }
@@ -126,7 +126,7 @@ int main_impl(int argc, char** argv)
   app_log(1, welcome);      
 
   if(root)
-    print_version(output_level);
+    print_version();
 
   // !!!! assume a single input for now
   std::string myinput = inputs[0];

--- a/src/numerics/device_kernels/cuda/add_diagonal.cuh
+++ b/src/numerics/device_kernels/cuda/add_diagonal.cuh
@@ -17,7 +17,6 @@ namespace detail
 template<typename V, nda::MemoryArrayOfRank<3> A>
 requires(std::decay_t<A>::is_stride_order_C())
 void add_diagonal(V alpha, A&& a) {
-  using T = nda::get_value_t<V>;
   sfqmc::utils::check(a.extent(1) == a.extent(2), "add_diagonal requires square matrices");
 
   auto a_b = to_basic_layout(a());

--- a/src/numerics/device_kernels/cuda/determinants.cuh
+++ b/src/numerics/device_kernels/cuda/determinants.cuh
@@ -21,7 +21,6 @@ template<nda::MemoryArrayOfRank<3> A, nda::MemoryMatrix IPIV, nda::MemoryVector 
 requires(std::decay_t<A>::is_stride_order_C() and std::decay_t<IPIV>::is_stride_order_C() and
          nda::mem::have_compatible_addr_space<A,IPIV,V>)
 void log_determinant_from_getrf(A const& a, IPIV const& ipiv, V && log_det) {
-  using T = nda::get_value_t<V>;
   static_assert(nda::is_complex_v<nda::get_value_t<V>>,
                 "log_determinant_from_getrf expects complex numbers.");
   sfqmc::utils::check(a.extent(0) == ipiv.extent(0), "Size mismatch");
@@ -40,7 +39,6 @@ template<nda::MemoryArrayOfRank<3> A, nda::MemoryMatrix S, nda::MemoryVector V>
 requires(std::decay_t<A>::is_stride_order_C() and std::decay_t<S>::is_stride_order_C() and
          nda::mem::have_compatible_addr_space<A,S,V>)
 void log_determinant_from_geqrf(A const& a, S && scl, V && log_det) {
-  using T = nda::get_value_t<V>;
   static_assert(nda::is_complex_v<nda::get_value_t<V>>,
                 "log_determinant_from_getrf expects complex numbers.");
   sfqmc::utils::check(a.extent(0) == log_det.extent(0), "Size mismatch");

--- a/src/numerics/device_kernels/cuda/phmsd_routines.cuh
+++ b/src/numerics/device_kernels/cuda/phmsd_routines.cuh
@@ -104,7 +104,6 @@ template<nda::MemoryArrayOfRank<3> T_t, nda::MemoryArrayOfRank<4> R_t>
 void calculate_compact_ph_R(int const* refc, int const* iexcit, T_t const& T, R_t &R)
 {
   using nda::range;
-  auto all = range::all;
   // T(nw,nact,nel)
   // R(nw,ndet,nex,nact)
   auto [nwalk,ndet,nex,nact] = R.shape(); 

--- a/src/numerics/device_kernels/cuda/split_singular_vals.cuh
+++ b/src/numerics/device_kernels/cuda/split_singular_vals.cuh
@@ -22,7 +22,6 @@ template<nda::MemoryMatrix A_t, nda::MemoryMatrix B_t, nda::MemoryMatrix C_t, nd
 requires(std::decay_t<A_t>::is_stride_order_C() and std::decay_t<B_t>::is_stride_order_C() and
          std::decay_t<C_t>::is_stride_order_C() and nda::mem::have_compatible_addr_space<A_t,B_t,C_t,V_t,S_t>)
 void splitDmatrix(A_t const& A, B_t && B, C_t && C, V_t && log_det, S_t const& scl) {
-  using T = nda::get_value_t<V_t>;
   //static_assert(nda::is_complex_v<nda::get_value_t<V>>,
   //              "log_determinant_from_getrf expects complex numbers.");
   sfqmc::utils::check(A.shape() == B.shape(), "Size mismatch");

--- a/src/numerics/nda_functions.hpp
+++ b/src/numerics/nda_functions.hpp
@@ -411,8 +411,6 @@ void reduce([[maybe_unused]] get_value_t<A> alpha, A const& a, std::string_view 
   if constexpr (mem::have_device_compatible_addr_space<A, B>) {
 #if defined(ENABLE_DEVICE)
 #if defined(NDA_HAVE_CUTENSOR)
-      using value_t = get_value_t<A>;
-      constexpr int rank = get_rank<A>;
       cutensor::cutensor_desc<get_value_t<A>, get_rank<A>> a_t(a);
       cutensor::cutensor_desc<get_value_t<B>, get_rank<B>> b_t(b);
       cutensor::reduce(alpha, a_t, op::ID, a.data(), indxA, beta, b_t, op::ID, b.data(), indxB, b.data(), oper);

--- a/src/numerics/operations/determinants.hpp
+++ b/src/numerics/operations/determinants.hpp
@@ -30,7 +30,6 @@ template<nda::MemoryArrayOfRank<3> A, nda::MemoryMatrix IPIV, nda::MemoryVector 
 requires(std::decay_t<A>::is_stride_order_C() and std::decay_t<IPIV>::is_stride_order_C() and
          nda::mem::have_compatible_addr_space<A,IPIV,V>)
 void log_determinant_from_getrf(A const& a, IPIV const& ipiv, V && log_det) {
-  using T = nda::get_value_t<V>;
   static_assert(nda::is_complex_v<nda::get_value_t<V>>, 
                 "log_determinant_from_getrf expects complex numbers.");
   sfqmc::utils::check(a.extent(0) == ipiv.extent(0), "Size mismatch");

--- a/src/numerics/operations/exp.hpp
+++ b/src/numerics/operations/exp.hpp
@@ -30,8 +30,7 @@ template<nda::MemoryMatrix A_t>
 auto exp_hermitian(A_t const& A, bool printeV = false)
 {
   using Array_t = typename std::decay_t<A_t>::regular_type;
-  using Type     = nda::get_value_t<A_t>; 
-  using RealType = nda::remove_complex_t<Type>;
+  using Type     = nda::get_value_t<A_t>;
   sfqmc::utils::check(A.extent(0) == A.extent(1), "Shape mismatch");
   long N = A.extent(0);
 

--- a/src/numerics/sparse/csr_utils.hpp
+++ b/src/numerics/sparse/csr_utils.hpp
@@ -330,7 +330,6 @@ auto HDF2CSR(h5::group grp)
   sfqmc::utils::check(data.size() == nnz, "Size mismatch");
   nda::h5_read(grp,"jdata_",jdata);
   sfqmc::utils::check(jdata.size() == nnz, "Size mismatch");
-  long cnt = 0;
   for (long r = 0; r < nrows; r++)
   {
     for(long i=ptrb[r]; i<ptre[r]; ++i) 

--- a/src/utilities/app_version.cpp
+++ b/src/utilities/app_version.cpp
@@ -21,7 +21,7 @@
 #include "app_version.h"
 #include "git-rev.h"
 
-void print_version(int verbosity) {
+void print_version() {
   constexpr const char* mkl_feature =
   #ifdef HAVE_MKL
       " MKL";

--- a/src/utilities/app_version.h
+++ b/src/utilities/app_version.h
@@ -17,6 +17,6 @@
 #ifndef UTILITIES_APP_VERSION_HPP
 #define UTILITIES_APP_VERSION_HPP
 
-void print_version(int verbosity);
+void print_version();
 
 #endif

--- a/src/utilities/h5_utils.hpp
+++ b/src/utilities/h5_utils.hpp
@@ -123,7 +123,6 @@ auto h5_read(h5::group& g, std::string name, nda::MemoryArray auto && A)
   using T = nda::get_value_t<A_t>;
   if constexpr (nda::mem::on_host<A_t>) {
     if constexpr (nda::is_complex_v<T>) {
-      using T_real = nda::remove_complex_t<T>; 
       auto l = h5::array_interface::get_dataset_info(g,name);
       // backwards-compatibility with older format
       if (!l.has_complex_attribute && nda::get_rank<A_t>+1 == l.rank())


### PR DESCRIPTION
This PR contains a lot of small changes that fixes warnings.

It also enables the previously commendet sharedwset test.

- c++/tests: missing cast in test_phmsd
- cmake: hide subproject config variables from rest of build
- c++/version: remove unused verbosity param
- reenable and fixed warnings
- c++/tests: uncomment and fix sharedwset test
