### PR TITLE
test_estimators, test_phmsd, test_phmsd_components bugfixes

### DIFF
--- a/src/AFQMC/Estimators/Observables/full1rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full1rdm.hpp
@@ -48,7 +48,6 @@ public:
       : AFQMCInfo(info),
         mpi(_mpi),
         walker_type(wlk),
-        nave(nave_),
         apply_rotation(false),
         XRot(memory::make_shared_array<HOST_MEMORY,ComplexType,3>(mpi,{1,1,1})),
         print_from_list(false),
@@ -133,7 +132,7 @@ public:
     }
 
     ncalls = 0;
-    DMAverage.resize(nave, dm_size);
+    DMAverage.resize(nave_, dm_size);
     DMAverage() = ComplexType(0.0, 0.0);
   }
 
@@ -211,27 +210,21 @@ public:
      utils::check(false," Finish: accumulate_excited_configuration_second "); 
   }
 
-  void print(int iblock, h5::group *g, nda::MemoryVector auto && Wsum)
+  void print(int iblock, h5::group *group, nda::MemoryVector auto && Wsum)
   {
     memory::check_memory_space<HOST_MEMORY>(Wsum);
-    const int n_zero = 9;
-
     DMAverage() *= ComplexType(1.0 / double(ncalls));
     mpi->all_reduce(DMAverage, std::plus<>{});
     if (mpi->comm.root())
     {
-      h5::group grp = ( g->has_key("FullOneRDM") ? 
-                        g->open_group("FullOneRDM")  : 
-                        g->create_group("FullOneRDM") );
-      for (int i = 0; i < nave; ++i)
+      assert(group);
+      h5::group parent = group->create_group("FullOneRDM");
+      for (int i = 0; i < DMAverage.shape(0); ++i)
       {
-        std::string dname = std::string("Average_") + std::to_string(i);
-        h5::group agrp = ( grp.has_key(dname) ? grp.open_group(dname) : grp.create_group(dname)); 
-        std::string padded_iblock =
-            std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-        auto DMAverage_i = DMAverage(i, nda::range::all);
-        nda::h5_write(agrp,"one_rdm_" + padded_iblock,DMAverage_i);
-        h5::h5_write(agrp,"denominator_" + padded_iblock,Wsum(i));
+        h5::group obs_group = parent.create_group(std::format("Average_{}", i));
+        std::string padded_iblock = std::format("{:09}", iblock);
+        h5::write(obs_group, "one_rdm_" + padded_iblock, nda::to_host(nda::flatten(DMAverage(i, nda::ellipsis{}))));
+        h5::write(obs_group, "denominator_" + padded_iblock, Wsum[i]);
       }
     }
     ncalls=0;
@@ -244,8 +237,6 @@ private:
   WALKER_TYPES walker_type;
 
   int ncalls = 0;
-
-  int nave = 1;
 
   int dm_size;
 

--- a/src/AFQMC/Estimators/Observables/full1rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full1rdm.hpp
@@ -44,7 +44,7 @@ public:
     utils::check(false, "Error in Observables::full1rdm: Reached disabled default constructor.");
   }
 
-  full1rdm(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> _mpi, AFQMCInfo& info, ptree pt, WALKER_TYPES wlk, int nave_ = 1)
+  full1rdm(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> _mpi, AFQMCInfo& info, ptree pt, WALKER_TYPES wlk, int nave = 1)
       : AFQMCInfo(info),
         mpi(_mpi),
         walker_type(wlk),
@@ -132,7 +132,7 @@ public:
     }
 
     ncalls = 0;
-    DMAverage.resize(nave_, dm_size);
+    DMAverage.resize(nave, dm_size);
     DMAverage() = ComplexType(0.0, 0.0);
   }
 

--- a/src/AFQMC/Estimators/tests/CMakeLists.txt
+++ b/src/AFQMC/Estimators/tests/CMakeLists.txt
@@ -2,33 +2,15 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_UNIT_TEST_DIR})
 
 set(TEST_ID afqmc_estimators)
-set( TEST_SRCS 
-	test_estimators.cpp
-        )
-
-add_executable( test_${TEST_ID} ${TEST_SRCS} )
+add_executable( test_${TEST_ID} test_estimators.cpp)
 target_link_libraries(test_${TEST_ID} PRIVATE catch_main)
-#list(LENGTH AFQMC_UNIT_TEST_INPUTS NUM_PAIRS)
-#math(EXPR ENDP "${NUM_PAIRS}-1")
-#foreach(I RANGE 0 ${ENDP} 2)
-#    list(GET AFQMC_UNIT_TEST_INPUTS ${I} HAMIL_FILE)
-#    math(EXPR J "${I}+1")
-#    list(GET AFQMC_UNIT_TEST_INPUTS ${J} WFN_FILE)
-#    get_filename_component(HAMIL ${HAMIL_FILE} NAME_WE)
-#    get_filename_component(WFN ${WFN_FILE} NAME_WE)
-#    # back propagate not yet working with model hamiltonian 
-#    #if(NOT (${HAMIL} MATCHES "hubb4x4U1") )
-#      set(UTEST_NAME unit_test_${TEST_ID}_${HAMIL}_${WFN})
-#      add_unit_test(${UTEST_NAME} "${PROJECT_UNIT_TEST_DIR}/test_${TEST_ID}"
-#                    "--hamil ${HAMIL_FILE}" "--wfn ${WFN_FILE}")
-#      set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${PROJECT_UNIT_TEST_DIR})
-#      set_property(TEST ${UTEST_NAME} APPEND PROPERTY LABELS "afqmc")
-#    #endif()
-#endforeach()
+set(UTEST_NAME unit_test_${TEST_ID})
+add_unit_test(${UTEST_NAME} "${PROJECT_UNIT_TEST_DIR}/test_${TEST_ID}")
+set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${PROJECT_UNIT_TEST_DIR})
+set_property(TEST ${UTEST_NAME} APPEND PROPERTY LABELS "afqmc")
 
 set(TEST_ID afqmc_observables_reference)
-set(TEST_SRCS test_observables_reference.cpp)
-add_executable( test_${TEST_ID} ${TEST_SRCS} )
+add_executable(test_${TEST_ID} test_observables_reference.cpp)
 target_link_libraries(test_${TEST_ID} PRIVATE catch_main)
 set(UTEST_NAME unit_test_${TEST_ID})
 add_unit_test(${UTEST_NAME} "${PROJECT_UNIT_TEST_DIR}/test_${TEST_ID}")
@@ -36,26 +18,9 @@ set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${PROJECT_UNIT_T
 set_property(TEST ${UTEST_NAME} APPEND PROPERTY LABELS "afqmc")
 
 set(TEST_ID afqmc_estimator_handler)
-set( TEST_SRCS 
-  test_estimator_handler.cpp
-        )
-
-add_executable( test_${TEST_ID} ${TEST_SRCS} )
+add_executable( test_${TEST_ID} test_estimator_handler.cpp)
 target_link_libraries(test_${TEST_ID} PRIVATE catch_main)
-#list(LENGTH AFQMC_UNIT_TEST_INPUTS NUM_PAIRS)
-#math(EXPR ENDP "${NUM_PAIRS}-1")
-#foreach(I RANGE 0 ${ENDP} 2)
-#    list(GET AFQMC_UNIT_TEST_INPUTS ${I} HAMIL_FILE)
-#    math(EXPR J "${I}+1")
-#    list(GET AFQMC_UNIT_TEST_INPUTS ${J} WFN_FILE)
-#    get_filename_component(HAMIL ${HAMIL_FILE} NAME_WE)
-#    get_filename_component(WFN ${WFN_FILE} NAME_WE)
-#    # chosen arbitrarily - the EstimatorHandler's behavior is independent of the hamiltonian
-#    if(${HAMIL} MATCHES "hubb4x4U1")
-#      set(UTEST_NAME unit_test_${TEST_ID}_${HAMIL}_${WFN})
-#      add_unit_test(${UTEST_NAME} "${PROJECT_UNIT_TEST_DIR}/test_${TEST_ID}"
-#                    "--hamil ${HAMIL_FILE}" "--wfn ${WFN_FILE}")
-#      set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${PROJECT_UNIT_TEST_DIR})
-#      set_property(TEST ${UTEST_NAME} APPEND PROPERTY LABELS "afqmc")
-#    endif()
-#endforeach()
+set(UTEST_NAME unit_test_${TEST_ID})
+add_unit_test(${UTEST_NAME} "${PROJECT_UNIT_TEST_DIR}/test_${TEST_ID}")
+set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${PROJECT_UNIT_TEST_DIR})
+set_property(TEST ${UTEST_NAME} APPEND PROPERTY LABELS "afqmc")

--- a/src/AFQMC/Estimators/tests/test_estimator_handler.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimator_handler.cpp
@@ -39,11 +39,6 @@
 #include "AFQMC/Utilities/AFQMCTimer.h"
 #include "AFQMC/Utilities/readWfn.cpp"
 
-using std::complex;
-using std::cout;
-using std::endl;
-using std::ifstream;
-using std::string;
 
 extern std::string UTEST_HAMIL, UTEST_WFN;
 
@@ -63,7 +58,7 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
                " Wavefunction file not found: {}. \n Run unit test with --wfn /path/to/wfn.h5 ", wfn_file);
 
   int population_control_interval = 10;
-  auto[NMO,nup, ndown] = read_info_from_wfn(UTEST_WFN, "any");
+  auto[NMO,nup, ndown] = read_info_from_wfn(wfn_file, "any");
   utils::check(NMO == read_nmo_from_hdf(hamil_file), "NMO differ between hamil and wfn files.");
 
   std::shared_ptr<utils::RandomGenerator_t<>> rng = std::make_shared<utils::RandomGenerator_t<>>();
@@ -126,28 +121,24 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
   test_case.put("name", "case1");
   test_case.put("meas1", 5);
   test_case.put("meas2", 20);
-  test_case.put("gcd", 5*population_control_interval);
   cases.push_back(test_case);
   test_case.clear();
 
   test_case.put("name", "case2");
   test_case.put("meas1", 20);
   test_case.put("meas2", 10);
-  test_case.put("gcd", 10*population_control_interval);
   cases.push_back(test_case);
   test_case.clear();
   
   test_case.put("name", "case3");
   test_case.put("meas1", 5);
   test_case.put("meas2", 7);
-  test_case.put("gcd", 1*population_control_interval);
   cases.push_back(test_case);
   test_case.clear();
     
   test_case.put("name", "case4");
   test_case.put("meas1", 11);
   test_case.put("meas2", 7);
-  test_case.put("gcd", 1*population_control_interval);
   cases.push_back(test_case);
   test_case.clear();
   
@@ -155,7 +146,6 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
   test_case.put("name", "case5");
   test_case.put("meas1", 1);
   test_case.put("meas2", 7);
-  test_case.put("gcd", 1*population_control_interval);
   cases.push_back(test_case);
   test_case.clear();
 
@@ -191,8 +181,7 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
     std::cout <<" Test case Ptree:  "<< std::endl;
     std::cout << io::to_string(est_pt) << std::endl;
 
-    int measure_interval;
-    int estimator_handler_querries = 0;
+    int measure_interval{};
     {
       int nPopulation = 1;
       float dt = 0.01f;
@@ -204,7 +193,7 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
     
       // set measurement intervals
       measure_interval = estim0.get_max_common_interval();
-      std::cout << "Querrying estimator handler with interval " << measure_interval << " (commensurate with all measurement intervals)" << std::endl;
+      std::cout << "Querying estimator handler with interval " << measure_interval << " (commensurate with all measurement intervals)" << std::endl;
 
       /* Fake Driver Block */
       std::vector<ComplexType> dummyData;
@@ -227,14 +216,13 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
         {
           estim0.accumulate_block(total_time, wset);
           estim0.print(iStep + 1, total_time, E1, wset);
-          estimator_handler_querries++;
         }
       }
     
     }
     // Energy estimator uses meas1 as the global measure_interval_multiplier
     int energy_interval = test_ptree.get<int>("meas1") * population_control_interval;
-    int expected_measurments = nStep / energy_interval;
+    int expected_measurements = nStep / energy_interval;
     // read results from "test_est_handler.scalar.dat"
     std::string filename = "test_est_handler.scalar.dat";
     std::ifstream in(filename.c_str());
@@ -244,12 +232,10 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
     while (std::getline(in, line))
     {
       line_count++;
-      cout << line << endl;
+      std::cout << line << std::endl;
     }
     app_log(1, "\n[TESTS] Running test case: {} \n",test_ptree.get<std::string>("name","no name"));
-//    CHECK(measure_interval == test_ptree.get<int>("gcd"));
-//    CHECK(estimator_handler_querries == expected_estimator_querries);
-    CHECK(line_count == expected_measurments);
+    CHECK(line_count == expected_measurements);
     in.close();
 
     mpi->comm.barrier();
@@ -259,14 +245,23 @@ void measure_schedule(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
 }
 
 TEST_CASE("measure_schedule", "[estimators]")
-{ 
+{
   auto& mpi = utils::make_unit_test_mpi_context();
 
-  measure_schedule<HOST_MEMORY>(mpi,UTEST_HAMIL,UTEST_WFN);
-
+  if (UTEST_HAMIL!="" and UTEST_WFN!="") {
+    measure_schedule<HOST_MEMORY>(mpi,UTEST_HAMIL,UTEST_WFN);
 #if defined(ENABLE_DEVICE)
-  measure_schedule<DEVICE_MEMORY>(mpi,UTEST_HAMIL,UTEST_WFN);
+    measure_schedule<DEVICE_MEMORY>(mpi,UTEST_HAMIL,UTEST_WFN);
 #endif
+  } else {
+    app_log(0,"EstimatorHandler unit testing. Running standard test.");
+    std::string hamil = utils::unit_test_base() + "models/square_4x4_hubbard_nup5_ndn5/afqmc_inputs/ham_collinear.h5";
+    std::string wfn   = utils::unit_test_base() + "models/square_4x4_hubbard_nup5_ndn5/afqmc_inputs/uhf_U0.1_wfn_nup5_ndn5.h5";
+    measure_schedule<HOST_MEMORY>(mpi, hamil, wfn);
+#if defined(ENABLE_DEVICE)
+    measure_schedule<DEVICE_MEMORY>(mpi, hamil, wfn);
+#endif
+  }
 }
 
 }

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -179,7 +179,8 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
   wset.resize(nwalk, initial_guess);
 
   // generate P1 with dt=0 so the BP RDM should match the mixed estimate
-  prop.generateP1(0.0, wset.getWalkerType());
+  // we cannot actually use exactly 0 because that changes the sparsity structure in model hamiltonians
+  prop.generateP1(1e-10, wset.getWalkerType());
 
   using EstimPtr = std::unique_ptr<EstimatorBase<MEM>>;
 

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -19,41 +19,36 @@
 #include "catch2/catch.hpp"
 
 #include "config.h"
-    
+
 #include "IO/ptree/ptree_utilities.hpp"
 #include "utilities/Random.hpp"
 #include "utilities/check.hpp"
-#include "IO/app_loggers.h"
 #include "utilities/test_common.hpp"
-  
+#include "utilities/h5_utils.hpp"
+#include "IO/app_loggers.h"
+
 #include "nda/nda.hpp"
 #include "nda/tensor.hpp"
 #include "nda/h5.hpp"
-#include "numerics/sparse/sparse.hpp"
-    
+
 #include <string>
 #include <vector>
-#include <complex> 
-#include <iomanip>
-#include <random>
+#include <complex>
+#include <format>
+#include <fstream>
 
 #include "AFQMC/config.h"
 #include "AFQMC/Hamiltonians/HamiltonianFactory.h"
 #include "AFQMC/Wavefunctions/WavefunctionFactory.h"
 #include "AFQMC/Walkers/WalkerSetFactory.hpp"
 #include "AFQMC/Estimators/EstimatorBase.h"
+#include "AFQMC/Estimators/BackPropagatedEstimator.hpp"
 #include "AFQMC/Propagators/PropagatorFactory.h"
-//#include "AFQMC/Estimators/BackPropagatedEstimator.hpp"
 #include "AFQMC/Utilities/readWfn.h"
 #include "AFQMC/Utilities/test_utils.hpp"
 #include "AFQMC/Utilities/AFQMCTimer.h"
 
-using std::cerr;
 using std::complex;
-using std::cout;
-using std::endl;
-using std::ifstream;
-using std::setprecision;
 using std::string;
 
 extern std::string UTEST_HAMIL, UTEST_WFN;
@@ -62,18 +57,78 @@ namespace sfqmc
 {
 using namespace afqmc;
 
+namespace
+{
+inline std::string test_hdf_name(std::string const& wfn_file,
+                                 std::string const& hamil_file,
+                                 std::string const& suffix)
+{
+  auto stem = [](std::string const& p) {
+    auto s = p.find_last_of("\\/");
+    auto e = p.find_last_of(".");
+    return p.substr(s + 1, e - s - 1);
+  };
+  return stem(wfn_file) + "_" + stem(hamil_file) + "_" + suffix + ".h5";
+}
+
+template<MEMORY_SPACE MEM>
+void verify_bp_matches_mixed(string const& file, string const& avg_path, int iblock,
+                             WALKER_TYPES type, int NMO, int nup, int ndown,
+                             Wavefunction<MEM>& wfn, WalkerSet<MEM>& wset)
+{
+  int nspin = (type == COLLINEAR) ? 2 : 1;
+  int npol  = (type == NONCOLLINEAR) ? 2 : 1;
+
+  std::string suffix = std::format("{:09d}", iblock);
+
+  nda::array<ComplexType, 1> read_data;
+  ComplexType denom;
+  {
+    h5::file reader(file, 'r');
+    h5::group root(reader);
+    utils::h5_read(root, avg_path + "/one_rdm_" + suffix, read_data);
+    h5::read(root, avg_path + "/denominator_" + suffix, denom);
+  }
+
+  // Since no back propagation has been performed (dt=0), the BP RDM should
+  // equal the mixed estimate.
+  REQUIRE(read_data.size() == nspin * npol * NMO * npol * NMO);
+  auto BPRDM = nda::reshape(read_data, std::array<long, 3>{nspin, npol * NMO, npol * NMO});
+  BPRDM *= 1.0 / denom;
+  ComplexType trace{};
+  for(int spin = 0; spin < nspin; spin++) {
+    for(int i = 0; i < npol * NMO; ++i) {
+      trace += BPRDM(spin, i, i);
+    }
+  }
+  if(type == CLOSED) {
+    trace *= 2;
+  }
+  REQUIRE(trace.real() == Approx(nup + ndown));
+  REQUIRE(trace.imag() == Approx(0.0).margin(1e-9));
+
+  memory::array<MEM, ComplexType, 2> Gw(wset.size(), nspin * npol * NMO * npol * NMO);
+  wfn.MixedDensityMatrix(wset, Gw, false);
+  auto G = nda::reshape(Gw(0,nda::ellipsis{}), std::array<long, 3>{nspin, npol * NMO, npol * NMO});
+  utils::ARRAY_EQUAL(G, BPRDM);
+}
+} // namespace
+
 template<MEMORY_SPACE MEM>
 void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
              std::string hamil_file, std::string wfn_file)
 {
-  using sfqmc::utils::ARRAY_EQUAL;
-  using nda::range;
+  app_log(1, "Running estimators unit test "
+    "with files:\n --hamil {} \\\n --wfn {}", 
+    hamil_file, wfn_file
+  );
+
   utils::check(utils::file_exists(hamil_file),
                " Hamiltonian file not found: {}. \n Run unit test with --hamil /path/to/hamil.h5 ", hamil_file);
   utils::check(utils::file_exists(wfn_file),
                " Wavefunction file not found: {}. \n Run unit test with --wfn /path/to/wfn.h5 ", wfn_file);
 
-  auto[NMO,nup, ndown] = read_info_from_wfn(UTEST_WFN, "any");
+  auto [NMO, nup, ndown] = read_info_from_wfn(wfn_file, "any");
   utils::check(NMO == read_nmo_from_hdf(hamil_file), "NMO differ between hamil and wfn files.");
 
   std::shared_ptr<utils::RandomGenerator_t<>> rng = std::make_shared<utils::RandomGenerator_t<>>();
@@ -98,8 +153,8 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
   wlk_pt.put("walker_type", walkerTypeToString(type));
   auto wset = make_WalkerSet<MEM>(mpi, wlk_pt, InfoMap["info0"], rng);
 
-  int nspin            = (type == COLLINEAR) ? 2 : 1;
-  int npol             = (type == NONCOLLINEAR) ? 2 : 1;
+  int nspin = (type == COLLINEAR) ? 2 : 1;
+  int npol  = (type == NONCOLLINEAR) ? 2 : 1;
 
   ptree wfn_pt;
   wfn_pt.put("name","wfn0");
@@ -107,7 +162,7 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
   wfn_pt.put("filename",wfn_file);
   wfn_pt.put("dense_trial",true);
 
-  int nwalk = 11; 
+  int nwalk = 11;
   WavefunctionFactory<MEM> WfnFac(InfoMap);
   WfnFac.push("wfn0", wfn_pt);
   auto& wfn = WfnFac.getWavefunction(mpi, "wfn0", type, &ham, nwalk);
@@ -118,217 +173,115 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
 
   PropagatorFactory<MEM> PropgFac(InfoMap);
   PropgFac.push("prop0", prop_pt);
-  PropgFac.getPropagator(mpi, "prop0", wfn, rng_dev);
+  auto& prop = PropgFac.getPropagator(mpi, "prop0", wfn, rng_dev);
 
   auto initial_guess = WfnFac.getInitialGuess("wfn0");
   REQUIRE(initial_guess.shape() == std::array<long,3>{nspin,npol*NMO,nup});
   wset.resize(nwalk, initial_guess);
 
-  using EstimPtr = std::shared_ptr<EstimatorBase<MEM>>;
-  std::vector<EstimPtr> estimators;
-/*
+  // generate P1 with dt=0 so the BP RDM should match the mixed estimate
+  prop.generateP1(0.0, wset.getWalkerType());
+
+  using EstimPtr = std::unique_ptr<EstimatorBase<MEM>>;
+
+  // ---- Run 1: scalar measure_interval_multiplier ----
+  {
     ptree est_pt;
     est_pt.put("name","back_propagation");
-    est_pt.put("nsteps",1); // deprecated
-    est_pt.put("block_size",1); // deprecated
     est_pt.put("measure_interval_multiplier", 2); // test with single value
     est_pt.put("path_restoration","no");
-    est_pt.put("OneRDM.nskip_output",0);
+    est_pt.put("onerdm.nskip_output",0);
     app_log(1,"\nEstimator input:\n{}\n",io::to_string(est_pt));
-    bool impsamp = true;
-    estimators.emplace_back(
-        static_cast<EstimPtr>(std::make_shared<BackPropagatedEstimator>(TG, InfoMap["info0"], "none", est_pt,
-                                                                        type, wset, wfn, prop, impsamp)));
 
-    // generate P1 with dt=0
-    prop.generateP1(0.0, wset.getWalkerType());
+    std::vector<EstimPtr> estimators;
+    estimators.push_back(std::make_unique<BackPropagatedEstimator<MEM>>(
+        mpi, InfoMap["info0"], "none", est_pt, type, wset, wfn, prop, true));
 
-    std::string file = create_test_hdf(UTEST_WFN, UTEST_HAMIL);
+    std::string file = test_hdf_name(UTEST_WFN, UTEST_HAMIL, "run1");
     std::ofstream out;
-    dump.create(file);
-    dump.open(file);
-    for (int iblock = 0; iblock < 10*afqmc::DEFAULT_POPULATION_CONTROL_INTERVAL; iblock++)
     {
-      wset.advanceBPPos();
-      estimators[0]->accumulate_block(iblock*0.01,wset);
-      estimators[0]->print(out, dump, wset);
-    }
-    dump.close();
-    boost::multi::array<ComplexType, 1> read_data(boost::multi::iextensions<1u>{2 * NMO * NMO});
-
-    ComplexType denom;
-    hdf_archive reader;
-    // Read from a particular block.
-    if (!reader.open(file, H5F_ACC_RDONLY))
-      APP_ABORT(" Error opening estimates.h5. ");
-    reader.read(read_data, "Observables/BackPropagated/FullOneRDM/Average_0/one_rdm_000000004");
-    reader.read(denom, "Observables/BackPropagated/FullOneRDM/Average_0/denominator_000000004");
-    // Test EstimatorHandler eventually.
-    //int nup_READ, ndown_READ, NMO_READ, WALKER_TYPE_READ;
-    //reader.read(nup_READ, "Metadata/nup");
-    //REQUIRE(nup_READ==nup);
-    //reader.read(ndown_READ, "Metadata/ndown");
-    //REQUIRE(ndown_READ==ndown);
-    //reader.read(NMO_READ, "Metadata/NMO");
-    //REQUIRE(NMO_READ==NMO);
-    //reader.read(WALKER_TYPE_READ, "Metadata/WALKER_TYPE");
-    //REQUIRE(WALKER_TYPE_READ==type);
-    reader.close();
-    // Test the RDM. Since no back propagation has been performed the RDM should be
-    // identical to the mixed estimate.
-    if (type == CLOSED)
-    {
-      REQUIRE(read_data.num_elements() >= NMO * NMO);
-      boost::multi::array_ref<ComplexType, 2> BPRDM(read_data.origin(), {NMO, NMO});
-      ma::scal(1.0 / denom, BPRDM);
-      ComplexType trace = ComplexType(0.0);
-      for (int i = 0; i < NMO; i++)
-        trace += BPRDM[i][i];
-      REQUIRE(trace.real() == Approx(nup));
-      boost::multi::array<ComplexType, 2, Allocator> Gw({1, NMO * NMO}, alloc_);
-      wfn.MixedDensityMatrix(wset, Gw, false, true);
-      boost::multi::array_ref<ComplexType, 2, pointer> G(Gw.origin(), {NMO, NMO});
-      verify_approx(G, BPRDM);
-    }
-    else if (type == COLLINEAR)
-    {
-      REQUIRE(read_data.num_elements() >= 2 * NMO * NMO);
-      boost::multi::array_ref<ComplexType, 3> BPRDM(read_data.origin(), {2, NMO, NMO});
-      ma::scal(1.0 / denom, BPRDM[0]);
-      ma::scal(1.0 / denom, BPRDM[1]);
-      ComplexType trace = ComplexType(0.0);
-      for (int i = 0; i < NMO; i++)
-        trace += BPRDM[0][i][i] + BPRDM[1][i][i];
-      REQUIRE(trace.real() == Approx(nup + ndown));
-      boost::multi::array<ComplexType, 2, Allocator> Gw({1, 2 * NMO * NMO}, alloc_);
-      wfn.MixedDensityMatrix(wset, Gw, false, true);
-      boost::multi::array_ref<ComplexType, 3, pointer> G(Gw.origin(), {2, NMO, NMO});
-      verify_approx(G, BPRDM);
-    }
-    else if (type == FULLYPOLARIZED) // Kyle: be careful here; I'm not sure that I have a reference!
-    {
-      REQUIRE(read_data.num_elements() >= NMO * NMO);
-      boost::multi::array_ref<ComplexType, 2> BPRDM(read_data.origin(), {NMO, NMO});
-      ma::scal(1.0 / denom, BPRDM);
-      ComplexType trace = ComplexType(0.0);
-      for (int i = 0; i < NMO; i++)
-        trace += BPRDM[i][i];
-      REQUIRE(trace.real() == Approx(nup));
-      boost::multi::array<ComplexType, 2, Allocator> Gw({1, NMO * NMO}, alloc_);
-      wfn.MixedDensityMatrix(wset, Gw, false, true);
-      boost::multi::array_ref<ComplexType, 2, pointer> G(Gw.origin(), {NMO, NMO});
-      verify_approx(G, BPRDM);
-    }
-    else
-    {
-      APP_ABORT(" NONCOLLINEAR Wavefunction found.");
+      h5::file h5out(file, 'w');
+      for (int iblock = 0; iblock < 10*afqmc::DEFAULT_POPULATION_CONTROL_INTERVAL; ++iblock)
+      {
+        wset.advanceBPPos();
+        estimators[0]->accumulate_block(iblock*0.01, wset);
+        estimators[0]->print(out, h5out, wset);
+      }
     }
 
+    verify_bp_matches_mixed<MEM>(file,
+        "Observables/BackPropagated/FullOneRDM/Average_0", 5,
+        type, NMO, nup, ndown, wfn, wset);
+  }
+
+  // ---- Run 2: vector measure_interval_multiplier ----
+  {
     ptree est_pt2;
     est_pt2.put("name","back_propagation");
-    est_pt2.put("nsteps",1); // deprecated
-    est_pt2.put("block_size",1); // deprecated
-    
+
     std::vector<int> nback_prop_interval_multipliers = {1, 2, 3};
     ptree temp_tree;
     for (const auto& value : nback_prop_interval_multipliers) {
-        ptree item;
-        item.put("", value); // empty key for the value
-        temp_tree.push_back(std::make_pair("", item));
+      ptree item;
+      item.put("", value);
+      temp_tree.push_back(std::make_pair("", item));
     }
-    est_pt2.add_child("measure_interval_multiplier", temp_tree); // test with a vector
+    est_pt2.add_child("measure_interval_multiplier", temp_tree);
     est_pt2.put("path_restoration","no");
-    est_pt2.put("OneRDM.nskip_output",0);
+    est_pt2.put("onerdm.nskip_output",0);
     app_log(1,"\nEstimator input:\n{}\n",io::to_string(est_pt2));
 
     std::vector<EstimPtr> estimators2;
-    estimators2.emplace_back(
-        static_cast<EstimPtr>(std::make_shared<BackPropagatedEstimator>(TG, InfoMap["info0"], "none", est_pt2,
-                                                                        type, wset, wfn, prop, impsamp)));
+    estimators2.push_back(std::make_unique<BackPropagatedEstimator<MEM>>(
+        mpi, InfoMap["info0"], "none", est_pt2, type, wset, wfn, prop, true));
 
-    dump.open(file);
-    for (int iblock = 0; iblock < 6*afqmc::DEFAULT_POPULATION_CONTROL_INTERVAL; iblock++)
+    std::string file = test_hdf_name(wfn_file, hamil_file, "run2");
+    std::ofstream out;
     {
-      wset.advanceBPPos();
-      estimators2[0]->accumulate_block(iblock*0.01,wset);
-      estimators2[0]->print(out, dump, wset);
-    }
-    dump.close();
-
-    if (!reader.open(file, H5F_ACC_RDONLY))
-      APP_ABORT(" Error opening estimates.h5. ");
-    else
-      app_log(1," Successfully opened {}", file);
-    reader.read(read_data, "Observables/BackPropagated/FullOneRDM/Average_1/one_rdm_000000002");
-    reader.read(denom, "Observables/BackPropagated/FullOneRDM/Average_1/denominator_000000002");
-    reader.close();
-
-    if (type == CLOSED)
-    {
-      REQUIRE(read_data.num_elements() >= NMO * NMO);
-      boost::multi::array_ref<ComplexType, 2> BPRDM(read_data.origin(), {NMO, NMO});
-      ma::scal(1.0 / denom, BPRDM);
-      ComplexType trace = ComplexType(0.0);
-      for (int i = 0; i < NMO; i++)
-        trace += BPRDM[i][i];
-      REQUIRE(trace.real() == Approx(nup));
-      boost::multi::array<ComplexType, 2, Allocator> Gw({1, NMO * NMO}, alloc_);
-      wfn.MixedDensityMatrix(wset, Gw, false, true);
-      boost::multi::array_ref<ComplexType, 2, pointer> G(Gw.origin(), {NMO, NMO});
-      verify_approx(G, BPRDM);
-    }
-    else if (type == COLLINEAR)
-    {
-      REQUIRE(read_data.num_elements() >= 2 * NMO * NMO);
-      boost::multi::array_ref<ComplexType, 3> BPRDM(read_data.origin(), {2, NMO, NMO});
-      ma::scal(1.0 / denom, BPRDM[0]);
-      ma::scal(1.0 / denom, BPRDM[1]);
-      ComplexType trace = ComplexType(0.0);
-      for (int i = 0; i < NMO; i++)
-        trace += BPRDM[0][i][i] + BPRDM[1][i][i];
-      REQUIRE(trace.real() == Approx(nup + ndown));
-      boost::multi::array<ComplexType, 2, Allocator> Gw({1, 2 * NMO * NMO}, alloc_);
-      wfn.MixedDensityMatrix(wset, Gw, false, true);
-      boost::multi::array_ref<ComplexType, 3, pointer> G(Gw.origin(), {2, NMO, NMO});
-      verify_approx(G, BPRDM);
-    }
-    else if (type == FULLYPOLARIZED) // Kyle: be careful here; I'm not sure that I have a reference!
-    {
-      REQUIRE(read_data.num_elements() >= NMO * NMO);
-      boost::multi::array_ref<ComplexType, 2> BPRDM(read_data.origin(), {NMO, NMO});
-      ma::scal(1.0 / denom, BPRDM);
-      ComplexType trace = ComplexType(0.0);
-      for (int i = 0; i < NMO; i++)
-        trace += BPRDM[i][i];
-      REQUIRE(trace.real() == Approx(nup));
-      boost::multi::array<ComplexType, 2, Allocator> Gw({1, NMO * NMO}, alloc_);
-      wfn.MixedDensityMatrix(wset, Gw, false, true);
-      boost::multi::array_ref<ComplexType, 2, pointer> G(Gw.origin(), {NMO, NMO});
-      verify_approx(G, BPRDM);
-    }
-    else
-    {
-      APP_ABORT(" NONCOLLINEAR Wavefunction found.");
+      h5::file h5out(file, 'w');
+      // 6 * pc_interval = 60 steps, with max_nback_prop = 3 * pc_interval = 30
+      // => iblock reaches 2; check Average_1 (multiplier=2) written at iblock=2
+      for (int iblock = 0; iblock < 6*afqmc::DEFAULT_POPULATION_CONTROL_INTERVAL; ++iblock)
+      {
+        wset.advanceBPPos();
+        estimators2[0]->accumulate_block(iblock*0.01, wset);
+        estimators2[0]->print(out, h5out, wset);
+      }
     }
 
-    if (!reader.open(file, H5F_ACC_RDONLY))
-      APP_ABORT(" Error opening estimates.h5. ");
-    reader.read(read_data, "Observables/BackPropagated/FullOneRDM/Average_2/one_rdm_000000002");
-    reader.read(denom, "Observables/BackPropagated/FullOneRDM/Average_2/denominator_000000002");
-    reader.close();
+    verify_bp_matches_mixed<MEM>(file,
+        "Observables/BackPropagated/FullOneRDM/Average_1", 2,
+        type, NMO, nup, ndown, wfn, wset);
   }
-*/
 }
 
 TEST_CASE("reduced_density_matrix", "[estimators]")
 {
   auto& mpi = utils::make_unit_test_mpi_context();
 
-  reduced_density_matrix<HOST_MEMORY>(mpi,UTEST_HAMIL,UTEST_WFN);
-
+  if (UTEST_HAMIL!="" and UTEST_WFN!="") {
+    reduced_density_matrix<HOST_MEMORY>(mpi,UTEST_HAMIL,UTEST_WFN);
 #if defined(ENABLE_DEVICE)
-  reduced_density_matrix<DEVICE_MEMORY>(mpi,UTEST_HAMIL,UTEST_WFN);
+    reduced_density_matrix<DEVICE_MEMORY>(mpi,UTEST_HAMIL,UTEST_WFN);
 #endif
+  } else {
+    app_log(0,"Estimators unit testing. Running standard tests.");
+    auto files = utils::get_unit_tests_files(true,true,true,true,true,true);
+    for( auto f : files ) {
+      try {
+        reduced_density_matrix<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in reduced_density_matrix<HOST_MEMORY>(" << std::get<0>(f) << "): " << e.what());
+      }
+#if defined(ENABLE_DEVICE)
+      try {
+        reduced_density_matrix<DEVICE_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in reduced_density_matrix<DEVICE_MEMORY>(" << std::get<0>(f) << "): " << e.what());
+      }
+#endif
+    }
+  }
 }
 
 } // namespace sfqmc

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -159,7 +159,6 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
   wfn_pt.put("name","wfn0");
   wfn_pt.put("system","info0");
   wfn_pt.put("filename",wfn_file);
-  wfn_pt.put("dense_trial",true);
 
   int nwalk = 2;
   WavefunctionFactory<MEM> WfnFac(InfoMap);

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -48,8 +48,6 @@
 #include "AFQMC/Utilities/test_utils.hpp"
 #include "AFQMC/Utilities/AFQMCTimer.h"
 
-using std::complex;
-using std::string;
 
 extern std::string UTEST_HAMIL, UTEST_WFN;
 
@@ -72,7 +70,7 @@ inline std::string test_hdf_name(std::string const& wfn_file,
 }
 
 template<MEMORY_SPACE MEM>
-void verify_bp_matches_mixed(string const& file, string const& avg_path, int iblock,
+void verify_bp_matches_mixed(std::string const& file, std::string const& avg_path, int iblock,
                              WALKER_TYPES type, int NMO, int nup, int ndown,
                              Wavefunction<MEM>& wfn, WalkerSet<MEM>& wset)
 {
@@ -82,7 +80,7 @@ void verify_bp_matches_mixed(string const& file, string const& avg_path, int ibl
   std::string suffix = std::format("{:09d}", iblock);
 
   nda::array<ComplexType, 1> read_data;
-  ComplexType denom;
+  ComplexType denom{};
   {
     h5::file reader(file, 'r');
     h5::group root(reader);
@@ -95,6 +93,7 @@ void verify_bp_matches_mixed(string const& file, string const& avg_path, int ibl
   REQUIRE(read_data.size() == nspin * npol * NMO * npol * NMO);
   auto BPRDM = nda::reshape(read_data, std::array<long, 3>{nspin, npol * NMO, npol * NMO});
   BPRDM *= 1.0 / denom;
+
   ComplexType trace{};
   for(int spin = 0; spin < nspin; spin++) {
     for(int i = 0; i < npol * NMO; ++i) {
@@ -162,7 +161,7 @@ void reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boost::mpi3::co
   wfn_pt.put("filename",wfn_file);
   wfn_pt.put("dense_trial",true);
 
-  int nwalk = 11;
+  int nwalk = 2;
   WavefunctionFactory<MEM> WfnFac(InfoMap);
   WfnFac.push("wfn0", wfn_pt);
   auto& wfn = WfnFac.getWavefunction(mpi, "wfn0", type, &ham, nwalk);

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -266,7 +266,7 @@ TEST_CASE("reduced_density_matrix", "[estimators]")
 #endif
   } else {
     app_log(0,"Estimators unit testing. Running standard tests.");
-    auto files = utils::get_unit_tests_files(true,true,true,true,true,true);
+    auto files = utils::get_unit_tests_files(true,true,true,true,true,false);
     for( auto f : files ) {
       try {
         reduced_density_matrix<HOST_MEMORY>(mpi,std::get<0>(f),std::get<1>(f));

--- a/src/AFQMC/HamiltonianOperations/ModelComponents/Discrete_GeneralUJ.hpp
+++ b/src/AFQMC/HamiltonianOperations/ModelComponents/Discrete_GeneralUJ.hpp
@@ -228,6 +228,8 @@ private:
                     nda::MemoryVector auto const& n2IJ, map_t& IJ2n, 
                     nda::MemoryVector auto&& vMF, bool natural_shift)
   {
+    // if dt == 0, it will mess up the sparsity structure below
+    utils::check(dt > 0, "dt has to be positive");
     
     int NMO = U.extent(0) / 2;
 
@@ -336,7 +338,7 @@ private:
         // now transpose  
         nda::array<ComplexType,2> Vn_array = math::sparse::to_array<'T'>(VnT);
         auto Vn = math::sparse::to_csr<HOST_MEMORY,int,int>(Vn_array);
-        utils::check(Vn.nnz() == SpVn.nnz(), "Error: Contact developers.");                  
+        utils::check(Vn.nnz() == SpVn.nnz(), "Error: Contact developers.");
         nda::range rng(Vn.nnz());
         auto col_h = nda::to_host(SpVn.columns());
         utils::check(nda::sum(nda::abs(Vn.columns()(rng)-col_h(rng)))==0, "Error: Contact developers.");

--- a/src/AFQMC/SlaterDeterminantOperations/density_matrix.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/density_matrix.hpp
@@ -80,7 +80,7 @@ void inverse_logdet(A_t const& A, O_t && ovlp, T_t && TNN, int nbatch = 0, bool 
 
   // Invert
   if(invert)
-    nda::lapack::getri(TNN,ipiv,work);
+    nda::lapack::getri_or_zero(TNN,ipiv,work);
 }
 
 template<nda::MemoryArrayOfRank<3> A_t, typename O_t, nda::MemoryArrayOfRank<3> T_t>
@@ -112,7 +112,7 @@ void inverse_logdet(A_t const& A, O_t && ovlp, T_t && TNN, bool invert = true)
 
   // Invert
   if(invert)
-    nda::lapack::getri(TNN,ipiv,work);
+    nda::lapack::getri_or_zero(TNN,ipiv,work);
 }
 
 template<typename A_t, nda::MemoryArrayOfRank<3> B_t, nda::MemoryArrayOfRank<1> O_t,
@@ -151,8 +151,9 @@ void log_overlap_impl(A_t const& A, B_t const& B, O_t && ovlp, T_t && TNN, bool 
   math::log_determinant_from_getrf(TNN,ipiv,ovlp);
 
   // Invert
-  if(invert)
-    nda::lapack::getri(TNN,ipiv,work);
+  if(invert) {
+    nda::lapack::getri_or_zero(TNN,ipiv,work);
+  }
 }
 
 template<nda::MemoryArrayOfRank<3> A_t, nda::MemoryArrayOfRank<3> B_t, 
@@ -186,8 +187,9 @@ void log_overlap_impl(A_t const& A, B_t const& B, O_t && ovlp, T_t && TNN, bool 
   math::log_determinant_from_getrf(TNN,ipiv,ovlp);
 
   // Invert
-  if(invert)
-    nda::lapack::getri(TNN,ipiv,work);
+  if(invert) {
+    nda::lapack::getri_or_zero(TNN,ipiv,work);
+  }
 }
 
 //finite-T
@@ -519,9 +521,7 @@ void Log_OverlapForWoodbury(A_t const& A, B_t const& B, O_t && ovlp, QQ0_t && QQ
   math::log_determinant_from_getrf(TNN,ipiv,ovlp);
 
   // Invert 
-  nda::lapack::getri(TNN,ipiv,work);
-
-  // fill_if_zero()
+  nda::lapack::getri_or_zero(TNN,ipiv,work);
 
   // QQ0 = TMN * inv(TNN)
   math::product(TMN,TNN,QQ0);
@@ -558,9 +558,6 @@ void MixedDensityMatrix(A_t const& A, B_t const& B, C_t && C, O_t && ovlp, bool 
 
   // A*B and overlap
   detail::log_overlap_impl(A,B,ovlp,TNN,herm,true);
-
-  // zero out TNN if determinant is zero
-//  math::fill_if_zero(TNN, ovlp, Type(0.0));
 
   if(compact) {
 
@@ -620,9 +617,6 @@ void MixedDensityMatrix(A_t const& A, B_t const& B, C_t && C, O_t && ovlp, bool 
 
   // A*B and overlap
   detail::log_overlap_impl(A,B,ovlp,TNN,true);
-
-  // zero out TNN if determinant is zero
-//  math::fill_if_zero(TNN, ovlp, Type(0.0));
 
   if(compact) {
 
@@ -687,9 +681,7 @@ void MixedDensityMatrixForWoodbury(A_t const& A, B_t const& B, C_t &&C, O_t && o
   math::log_determinant_from_getrf(TNN,ipiv,ovlp);
 
   // Invert 
-  nda::lapack::getri(TNN,ipiv,work);
-
-  // fill_if_zero()
+  nda::lapack::getri_or_zero(TNN,ipiv,work);
 
   // QQ0 = TAB * inv(TNN)
   math::product(TAB,TNN,QQ0);
@@ -755,7 +747,7 @@ void MixedDensityMatrixFromConfiguration(A_t const& A, B_t const& B, C_t &&C, O_
   math::log_determinant_from_getrf(TNN,ipiv,ovlp);
 
   // Invert 
-  nda::lapack::getri(TNN,ipiv,work);
+  nda::lapack::getri_or_zero(TNN,ipiv,work);
 
   // fill_if_zero()
 

--- a/src/AFQMC/Wavefunctions/NOMSD.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.hpp
@@ -336,11 +336,9 @@ public:
     } else { 
       for(int i=0; i<number_of_references; ++i) {
         nda::tensor::add(nda::conj(OrbMats(i,0)()),"ji",Refs(i,all,range(nup)),"ij");
-        if(walker_type == COLLINEAR)
-          nda::tensor::add(nda::conj(OrbMats(i,0)()),"ji",Refs(i,all,range(nup,nel)),"ij");
-//        Refs(i,all,range(nup)) = nda::dagger(OrbMats(i,0)());
-//        if(walker_type == COLLINEAR)
-//          Refs(i,all,range(nup,nel)) = nda::dagger(OrbMats(i,1)());
+        if(walker_type == COLLINEAR) {
+          nda::tensor::add(nda::conj(OrbMats(i,1)()),"ji",Refs(i,all,range(nup,nel)),"ij");
+        }
       }
     }
   }

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -49,8 +49,11 @@ void NOMSD<MEM,devPsiT>::Energy(const WlkSet& wset, TMat&& E, TVec&& Ov, int nt)
 
   if( ndet == 1) {
 
-    DensityMatrix(wset, OrbMats(0,all), G, Ov); 
-    HamOp.energy(E, G(), 0); 
+    DensityMatrix(wset, OrbMats(0,all), G, Ov);
+    HamOp.energy(E, G(), 0);
+    ComplexType val = std::log(std::abs(ci(0)) < 1e-12 ? ComplexType(1e-12) : std::conj(ci(0)));
+    memory::buffered_array<MEM,ComplexType,1> buff(nw,val);
+    nda::tensor::add(1.0, buff,"w", 1.0, Ov,"w");
 
   } else {
 
@@ -229,6 +232,9 @@ void NOMSD<MEM,devPsiT>::Log_Overlap(const WlkSet& wset, TVec&& Ov, int nt)
     } else if (walker_type == COLLINEAR)  {
       det_ops::Log_Overlap(OrbMats(0,1)(),wset.SlaterMatrices(Beta),Ov);
     }
+    ComplexType val = std::log(std::abs(ci(0)) < 1e-12 ? 1e-12 : std::conj(ci(0)));
+    memory::buffered_array<MEM,ComplexType,1> buff(nw,val);
+    nda::tensor::add(1.0, buff,"w", 1.0, Ov,"w");
   } else {
     // compute separate, assemble afterwards
     memory::buffered_array<MEM,ComplexType,2> log_ovlps(ndet,nw);
@@ -243,7 +249,7 @@ void NOMSD<MEM,devPsiT>::Log_Overlap(const WlkSet& wset, TVec&& Ov, int nt)
       ComplexType val( std::log( (std::abs(ci(d)) < 1e-12 ? ComplexType(1e-12) : std::conj(ci(d)) ) ) );
       memory::buffered_array<MEM,ComplexType,1> buff(nw,val);
       // log_ovlp(d,w) = log( ci(d) ) + log( Ov(d, Beta) ) + log( Ov(d, Alpha) )
-      nda::tensor::add(ComplexType(1.0),buff,"w",ComplexType(1.0),log_ovlps(d,all),"w");
+      nda::tensor::add(1.0, buff,"w", 1.0, log_ovlps(d,all),"w");
     }
   
     // now assemble avoiding round-off problems 

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -158,7 +158,8 @@ void NOMSD<MEM,devPsiT>::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&&
   const int npol  = (walker_type==NONCOLLINEAR ? 2 : 1 );
   utils::check(Ov.size() == nw, "Size mismatch");
   const int nc    = ( compact ? nel : nspin*npol*NMO );
-  utils::check(G.shape() == std::array<long,2>{nw,nc*npol*NMO}, "Size mismatch");
+  auto expected_shape = std::to_array<long>({nw, nc * npol * NMO});
+  utils::check(G.shape() == expected_shape, "Size mismatch: given {} != {} expected", G.shape(), expected_shape);
   G() = ComplexType(0.0);
   Ov() = ComplexType(0.0);
 

--- a/src/AFQMC/Wavefunctions/PHMSD.hpp
+++ b/src/AFQMC/Wavefunctions/PHMSD.hpp
@@ -378,13 +378,14 @@ public:
     auto all = range::all;
     memory::check_memory_space<MEM>(Refs);
     int nel = nup + (walker_type == COLLINEAR ? ndown : 0);
+    int nspin = walker_type == COLLINEAR ? 2 : 1;
+    int nspin_in_wfn = OrbMats.extent(0);
     int npol = (walker_type == NONCOLLINEAR ? 2 : 1);
     if(number_of_references==0) return;
     if(number_of_references < 0) number_of_references = total_number_of_references(); 
     utils::check(number_of_references > 0 and
-                 number_of_references < OrbMats.extent(0) and
-                 number_of_references < Refs.extent(0),
-                 "Invalid number_of_references:{}", number_of_references);
+                 number_of_references <= Refs.extent(0),
+                 "Invalid number_of_references: {} should fulfill 0 < n <= {}!", number_of_references, Refs.extent(0));
     utils::check(Refs.extent(1) == npol*NMO and Refs.extent(2) == nel, "Size mismatch");
     if (RefOrbMats.extent(0) < number_of_references)
     {
@@ -392,30 +393,21 @@ public:
       RefOrbMats = memory::make_shared_array<HOST_MEMORY,ComplexType,3>(mpi,{number_of_references,npol*NMO,nel}); 
       if (mpi->node_comm.root())
       {
-        {
-          auto psi = nda::to_host(math::sparse::to_array<'N'>(OrbMats(0)));
-          nda::vector<int> Ac(nup);
-          for (int i_det = 0; i_det < number_of_references; ++i_det)
-          {
+        std::array nels = {nup, ndown};
+        std::array spin_offset = {0, nup};
+        for(int spin = 0; spin < nspin; spin++) {
+          int spin_ = spin % nspin_in_wfn;
+          auto psi = nda::to_host(math::sparse::to_array<'N'>(OrbMats(spin_)));
+          nda::vector<int> Ac(nels[spin]);
+          for (int i_det = 0; i_det < number_of_references; ++i_det) {
             auto c=abij.configuration(i_det);
-            abij.get_configuration(0, std::get<0>(*c), Ac);
-            for (int a = 0; a < nup; ++a)
-              RefOrbMats()(i_det,all,a) = nda::conj(psi(Ac(a),all));
+            abij.get_configuration(spin, std::get<0>(*c), Ac);
+            for (int a = 0; a < nels[spin]; ++a) {
+              RefOrbMats()(i_det,all,spin_offset[spin]+a) = nda::conj(psi(Ac(a),all));
+            }
           }
         }
-        if(walker_type == COLLINEAR) 
-        {
-          auto psi = nda::to_host(math::sparse::to_array<'N'>(OrbMats(1)));
-          nda::vector<int> Ac(ndown); 
-          for (int i_det = 0; i_det < number_of_references; ++i_det)
-          { 
-            auto c=abij.configuration(i_det);
-            abij.get_configuration(1, std::get<0>(*c), Ac);
-            for (int a = 0; a < ndown; ++a)
-              RefOrbMats()(i_det,all,nup+a) = nda::conj(psi(Ac(a),all));
-          }
-        }
-      }                    // TG.Node().root()
+      }
     }
     mpi->node_comm.barrier();
     utils::check(RefOrbMats.extent(0) >= number_of_references and

--- a/src/AFQMC/Wavefunctions/PHMSD.icc
+++ b/src/AFQMC/Wavefunctions/PHMSD.icc
@@ -481,6 +481,7 @@ void PHMSD<MEM>::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, boo
 
   if (walker_type == NONCOLLINEAR)
   {
+    utils::check(false, "noncollinear PHMSD MixedDensityMatrix not implemented");
 /*
     // always calculate compact and multiply by OrbMat at the end if full
     auto Gdims      = dm_dims(false, Alpha);
@@ -594,8 +595,7 @@ void PHMSD<MEM>::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, boo
   }
   else
   {
-    long nexcit[2] = {long(abij.number_of_unique_excitations()[0]), 
-                      long(abij.number_of_unique_excitations()[1])};
+    const auto& nexcit = abij.number_of_unique_excitations();
     const int nbatch__  = nwalk; 
 
     auto SMup=wset.SlaterMatrices(Alpha);
@@ -680,14 +680,7 @@ void PHMSD<MEM>::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, boo
         if (compact)
         {
           auto G3d = nda::reshape(G,std::array<long,3>{nwalk,nact,NMO});
-          if constexpr (MEM==HOST_MEMORY) {
-            for(int i=0; i<nw; ++i)
-              nda::blas::gemm(nda::transpose(Rb(i,all,all)),GB(i,all,all),
-                              G3d(iw+i,range(nactA,nact),all));
-          } else {
-            nda::tensor::contract(ComplexType(1.0), Rb, "wia", GB, "wik",
-                ComplexType(0.0), G3d(range(iw,iw+nw),range(nactA,nact),all), "wak");
-          }
+          math::product<'T','N'>(Rb, GB, G3d(range(iw,iw+nw), range(nactA,nact), all));
         }
         else
         {
@@ -734,6 +727,7 @@ void PHMSD<MEM>::Log_Overlap(const WlkSet& wset, TVec&& Ov, int nt)
   Ov() = ComplexType(0.0);
   if (walker_type == NONCOLLINEAR)
   {
+    utils::check(false, "noncollinear PHMSD MixedDensityMatrix not implemented");
 /*
     long nexcit = long(abij.number_of_unique_excitations()[0]);
     StaticVector ov0(iextensions<1u>{nbatch__}, ComplexType(0.0),

--- a/src/AFQMC/Wavefunctions/detail/phmsd_impl.hpp
+++ b/src/AFQMC/Wavefunctions/detail/phmsd_impl.hpp
@@ -17,15 +17,10 @@
 #include "nda/nda.hpp"
 #include "nda/tensor.hpp"
 
-/*
 #if defined(ENABLE_CUDA)
-#include "Numerics/detail/CUDA/Kernels/phmsd_energy.cuh"
-#include "Numerics/detail/CUDA/Kernels/phmsd_determinants.cuh"
-#include "Numerics/detail/CUDA/Kernels/phmsd_inverse.cuh"
-#include "Numerics/detail/CUDA/Kernels/extract_overlap_matrix.cuh"
-#include "Numerics/detail/CUDA/Kernels/construct_phmsd_R.cuh"
+#include "numerics/device_kernels/cuda/phmsd_routines.cuh"
 #endif
-*/
+
 
 namespace sfqmc::afqmc 
 {

--- a/src/AFQMC/Wavefunctions/tests/CMakeLists.txt
+++ b/src/AFQMC/Wavefunctions/tests/CMakeLists.txt
@@ -19,6 +19,21 @@ set(TEST_ID afqmc_phmsd)
 add_executable(test_${TEST_ID} test_phmsd.cpp)
 target_link_libraries(test_${TEST_ID} PRIVATE catch_main)
 
+set (UTEST_NAME unit_test_${TEST_ID})
+add_unit_test(${UTEST_NAME} "${PROJECT_UNIT_TEST_DIR}/test_${TEST_ID}")
+set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${PROJECT_UNIT_TEST_DIR})
+set_property(TEST ${UTEST_NAME} APPEND PROPERTY LABELS "afqmc")
+
+
+set(TEST_ID afqmc_phmsd_components)
+add_executable(test_${TEST_ID} test_phmsd_components.cpp)
+target_link_libraries(test_${TEST_ID} PRIVATE catch_main)
+
+set (UTEST_NAME unit_test_${TEST_ID})
+add_unit_test(${UTEST_NAME} "${PROJECT_UNIT_TEST_DIR}/test_${TEST_ID}")
+set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${PROJECT_UNIT_TEST_DIR})
+set_property(TEST ${UTEST_NAME} APPEND PROPERTY LABELS "afqmc")
+
 #set(TEST_ID optm_phmsd)
 #add_executable(${TEST_ID} optm_phmsd.cpp)
 #target_link_libraries(${TEST_ID} catch_main)

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -145,10 +145,10 @@ void test_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   using sfqmc::utils::ARRAY_EQUAL;
   using nda::range;
   auto all = range::all;
-  utils::check(utils::file_exists(hamil_file),
-               " Hamiltonian file not found: {}. \n Run unit test with --hamil /path/to/hamil.h5 ", hamil_file);
-  utils::check(utils::file_exists(wfn_file),
-               " Wavefunction file not found: {}. \n Run unit test with --wfn /path/to/wfn.h5 ", wfn_file);
+  app_log(1, "Running estimators unit test "
+    "with files:\n --hamil {} \\\n --wfn {}", 
+    hamil_file, wfn_file
+  );
 
   // First strip path of filename.
   std::string base_name = wfn_file.substr(wfn_file.find_last_of("\\/") + 1);
@@ -163,7 +163,7 @@ void test_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   int nspin         = (type == COLLINEAR) ? 2 : 1;
   int npol          = (type == NONCOLLINEAR) ? 2 : 1;
   int nwalk         = 1;
-  int ndets         = ( MEM == HOST_MEMORY ? 100 : 1000 ); 
+  int ndets         = -1; 
   double dt         = 0.01;
   std::shared_ptr<utils::RandomGenerator_t<>> rng = std::make_shared<utils::RandomGenerator_t<>>();
 
@@ -184,7 +184,7 @@ void test_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   wfn_pt.put("system","info0");
   wfn_pt.put("filename",wfn_file);
   wfn_pt.put("rediag","no");
-  wfn_pt.put("ndets_to_read",ndets);
+  wfn_pt.put("ndets_to_read",-1);
   wfn_pt.put("algorithm",0);
 
   WavefunctionFactory<MEM> WfnFac(InfoMap);
@@ -304,16 +304,17 @@ void test_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
   ComplexType log_ovlp_sum = std::log(ovlp_sum);
 
   // the phase can be off by 2*pi due to small round-off errors around 0, what to do???
-  for (auto it = wset.begin(); it != wset.end(); ++it)
-    VALUE_EQUAL(std::exp(it->get_property(OVLP)), ovlp_sum);
+  for (const auto &w : wset)
+    VALUE_EQUAL(std::exp(w.get_property(OVLP)), ovlp_sum);
 
   {
     memory::array<MEM,ComplexType,1> log_ov(nwalk);
     nomsd.Log_Overlap(wset,log_ov); 
     auto ov_h = nda::to_host(log_ov);
     ov_h() = nda::exp(ov_h());
-    for(int i=0; i<nwalk; ++i)
+    for(int i=0; i<nwalk; ++i) {
       VALUE_EQUAL(std::exp(wset[i].get_property(OVLP)), ov_h(i)); 
+    }
   }
 
   // 2. Green function
@@ -389,7 +390,7 @@ void test_phmsd(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>>
     wfn1_pt.put("system","info0");
     wfn1_pt.put("filename",wfn_file);
     wfn1_pt.put("rediag","no");
-    wfn1_pt.put("ndets_to_read",ndets);
+    wfn1_pt.put("ndets_to_read",-1);
     wfn1_pt.put("algorithm",1);
 
     WfnFac.push("wfn1", wfn1_pt);
@@ -457,7 +458,20 @@ TEST_CASE("test_read_phmsd", "[test_read_phmsd]")
 {
   auto& mpi = utils::make_unit_test_mpi_context();
 
-  test_read_phmsd<HOST_MEMORY>(mpi,UTEST_HAMIL, UTEST_WFN);
+  if (UTEST_HAMIL!="" and UTEST_WFN!="") {
+    test_read_phmsd<HOST_MEMORY>(mpi,UTEST_HAMIL, UTEST_WFN);
+  } else {
+    app_log(0,"test_read_phmsd: running standard PHMSD test files.");
+    auto files = utils::get_unit_tests_files(false, true, false, false, true);
+    for (auto f : files) {
+      try {
+        test_read_phmsd<HOST_MEMORY>(mpi, std::get<0>(f), std::get<1>(f));
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in test_read_phmsd(" << std::get<1>(f)
+                   << "): " << e.what());
+      }
+    }
+  }
 }
 
 TEST_CASE("test_phmsd", "[read_phmsd]")
@@ -465,10 +479,31 @@ TEST_CASE("test_phmsd", "[read_phmsd]")
   auto& mpi = utils::make_unit_test_mpi_context();
 
   bool write_reference = false;
-  test_phmsd<HOST_MEMORY>(mpi,UTEST_HAMIL, UTEST_WFN, write_reference);
+  if (UTEST_HAMIL!="" and UTEST_WFN!="") {
+    test_phmsd<HOST_MEMORY>(mpi,UTEST_HAMIL, UTEST_WFN, write_reference);
 #if defined(ENABLE_DEVICE)
-  test_phmsd<DEVICE_MEMORY>(mpi,UTEST_HAMIL, UTEST_WFN, false);
+    test_phmsd<DEVICE_MEMORY>(mpi,UTEST_HAMIL, UTEST_WFN, false);
 #endif
+  } else {
+    app_log(0,"test_phmsd: running standard PHMSD test files.");
+    auto files = utils::get_unit_tests_files(false, true, false, false, true);
+    for (auto f : files) {
+      try {
+        test_phmsd<HOST_MEMORY>(mpi, std::get<0>(f), std::get<1>(f), write_reference);
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in test_phmsd<HOST_MEMORY>(" << std::get<1>(f)
+                   << "): " << e.what());
+      }
+#if defined(ENABLE_DEVICE)
+      try {
+        test_phmsd<DEVICE_MEMORY>(mpi, std::get<0>(f), std::get<1>(f), false);
+      } catch (const sfqmc::AppAbortException& e) {
+        FAIL_CHECK("APP_ABORT in test_phmsd<DEVICE_MEMORY>(" << std::get<1>(f)
+                   << "): " << e.what());
+      }
+#endif
+    }
+  }
 }
 
 } // namespace sfqmc

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd_components.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd_components.cpp
@@ -25,7 +25,6 @@
 #include "IO/app_loggers.h"
 
 #include <vector>
-#include <random>
 
 #include "nda/nda.hpp"
 
@@ -36,208 +35,59 @@ namespace sfqmc
 {
 using namespace afqmc;
 
-#if defined(ENABLE_DEVICE)
-/*
-TEST_CASE("test_ph_excited_energy_real_dense_cholesky", "[Numerics][misc_kernels]")
-{
-  setup_loggers(true,2,0);
-  Alloc<ComplexType> alloc{};
-  Alloc<int> ialloc{};
-// for timing/perf
-//  int ndet = 500;
-//  int nmo = 100;
-//  int nelec = 50;
-//  int nact = 100;
-//  int nchol = 500;
-// for unit testing 
-  int ndet = 50;
-  int nmo = 10;
-  int nelec = 5;
-  int nact = 10;
-  int nchol = 50;
-  int maxwalk=16;
-  afqmc::HostBufferManager host_buffer(10uL * 1024uL * 1024uL);  
-  afqmc::DeviceBufferManager device_buffer(10uL * 1024uL * 1024uL);  
-  Tensor1D<int> refc(iextensions<1u>{nelec}, ialloc);
-  boost::multi::array<int, 1> refc_(iextensions<1u>{nelec});
-  for(int i=0; i<nelec; i++) refc[i]=i;
-  for(int i=0; i<nelec; i++) refc_[i]=i;
-  //for(int nex=5; nex<6; nex++) 
-  for(int nex=1; nex<6; nex++) 
-  {
-//    std::cout<<" # excitations: " <<nex <<std::endl;
-    boost::multi::array<ComplexType, 4> Tna({1, nelec, nchol, nact}, ComplexType(0.0));
-    boost::multi::array<ComplexType, 4> Tan({1, nelec, nact, nchol}, ComplexType(0.0));
-    boost::multi::array<ComplexType, 4> R_({1, ndet, nex, nact}, ComplexType(0.0));
-    boost::multi::array<ComplexType, 2> wgt_({ndet, 1}, ComplexType(0.0));
-    boost::multi::array<ComplexType, 3> KE_({ndet, 1, nchol}, ComplexType(0.0));
-    boost::multi::array<int, 2> iexcit_({ndet,2*nex});
-    Tensor1D<int> iexcit(iextensions<1u>{ndet*2*nex}, ialloc);
-    {
-      std::vector<ComplexType> tmp( std::max(Tna.num_elements(), R_.num_elements()) );
-      afqmc::fillRandomMatrix(tmp);
-      copy_n(tmp.data(), Tna.num_elements(), Tna.origin());
-      copy_n(tmp.data(), R_.num_elements(), R_.origin());
-      copy_n(tmp.data(), wgt_.num_elements(), wgt_.origin());
-      for(int i=0; i<nelec; i++)
-        for(int a=0; a<nact; a++)
-          for(int n=0; n<nchol; n++)
-            Tan[0][i][a][n] = Tna[0][i][n][a];
-      std::vector<int> tmpi(nex);
-      std::mt19937 generator(0);
-      {
-        std::uniform_int_distribution<int> distribution(0, nelec-1);
-        std::vector<int> iocc(nelec, 0);
-        for(int nd=0; nd<ndet; nd++) {
-          std::fill_n(iocc.begin(), nelec, 0);
-          for(int i=0; i<nex; i++) {
-            int v = distribution(generator);
-            while( iocc[v] != 0 ) {
-              v = distribution(generator);
-            }
-            iocc[v]=1;
-            iexcit_[nd][i] = v;
-          }
-        }
-      }
-      {
-        std::uniform_int_distribution<int> distribution(0, nact-nelec-1);
-        std::vector<int> iocc(nact-nelec, 0);
-        for(int nd=0; nd<ndet; nd++) {
-          std::fill_n(iocc.begin(), nact-nelec, 0);
-          for(int i=0; i<nex; i++) {
-            int v = distribution(generator);
-            while( iocc[v] != 0 ) {
-              v = distribution(generator);
-            }
-            iocc[v]=1;
-            iexcit_[nd][i+nex] = v+nelec;
-          }
-        }
-      }
-      copy_n(iexcit_.origin(), iexcit_.num_elements(), iexcit.origin());
-    }
-    Vector<ComplexType> EJ(iextensions<1u>{1}, 0.0);
-    Vector<ComplexType> EX(iextensions<1u>{1}, 0.0);
-    using ma::ph_excited_2body_energy_dense_cholesky_Tpan;
-    Watch timer;
-    ph_excited_2body_energy_dense_cholesky_Tpan(iexcit_.origin(), refc_.origin(),
-          Tan, R_, wgt_, EX, EJ, KE_);
-    double tcpu(timer.elapsed());
-    double tgpu_1w(0.0);
-    //for(int nwalk=1; nwalk<=72; nwalk+=71) {
-    for(int nwalk=1; nwalk<=maxwalk; nwalk*=2) {
-    //for(int nwalk=1; nwalk<2; nwalk++) {
-      Tensor4D<ComplexType> T({nwalk,nelec,nchol,nact}, ComplexType(0.0), alloc);
-      Tensor4D<ComplexType> R({nwalk,ndet,nex,nact}, ComplexType(0.0), alloc);
-      Tensor2D<ComplexType> wgt({ndet,nwalk}, ComplexType(0.0), alloc);
-      Tensor3D<ComplexType> KE({ndet,nwalk,nchol}, ComplexType(0.0), alloc);
-      Tensor2D<ComplexType> E({nwalk,2}, ComplexType(0.0), alloc);
-      for(int iw=0; iw<nwalk; iw++) {
-        copy_n(Tna.origin(), T[iw].num_elements(), T[iw].origin());
-        copy_n(R_.origin(), R[iw].num_elements(), R[iw].origin());
-	wgt({0,ndet},iw) = wgt_({0,ndet},0);
-      }
-      timer.reset();
-      ma::ph_excited_2body_energy_dense_cholesky_Tpna(iexcit.origin(), refc.origin(),
-		T, R, wgt, E.rotated()[0], E.rotated()[1], KE);
-      double tgpu(timer.elapsed());
-      if(nwalk==1) 
-        tgpu_1w=tgpu;
-      {
-        boost::multi::array<ComplexType, 2> tmp(E);
-        boost::multi::array<ComplexType, 3> tmpK(KE);
-        for(int iw=0; iw<nwalk; iw++) {
-          REQUIRE(std::real(tmp[iw][0]) == Approx(std::real(EX[0])));
-          REQUIRE(std::imag(tmp[iw][0]) == Approx(std::imag(EX[0])));
-          REQUIRE(std::real(tmp[iw][1]) == Approx(std::real(EJ[0])));
-          REQUIRE(std::imag(tmp[iw][1]) == Approx(std::imag(EJ[0])));
-        }
-        for(int id=0; id<ndet; id++) {
-        for(int iw=0; iw<nwalk; iw++) {
-        for(int n=0; n<nchol; n++) {
-          REQUIRE(std::real(tmpK[id][iw][n]) == Approx(std::real(KE_[id][0][n])));
-          REQUIRE(std::imag(tmpK[id][iw][n]) == Approx(std::imag(KE_[id][0][n])));
-        }
-        }
-        }
-      }
-      ma::fill(E, ComplexType(0.0));
-      ma::fill(KE.flatted(), ComplexType(0.0));
-      timer.reset();
-      for(int iw=0; iw<nwalk; iw++) {
-        ma::ph_excited_2body_energy_dense_cholesky_Tpna(iexcit.origin(), refc.origin(),
-		T.sliced(iw,iw+1), R.sliced(iw,iw+1), wgt(boost::multi::ALL, {iw,iw+1}), 
-		E.sliced(iw,iw+1).rotated()[0], E.sliced(iw,iw+1).rotated()[1], 
-		KE(boost::multi::ALL,{iw,iw+1},boost::multi::ALL));
-      }
-      double tgpu2(timer.elapsed());
-      {
-        boost::multi::array<ComplexType, 2> tmp(E);
-        boost::multi::array<ComplexType, 3> tmpK(KE);
-        for(int iw=0; iw<nwalk; iw++) {
-          REQUIRE(std::real(tmp[iw][0]) == Approx(std::real(EX[0])));
-          REQUIRE(std::imag(tmp[iw][0]) == Approx(std::imag(EX[0])));
-          REQUIRE(std::real(tmp[iw][1]) == Approx(std::real(EJ[0])));
-          REQUIRE(std::imag(tmp[iw][1]) == Approx(std::imag(EJ[0])));
-        }
-        for(int id=0; id<ndet; id++) {
-        for(int iw=0; iw<nwalk; iw++) {
-        for(int n=0; n<nchol; n++) {
-          REQUIRE(std::real(tmpK[id][iw][n]) == Approx(std::real(KE_[id][0][n])));
-          REQUIRE(std::imag(tmpK[id][iw][n]) == Approx(std::imag(KE_[id][0][n])));
-        }
-        }
-        }
-      }
-//      std::cout<<"    " <<nwalk <<"     " <<tcpu*nwalk <<" " <<tgpu <<" " <<tgpu2 <<"   -   " <<tgpu/tgpu2 <<std::endl; 
-    }  
-  }
-  host_buffer.release();
-  device_buffer.release();
-}
-*/
-#else
-TEST_CASE("test_ph_excited_energy_real_dense_cholesky", "[Numerics][misc_kernels]")
-{
-  constexpr MEMORY_SPACE MEM = HOST_MEMORY;
-  auto& mpi = utils::make_unit_test_mpi_context();
+template<MEMORY_SPACE MEM>
+void test_ph_excited_energy_real_dense_cholesky() {
+  
+
   int ndet = 50;
   int nelec = 5;
   int nact = 10;
   int nchol = 50;
   int nw = 1;
-  std::mt19937 generator(0);
-  std::normal_distribution<RealType> distribution(0.0, 1.0);
+
+  nda::matrix<ComplexType> EXJ_ref = {
+    {{-3.710389910208285,-666.8601775126258}, {-448.4580805193352,260.52361637250124}},
+    {{257.47347099950423,1000.2224737398957}, {-823.4796831379458,-1004.1196065341555}},
+    {{782.6224431929506,-1540.7376072631007}, {-183.51974621436153,85.49030799002679}},
+    {{2023.4979464340804,-36.30962737644677}, {1682.3242532758773,-442.1588977259531}},
+    {{314.60033183810424,-4993.354550714809}, {-1238.764790338722,-604.3447621988698}},
+  };
+  
   //for(int nex=1; nex<21; nex++) 
   for(int nex=1; nex<6; nex++) 
   {
 //    std::cout<<" # excitations: " <<nex <<std::endl;
-    memory::array<MEM,ComplexType, 4> Tna(nw, nelec, nchol, nact);
-    memory::array<MEM,ComplexType, 4> R(nw, ndet, nex, nact);
-    memory::array<MEM,ComplexType, 2> wgt(ndet, nw); 
-    memory::array<MEM,ComplexType, 3> KE(ndet, nw, nchol);
-    memory::array<MEM,int, 2> orbs(ndet,nelec);
-    memory::array<MEM,int, 2> iexcit(ndet,2*nex);
-    memory::array<MEM,int, 1> refc(nelec);
-    for(int i=0; i<nelec; i++) refc(i)=i;
+    nda::array<ComplexType, 4> Tna(nw, nelec, nchol, nact);
+    nda::array<ComplexType, 4> R(nw, ndet, nex, nact);
+    nda::array<ComplexType, 2> wgt(ndet, nw); 
+    nda::array<int, 2> orbs(ndet,nelec);
+    nda::array<int, 2> iexcit(ndet,2*nex);
+    nda::array<int, 1> refc(nelec);
+
+    for(int i=0; i<nelec; i++) {
+      refc(i) = i;
+    }
+    
     {
       nda::vector<ComplexType> tmp( std::max(Tna.size(), R.size()) );
-      for(int i=0; i<tmp.size(); ++i)
-        tmp(i) = ComplexType(distribution(generator),distribution(generator));
-      std::copy_n(tmp.data(), Tna.size(), Tna.data());
-      std::copy_n(tmp.data(), R.size(), R.data());
-      std::copy_n(tmp.data(), wgt.size(), wgt.data());
-      nda::vector<int> tmpi(nex);
+      for(int i=0; i<Tna.size(); ++i) {
+        nda::flatten(Tna)(i) = ComplexType(sin(i), cos(i*i));
+      }
+      for(int i=0; i<R.size(); ++i) {
+        nda::flatten(R)(i) = ComplexType(sin(i*3), cos(i+i*i));
+      }
+      for(int i=0; i<wgt.size(); ++i) {
+        nda::flatten(wgt)(i) = ComplexType(sin(i*2), cos(i-2*i*i));
+      }
+
       {  
-        std::uniform_int_distribution<int> u_distribution(0, nelec-1);
         nda::vector<int> iocc(nelec, 0);
         for(int nd=0; nd<ndet; nd++) {
           iocc() = 0;
           for(int i=0; i<nex; i++) {
-            int v = u_distribution(generator);
-            while( iocc(v) != 0 ) {
-              v = u_distribution(generator);
+            int v = (i*i) % nelec;
+            while(iocc(v) != 0) {
+              v = (v + 1) % nelec;
             }
             iocc(v)=1;
             iexcit(nd,i) = v;
@@ -245,29 +95,48 @@ TEST_CASE("test_ph_excited_energy_real_dense_cholesky", "[Numerics][misc_kernels
         }
       }  
       {
-        std::uniform_int_distribution<int> u_distribution(0, nact-nelec-1);
         nda::vector<int> iocc(nact-nelec, 0);
         for(int nd=0; nd<ndet; nd++) {
           iocc() = 0;
           for(int i=0; i<nex; i++) {
-            int v = u_distribution(generator);
-            while( iocc(v) != 0 ) {
-              v = u_distribution(generator);
+            int v = (i+i*i) % (nact-nelec);
+            while(iocc(v) != 0) {
+              v = (v+1) % (nact-nelec);
             }
-            iocc(v)=1;
+            iocc(v) = 1;
             iexcit(nd,i+nex) = v+nelec;
           }
         }
       }
     }
+    memory::array<MEM, ComplexType, 3> KE(ndet, nw, nchol);
+    memory::array<MEM,ComplexType,1> EJ(nw, 0.0);
+    memory::array<MEM,ComplexType,1> EX(nw, 0.0);
+    auto iexcit_d = memory::to_memory_space<MEM>(nda::flatten(iexcit));
+    auto refc_d = memory::to_memory_space<MEM>(refc);
+    auto Tna_d = memory::to_memory_space<MEM>(Tna);
+    auto R_d = memory::to_memory_space<MEM>(R);
+    auto wgt_d = memory::to_memory_space<MEM>(wgt);
     Watch timer;
-    nda::vector<ComplexType> EJ(nw, 0.0);
-    nda::vector<ComplexType> EX(nw, 0.0);
+    ph_excited_2body_energy_dense_cholesky(iexcit_d, refc_d, Tna_d, R_d, wgt_d, EX, EJ, KE);
     timer.reset();
-    ph_excited_2body_energy_dense_cholesky(nda::flatten(iexcit), refc,Tna, R, wgt, EX, EJ, KE); 
-//    std::cout<<"    " <<tcpu1 <<" " <<tcpu2 <<std::endl; 
+    
+
+    arch::synchronize();
+    
+    app_log(1, "{{{:15}, {:15}}}", nda::to_host(EX)[0], nda::to_host(EJ)[0]);
+    
+    utils::ARRAY_EQUAL(nda::to_host(EX), nda::vector{{EXJ_ref(nex-1, 0)}});
+    utils::ARRAY_EQUAL(nda::to_host(EJ), nda::vector{{EXJ_ref(nex-1, 1)}});
+    //    std::cout<<"    " <<tcpu1 <<" " <<tcpu2 <<std::endl;
   }  
 }
+
+TEST_CASE("test_ph_excited_energy_real_dense_cholesky", "[Numerics][misc_kernels]") {
+  test_ph_excited_energy_real_dense_cholesky<HOST_MEMORY>();
+#if defined(ENABLE_DEVICE)
+  test_ph_excited_energy_real_dense_cholesky<DEVICE_MEMORY>();
 #endif
+}
 
 } // namespace sfqmc

--- a/src/IO/fmt_extensions.hpp
+++ b/src/IO/fmt_extensions.hpp
@@ -23,21 +23,22 @@
 #include <spdlog/fmt/bundled/ranges.h>
 
 template <> struct fmt::formatter<std::complex<double>> {
-  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it == end || *it == '}') return it;
-    if (*it == 'f') ++it;
-    if (it != end && *it != '}')
-      throw format_error("invalid format");
-    return it;
+  fmt::formatter<double> inner;
+  
+  constexpr auto parse(format_parse_context& ctx) {
+    return inner.parse(ctx);
   }
 
   template <typename FormatContext>
-  auto format(const std::complex<double>& p, FormatContext& ctx) -> decltype(ctx.out()) {
-    return format_to(
-        ctx.out(),
-        "({:f}, {:f})", 
-        std::real(p), std::imag(p));
+  auto format(const std::complex<double>& p, FormatContext& ctx) {
+    auto out = ctx.out();
+    *out++ = '(';
+    out = inner.format(std::real(p), ctx);
+    *out++ = ',';
+    ctx.advance_to(out);
+    out = inner.format(std::imag(p), ctx);
+    *out++ = ')';
+    return out;
   }
 };
 

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -157,16 +157,16 @@ using array_view = std::conditional_t<MEM==HOST_MEMORY, host_array_view<T,N,Layo
                                                            default_array_view<T,N,Layout>>>>;
 
 template<MEMORY_SPACE MEM>
-auto to_memory_space(auto &&A)
+decltype(auto) to_memory_space(auto &&A)
 {
   if constexpr (MEM==HOST_MEMORY) {
-    return nda::to_host(A);
+    return nda::to_host(std::forward<decltype(A)>(A));
   } else if constexpr (MEM==DEVICE_MEMORY) {
-    return nda::to_device(A);
+    return nda::to_device(std::forward<decltype(A)>(A));
   } else if constexpr (MEM==UNIFIED_MEMORY) {
-    return nda::to_unified(A);
+    return nda::to_unified(std::forward<decltype(A)>(A));
   } else {
-    return to_memory_space<DEFAULT_MEMORY_SPACE>(A); 
+    return to_memory_space<DEFAULT_MEMORY_SPACE>(std::forward<decltype(A)>(A)); 
   }
 }
 

--- a/src/numerics/device_kernels/cuda/phmsd_determinants.cu
+++ b/src/numerics/device_kernels/cuda/phmsd_determinants.cu
@@ -336,7 +336,7 @@ void phmsd_compact_R_impl(int nex, int const* refc, int const* iex, T_t const& T
         long iw   = n/ndet;
         long idet = n - iw*ndet;
         int const* x = iex + 6*idet;
-        ov_d(idet,iw) = _D3x3_(T_d(iw,x[3],x[0]),T_d(iw,x[3],x[1]),T_d(iw,x[3],x[2]),
+        ov_d(iw,idet) = _D3x3_(T_d(iw,x[3],x[0]),T_d(iw,x[3],x[1]),T_d(iw,x[3],x[2]),
                              T_d(iw,x[4],x[0]),T_d(iw,x[4],x[1]),T_d(iw,x[4],x[2]),
                              T_d(iw,x[5],x[0]),T_d(iw,x[5],x[1]),T_d(iw,x[5],x[2]));
         if(abs(ov_d(iw,idet)) != 0) { 
@@ -355,7 +355,7 @@ void phmsd_compact_R_impl(int nex, int const* refc, int const* iex, T_t const& T
         long iw   = n/ndet;
         long idet = n - iw*ndet;
         int const* x = iex + 8*idet;
-        ov_d(idet,iw) = D4x4(T_d(iw,x[4],x[0]),T_d(iw,x[4],x[1]),T_d(iw,x[4],x[2]),T_d(iw,x[4],x[3]),
+        ov_d(iw,idet) = D4x4(T_d(iw,x[4],x[0]),T_d(iw,x[4],x[1]),T_d(iw,x[4],x[2]),T_d(iw,x[4],x[3]),
                              T_d(iw,x[5],x[0]),T_d(iw,x[5],x[1]),T_d(iw,x[5],x[2]),T_d(iw,x[5],x[3]),
                              T_d(iw,x[6],x[0]),T_d(iw,x[6],x[1]),T_d(iw,x[6],x[2]),T_d(iw,x[6],x[3]),
                              T_d(iw,x[7],x[0]),T_d(iw,x[7],x[1]),T_d(iw,x[7],x[2]),T_d(iw,x[7],x[3]));

--- a/src/numerics/nda_functions.hpp
+++ b/src/numerics/nda_functions.hpp
@@ -374,6 +374,34 @@ void gemm(A const &a, B const &b, C &&c)
 
 }
 
+namespace lapack
+{
+
+// checks lapack info and zeros output if inversion has failed. CPU lapack seems to do this
+// (sometimes?), but cusolve can fill A with nans, which will break subsequent usage.
+//
+// This function is useful for example when calculating the mixed one-rdm, where it can happen that the overlap between
+// Slater determinants is zero, leading to a singularity that does not matter because in the final form, A does not contribute.
+auto getri_or_zero(MemoryArray auto &&A, MemoryArray auto&& ipiv, MemoryArray auto&& work) {
+  auto infos = nda::lapack::getri(A,ipiv,work);
+  int idx{};
+  if constexpr (nda::get_rank<std::decay_t<decltype(A)>> == 2) {
+    if(infos != 0) {
+      A() = 0;
+    }
+  } else {
+    for(int info : infos) {
+      if(info != 0) { // singular
+        A(idx,nda::ellipsis{}) = 0;
+      }
+      idx++;
+    }
+  }
+  return infos;
+}
+
+}
+
 namespace tensor
 {
 


### PR DESCRIPTION
Uncommenting the estimators test uncovered a whole wrange of bugs that are fixed by this PR.

- c++/tests: reactivate commented test_estimators
- c++/observables: simplify full1rdm
- c++/SlaterDeteminantOperations: fix nan on GPU with orthogonal determinants
- c++/tests: simplify test_estimators.cpp
- c++/models/Discrete_GeneralUJ: check dt > 0 and avoid dt = 0 in estimator test
- c++/tests: remove finiteT from estimators test
- c++/NOMSD: fix wrong spin index in collinear getReferences
- c++/PHMSD: correctly handle closed trial with collinear walkers.
