### PR TITLE
Bugfixes

### DIFF
--- a/src/AFQMC/AFQMCFactory.h
+++ b/src/AFQMC/AFQMCFactory.h
@@ -30,8 +30,8 @@
 #include <cstdlib>
 
 #include "config.h"
-#include "arch/arch.h"
 #include "IO/ptree/ptree_utilities.hpp"
+#include "utilities/threading.h"
 #include "utilities/mpi_context.h"
 
 #include "AFQMC/Walkers/WalkerSetFactory.hpp"
@@ -57,7 +57,7 @@ namespace afqmc
   * - DriverFactory DriverFac
 
  *
- * @param type std::string describing the type of Driver to be used. Valid choices are "afqmc", "legacy_afqmc", and "csafqmc".
+ * @param type std::string describing the type of Driver to be used. Valid choices are "afqmc", and "csafqmc".
   * @param pt boost::property_tree::ptree The property tree containing input file parameters
  */
 template<MEMORY_SPACE MEM>
@@ -88,10 +88,10 @@ public:
     app_log(1, "    -- MPI tasks      : {} ", mpi->comm.size());
     app_log(1, "    -- Compute Device    : {} ", (MEM==DEVICE_MEMORY?"gpu":"cpu")); 
     app_log(1, "    -- TBLIS_NUM_THREADS : {} {}", std::getenv("TBLIS_NUM_THREADS"),
-            sfqmc::arch::tblis_threads_was_user_set() ? "(user-provided)" : "");
+            sfqmc::utils::tblis_threads_was_user_set() ? "(user-provided)" : "");
     app_log(1, "    -- OMP_NUM_THREADS   : {} {}\n\n", std::getenv("OMP_NUM_THREADS"),
-            sfqmc::arch::omp_threads_was_user_set() ? "(user-provided)" : "");
-    sfqmc::arch::check_thread_oversubscription(static_cast<int>(mpi->node_comm.size()));
+            sfqmc::utils::omp_threads_was_user_set() ? "(user-provided)" : "");
+    sfqmc::utils::check_thread_oversubscription(static_cast<int>(mpi->node_comm.size()));
 
     // parse input
     utils::check(parse(pt), " Error in AFQMCFactory: Problems parsing the input file. ");

--- a/src/AFQMC/AFQMCFactory.h
+++ b/src/AFQMC/AFQMCFactory.h
@@ -91,8 +91,6 @@ public:
             sfqmc::utils::tblis_threads_was_user_set() ? "(user-provided)" : "");
     app_log(1, "    -- OMP_NUM_THREADS   : {} {}\n\n", std::getenv("OMP_NUM_THREADS"),
             sfqmc::utils::omp_threads_was_user_set() ? "(user-provided)" : "");
-    sfqmc::utils::check_thread_oversubscription(static_cast<int>(mpi->node_comm.size()));
-
     // parse input
     utils::check(parse(pt), " Error in AFQMCFactory: Problems parsing the input file. ");
 

--- a/src/AFQMC/AFQMCFactory.h
+++ b/src/AFQMC/AFQMCFactory.h
@@ -27,8 +27,10 @@
 #include <map>
 #include <queue>
 #include <algorithm>
+#include <cstdlib>
 
 #include "config.h"
+#include "arch/arch.h"
 #include "IO/ptree/ptree_utilities.hpp"
 #include "utilities/mpi_context.h"
 
@@ -84,7 +86,12 @@ public:
     app_log(1, "    -- MPI tasks/node : {} ", mpi->node_comm.size());
     app_log(1, "    -- MPI nodes      : {} ", mpi->internode_comm.size());
     app_log(1, "    -- MPI tasks      : {} ", mpi->comm.size());
-    app_log(1, "    -- Compute Device : {} \n\n", (MEM==DEVICE_MEMORY?"gpu":"cpu")); 
+    app_log(1, "    -- Compute Device    : {} ", (MEM==DEVICE_MEMORY?"gpu":"cpu")); 
+    app_log(1, "    -- TBLIS_NUM_THREADS : {} {}", std::getenv("TBLIS_NUM_THREADS"),
+            sfqmc::arch::tblis_threads_was_user_set() ? "(user-provided)" : "");
+    app_log(1, "    -- OMP_NUM_THREADS   : {} {}\n\n", std::getenv("OMP_NUM_THREADS"),
+            sfqmc::arch::omp_threads_was_user_set() ? "(user-provided)" : "");
+    sfqmc::arch::check_thread_oversubscription(static_cast<int>(mpi->node_comm.size()));
 
     // parse input
     utils::check(parse(pt), " Error in AFQMCFactory: Problems parsing the input file. ");

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -937,7 +937,9 @@ public:
 
   /// Returns the number of spins and polarizations in the VHS potential.
   std::tuple<int,int> vHS_dims() const {
-    return std::make_tuple(1,1);
+    int nspin_in_H = hij.extent(0);
+    int npol_in_H = hij.extent(2)/nbnd;
+    return std::make_tuple(nspin_in_H, npol_in_H);
   }
   int number_of_ke_vectors() const { return 2 * ncvecs; }
   int number_of_cholesky_vectors() const { return 2 * ncvecs; }

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -73,6 +73,7 @@ public:
   {
     utils::check(bool(mpi), "Error: Null mpi_context.");
     std::tie(nspins_in_vHS, npol_in_vHS) = wfn->vHS_dims();
+    app_log(1," vHS dimensions: nspins = {}, npol = {}", nspins_in_vHS, npol_in_vHS);
     // convert user input to verbose input
     ptree pt = interpret_inputs(pt_in);
     app_log(2,"\nBasePropagator input:\n\n{}\n",io::to_string(pt));

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -604,7 +604,7 @@ void AFQMCBasePropagator<MEM>::assemble_X(RealType sqrtdt,
     kernels::device::construct_X(use_cp_constraint or use_real_vbias,free_projection,sqrtdt, vbias_bound, FieldTypes_dev, vMF, MF, HWs, RNGbuff, X);
 #endif
   } else {
-    detail::construct_X_impl construct_X{use_cp_constraint || use_real_vbias, free_projection, sqrtdt, vbias_bound, FieldTypes, vMF(), MF, HWs, RNGbuff, X};
+    detail::construct_X_impl construct_X{use_cp_constraint || use_real_vbias, free_projection, sqrtdt, vbias_bound, FieldTypes, vMF(), MF(), HWs(), RNGbuff(), X()};
     for(int i=0; i < X.size(); i++) {
       construct_X(i);
     }

--- a/src/AFQMC/Propagators/WalkerSetUpdate.hpp
+++ b/src/AFQMC/Propagators/WalkerSetUpdate.hpp
@@ -18,298 +18,312 @@
 
 #include <algorithm>
 
-#include "config.h"
-#include "AFQMC/config.h"
-#include "utilities/check.hpp"
 #include "AFQMC/Walkers/WalkerConfig.hpp"
+#include "AFQMC/config.h"
+#include "config.h"
+#include "utilities/check.hpp"
 
-namespace sfqmc
-{
-namespace afqmc
-{
-template<class Wlk>
-void free_projection_walker_update(Wlk& w,
-                                   RealType dt,
-                                   nda::MemoryVector auto&& overlap,
-                                   nda::MemoryVector auto&& MFfactor,
+namespace sfqmc {
+namespace afqmc {
+template <class Wlk>
+void free_projection_walker_update(Wlk &w, RealType dt,
+                                   nda::MemoryVector auto &&overlap,
+                                   nda::MemoryVector auto &&MFfactor,
                                    RealType Eshift,
-                                   nda::MemoryVector auto&& hybrid_weight,
-                                   bool debug_verbosity)
-{
+                                   nda::MemoryVector auto &&hybrid_weight,
+                                   bool debug_verbosity) {
   auto all = nda::range::all;
   int nwalk = w.size();
   nda::range rng(nwalk);
-  memory::buffered_array<HOST_MEMORY,ComplexType,2> work(11,nwalk);
-  w.getProperty(WEIGHT, work(0,all));
-  w.getProperty(PHASE, work(1,all));
-  w.getProperty(PSEUDO_ELOC_, work(2,all));
-  w.getProperty(OVLP, work(3,all));
-  work(4,all) = overlap(rng);
-  work(5,all) = MFfactor(rng);
-  work(6,all) = hybrid_weight(rng);
+  memory::buffered_array<HOST_MEMORY, ComplexType, 2> work(11, nwalk);
+  auto weight = work(0, all);
+  auto phase = work(1, all);
+  auto pseudo_eloc = work(2, all);
+  auto ovlp = work(3, all);
+  auto new_ovlp = work(4, all);
+  auto mf_factor = work(5, all);
+  auto hyb_weight = work(6, all);
+  w.getProperty(WEIGHT, weight);
+  w.getProperty(PHASE, phase);
+  w.getProperty(PSEUDO_ELOC_, pseudo_eloc);
+  w.getProperty(OVLP, ovlp);
+  new_ovlp = overlap(rng);
+  mf_factor = MFfactor(rng);
+  hyb_weight = hybrid_weight(rng);
 
-  for (int i = 0; i < nwalk; i++)
-  {
-    ComplexType old_ovlp = work(3,i);
-    ComplexType old_eloc = work(2,i);
+  for (int i = 0; i < nwalk; i++) {
+    ComplexType old_ovlp = ovlp(i);
+    ComplexType old_eloc = pseudo_eloc(i);
     ComplexType eloc;
     ComplexType ratioOverlaps = ComplexType(1.0, 0.0);
-    eloc                      = work(5,i) / dt;
-    ComplexType factor        = std::exp(-dt * (0.5 * (eloc + old_eloc) - Eshift));
-  
-    if (debug_verbosity)
-    {
-      std::cout << " update: iw:       " <<i <<"\n"     
-        << "    eloc:          " << eloc << "\n"
-        << "    ov:            " << work(4,i) << "\n"
-        << "    old_ov:        " << old_ovlp << "\n"
-        << "    old_eloc:      " << old_eloc<< "\n"
-        << "    old_weight:    " << work(0,i) << "\n"
-        << "    ratio:         " << ratioOverlaps << "\n"
-        << "    MFfactor:      " << work(5,i) << "\n"
-        << "    hybrid_weight: " << work(6,i) << "\n"
-        << "    Eshift:         " << Eshift << "\n"
-        << "    factor:         " << factor << "\n"
-        << std::endl;
+    eloc = mf_factor(i) / dt;
+    ComplexType factor = std::exp(-dt * (0.5 * (eloc + old_eloc) - Eshift));
+
+    if (debug_verbosity) {
+      std::cout << " update: iw:       " << i << "\n"
+                << "    eloc:          " << eloc << "\n"
+                << "    ov:            " << new_ovlp(i) << "\n"
+                << "    old_ov:        " << old_ovlp << "\n"
+                << "    old_eloc:      " << old_eloc << "\n"
+                << "    old_weight:    " << weight(i) << "\n"
+                << "    ratio:         " << ratioOverlaps << "\n"
+                << "    MFfactor:      " << mf_factor(i) << "\n"
+                << "    hybrid_weight: " << hyb_weight(i) << "\n"
+                << "    Eshift:         " << Eshift << "\n"
+                << "    factor:         " << factor << "\n"
+                << std::endl;
     }
-    
-    work(0,i) *= std::abs(factor);
-    work(1,i) *= factor / std::abs(factor);
-    work(2,i) = eloc;
-    work(3,i) = work(4,i);
+
+    weight(i) *= std::abs(factor);
+    phase(i) *= factor / std::abs(factor);
+    pseudo_eloc(i) = eloc;
+    ovlp(i) = new_ovlp(i);
   }
 
-  w.setProperty(WEIGHT, work(0,all));
-  w.setProperty(PHASE, work(1,all));
-  w.setProperty(PSEUDO_ELOC_, work(2,all));
-  w.setProperty(OVLP, work(3,all));
+  w.setProperty(WEIGHT, weight);
+  w.setProperty(PHASE, phase);
+  w.setProperty(PSEUDO_ELOC_, pseudo_eloc);
+  w.setProperty(OVLP, ovlp);
 }
 
-template<class Wlk>
-void hybrid_walker_update(Wlk& w,
-                          RealType dt,
-                          bool apply_constrain,
-                          bool imp_sampl,
-                          RealType Eshift,
-                          nda::MemoryVector auto&& overlap,
-                          nda::MemoryVector auto&& MFfactor,
-                          nda::MemoryVector auto&& hybrid_weight,
-                          double lower_cutoff_scale,
-                          double upper_cutoff_scale,
-                          bool symmetric_split,
-                          bool debug_verbosity = false,
-                          bool use_cp_constraint = false)
-{
+template <class Wlk>
+void hybrid_walker_update(Wlk &w, RealType dt, bool apply_constrain,
+                          bool imp_sampl, RealType Eshift,
+                          nda::MemoryVector auto &&overlap,
+                          nda::MemoryVector auto &&MFfactor,
+                          nda::MemoryVector auto &&hybrid_weight,
+                          double lower_cutoff_scale, double upper_cutoff_scale,
+                          bool symmetric_split, bool debug_verbosity = false,
+                          bool use_cp_constraint = false) {
   auto all = nda::range::all;
   int nwalk = w.size();
   bool BackProp = (w.getBPPos() >= 0 && w.getBPPos() < w.NumBackProp());
   nda::range rng(nwalk);
-  memory::buffered_array<HOST_MEMORY,ComplexType,2> work(11,nwalk);
-  w.getProperty(WEIGHT, work(0,all));
-  w.getProperty(PSEUDO_ELOC_, work(1,all));
-  w.getProperty(OVLP, work(2,all));
-  w.getProperty(PHASE1, work(7,all));
-  w.getProperty(PHASE2, work(8,all));
-  w.getProperty(PHASE3, work(9,all));
-  work(4,all) = overlap(rng);
-  work(5,all) = MFfactor(rng);
-  work(6,all) = hybrid_weight(rng);
+  memory::buffered_array<HOST_MEMORY, ComplexType, 2> work(11, nwalk);
+  auto weight = work(0, all);
+  auto pseudo_eloc = work(1, all);
+  auto ovlp = work(2, all);
+  auto weight_factor = work(3, all);
+  auto new_ovlp = work(4, all);
+  auto mf_factor = work(5, all);
+  auto hyb_weight = work(6, all);
+  auto phase1 = work(7, all);
+  auto phase2 = work(8, all);
+  auto phase3 = work(9, all);
+  auto theta = work(10, all);
+  w.getProperty(WEIGHT, weight);
+  w.getProperty(PSEUDO_ELOC_, pseudo_eloc);
+  w.getProperty(OVLP, ovlp);
+  w.getProperty(PHASE1, phase1);
+  w.getProperty(PHASE2, phase2);
+  w.getProperty(PHASE3, phase3);
+  new_ovlp = overlap(rng);
+  mf_factor = MFfactor(rng);
+  hyb_weight = hybrid_weight(rng);
 
-  for (int i = 0; i < nwalk; i++)
-  {
-    ComplexType old_ovlp = work(2,i);
-    ComplexType old_eloc = work(1,i);
+  for (int i = 0; i < nwalk; i++) {
+    ComplexType old_ovlp = ovlp(i);
+    ComplexType old_eloc = pseudo_eloc(i);
     ComplexType eloc;
     RealType delta_theta;
-    RealType scale            = 1.0;
+    RealType scale = 1.0;
     ComplexType ratioOverlaps = ComplexType(1.0, 0.0);
 
     if (imp_sampl)
-    {
-      auto dbg_tmp1 = work(4,i);
-      ratioOverlaps = std::exp(dbg_tmp1 - old_ovlp);
-    }
+      ratioOverlaps = std::exp(new_ovlp(i) - old_ovlp);
 
-    ComplexType ratioOverlaps_ = ratioOverlaps;
-    
-    if (!std::isfinite(ratioOverlaps.real()) && apply_constrain && imp_sampl)
-    {
+    if (!std::isfinite(ratioOverlaps.real()) && apply_constrain && imp_sampl) {
       scale = 0.0;
-      eloc  = old_eloc;
-    }
-    else
-    {
+      eloc = old_eloc;
+    } else {
       // save constraint theta for sanity checks
-      delta_theta = std::arg(ratioOverlaps) - work(5,i).imag();
-      work(10,i) = delta_theta;
-      if (use_cp_constraint)
-      {
-        // if real part of ratioOverlaps is positive, scale is 1.0 otherwise, scale is 0.0
+      delta_theta = std::arg(ratioOverlaps) - mf_factor(i).imag();
+      theta(i) = delta_theta;
+      if (use_cp_constraint) {
+        // if real part of ratioOverlaps is positive, scale is 1.0 otherwise,
+        // scale is 0.0
         scale = (std::cos(delta_theta) > 0.0 ? 1.0 : 0.0);
         ratioOverlaps = std::real(ratioOverlaps); // is this needed?
-      }
-      else 
-      {
+      } else {
         scale = (apply_constrain ? std::max(0.0, std::cos(delta_theta)) : 1.0);
       }
-      
+
       if (imp_sampl)
-        eloc = (work(5,i) - work(6,i) - std::log(ratioOverlaps_)) / dt;
+        eloc = (mf_factor(i) - hyb_weight(i) - (new_ovlp(i) - old_ovlp)) / dt;
       else
-        eloc = work(5,i) / dt;
+        eloc = mf_factor(i) / dt;
     }
     ComplexType eloc_ = eloc;
 
-    if ((!std::isfinite(eloc.real())) || (std::abs(eloc.real()) < std::numeric_limits<RealType>::min()))
-    {
+    if ((!std::isfinite(eloc.real())) ||
+        (std::abs(eloc.real()) < std::numeric_limits<RealType>::min())) {
       scale = 0.0;
-      eloc  = old_eloc;
-    }
-    else
-    {
-	eloc = ComplexType( std::max( std::min(eloc.real(), 
-			Eshift + upper_cutoff_scale * std::sqrt(2.0 / dt)), 
-			Eshift - lower_cutoff_scale * std::sqrt(2.0 / dt)), eloc.imag());
-    }
-    
-    if (debug_verbosity)
-    {
-    std::cout << " update: iw:       " <<i <<"\n"     
-              << "    eloc:          " << eloc << "\n"
-              << "    eloc_:         " << eloc_ << "\n"
-              << "    ov:            " << work(4,i) << "\n"
-              << "    old_ov:        " << old_ovlp << "\n"
-              << "    old_eloc:      " << old_eloc<< "\n"
-              << "    old_weight:    " << work(0,i) << "\n"
-              << "    ratio:         " << ratioOverlaps << "\n"
-              << "    MFfactor:      " << work(5,i) << "\n"
-              << "    hybrid_weight: " << work(6,i) << "\n"
-              << "    scale:         " << scale << "\n"
-              << "    Eshift:         " << Eshift << "\n"
-              << "    Theta:         " << work(10,i) << "\n"
-              << std::endl;
+      eloc = old_eloc;
+    } else {
+      eloc = ComplexType(
+          std::max(std::min(eloc.real(),
+                            Eshift + upper_cutoff_scale * std::sqrt(2.0 / dt)),
+                   Eshift - lower_cutoff_scale * std::sqrt(2.0 / dt)),
+          eloc.imag());
     }
 
-    if(symmetric_split)
-      work(0,i) *= ComplexType(scale * std::exp(-dt * (0.5 * (eloc.real() + old_eloc.real()) - Eshift)), 0.0);
+    if (debug_verbosity) {
+      std::cout << " update: iw:       " << i << "\n"
+                << "    eloc:          " << eloc << "\n"
+                << "    eloc_:         " << eloc_ << "\n"
+                << "    ov:            " << new_ovlp(i) << "\n"
+                << "    old_ov:        " << old_ovlp << "\n"
+                << "    old_eloc:      " << old_eloc << "\n"
+                << "    old_weight:    " << weight(i) << "\n"
+                << "    ratio:         " << ratioOverlaps << "\n"
+                << "    MFfactor:      " << mf_factor(i) << "\n"
+                << "    hybrid_weight: " << hyb_weight(i) << "\n"
+                << "    scale:         " << scale << "\n"
+                << "    Eshift:         " << Eshift << "\n"
+                << "    Theta:         " << theta(i) << "\n"
+                << std::endl;
+    }
+
+    if (symmetric_split)
+      weight(i) *= ComplexType(
+          scale *
+              std::exp(-dt * (0.5 * (eloc.real() + old_eloc.real()) - Eshift)),
+          0.0);
     else
-      work(0,i) *= ComplexType(scale * std::exp(-dt * (eloc.real() - Eshift)), 0.0);
-    work(1,i) = eloc;
-    work(2,i) = work(4,i);
-    if (scale !=0)
-      work(3,i) = std::exp(-ComplexType(0.0, dt) * (0.5 * (eloc.imag() + old_eloc.imag()))) / scale;
+      weight(i) *=
+          ComplexType(scale * std::exp(-dt * (eloc.real() - Eshift)), 0.0);
+    pseudo_eloc(i) = eloc;
+    ovlp(i) = new_ovlp(i);
+    if (scale != 0)
+      weight_factor(i) = std::exp(-ComplexType(0.0, dt) *
+                                  (0.5 * (eloc.imag() + old_eloc.imag()))) /
+                         scale;
     else
-      work(3,i) = 0.0;
-    work(7,i) *= work(3,i); 
-    work(8,i) = work(4,i); 
-    work(9,i) = scale; // KE: this was originally the cumulative product of "scale"
-                        //    changed to just "scale" since this isn't used anywhere 
+      weight_factor(i) = 0.0;
+    phase1(i) *= weight_factor(i);
+    phase2(i) = new_ovlp(i);
+    phase3(i) =
+        scale; // KE: this was originally the cumulative product of "scale"
+               //    changed to just "scale" since this isn't used anywhere
   }
-  w.setProperty(WEIGHT, work(0,all));
-  w.setProperty(PSEUDO_ELOC_, work(1,all));
-  w.setProperty(OVLP, work(2,all));
-  w.setProperty(PHASE1, work(7,all));
-  w.setProperty(PHASE2, work(8,all));
-  w.setProperty(PHASE3, work(9,all));
-  w.setProperty(THETA, work(10,all));
-  if (BackProp)
-  {
+  w.setProperty(WEIGHT, weight);
+  w.setProperty(PSEUDO_ELOC_, pseudo_eloc);
+  w.setProperty(OVLP, ovlp);
+  w.setProperty(PHASE1, phase1);
+  w.setProperty(PHASE2, phase2);
+  w.setProperty(PHASE3, phase3);
+  w.setProperty(THETA, theta);
+  if (BackProp) {
     auto pos = w.getHistoryPos();
-    auto WFac = w.getWeightFactors();  
-    WFac(all,pos) = work(3,all);
-    auto WHis = w.getWeightHistory();  
-    WHis(all,pos) = work(0,all);
+    auto WFac = w.getWeightFactors();
+    WFac(all, pos) = weight_factor;
+    auto WHis = w.getWeightHistory();
+    WHis(all, pos) = weight;
   }
 }
 
-template<class Wlk>
-void local_energy_walker_update(Wlk& w,
-                                RealType dt,
-                                bool apply_constrain,
+template <class Wlk>
+void local_energy_walker_update(Wlk &w, RealType dt, bool apply_constrain,
                                 RealType Eshift,
-                                nda::MemoryVector auto&& overlap,
-                                nda::MemoryMatrix auto&& energies,
-                                nda::MemoryVector auto&& MFfactor,
-				double lower_cutoff_scale,
-				double upper_cutoff_scale)
-{
+                                nda::MemoryVector auto &&overlap,
+                                nda::MemoryMatrix auto &&energies,
+                                nda::MemoryVector auto &&MFfactor,
+                                double lower_cutoff_scale,
+                                double upper_cutoff_scale) {
   auto all = nda::range::all;
   int nwalk = w.size();
   bool BackProp = (w.getBPPos() >= 0 && w.getBPPos() < w.NumBackProp());
   nda::range rng(nwalk);
-  memory::buffered_array<HOST_MEMORY,ComplexType,2> work(14,nwalk);
-  w.getProperty(WEIGHT, work(0,all));
-  w.getProperty(PSEUDO_ELOC_, work(1,all));
-  w.getProperty(OVLP, work(2,all));
-  w.getProperty(E1_, work(3,all));
-  w.getProperty(EXX_, work(4,all));
-  w.getProperty(EJ_, work(5,all));
-  w.getProperty(PHASE, work(12,all));
-  work(7,all) = overlap(rng);
-  work(8,all) = MFfactor(rng);
-  work(9,all) = energies(rng,0); 
-  work(10,all) = energies(rng,1); 
-  work(11,all) = energies(rng,2); 
+  memory::buffered_array<HOST_MEMORY, ComplexType, 2> work(14, nwalk);
+  auto weight = work(0, all);
+  auto pseudo_eloc = work(1, all);
+  auto ovlp = work(2, all);
+  auto e1 = work(3, all);
+  auto exx = work(4, all);
+  auto ej = work(5, all);
+  auto weight_factor = work(6, all);
+  auto new_ovlp = work(7, all);
+  auto mf_factor = work(8, all);
+  auto new_e1 = work(9, all);
+  auto new_exx = work(10, all);
+  auto new_ej = work(11, all);
+  auto phase = work(12, all);
+  auto theta = work(13, all);
+  w.getProperty(WEIGHT, weight);
+  w.getProperty(PSEUDO_ELOC_, pseudo_eloc);
+  w.getProperty(OVLP, ovlp);
+  w.getProperty(E1_, e1);
+  w.getProperty(EXX_, exx);
+  w.getProperty(EJ_, ej);
+  w.getProperty(PHASE, phase);
+  new_ovlp = overlap(rng);
+  mf_factor = MFfactor(rng);
+  new_e1 = energies(rng, 0);
+  new_exx = energies(rng, 1);
+  new_ej = energies(rng, 2);
 
-  for (int i = 0; i < nwalk; i++)
-  {
-    ComplexType old_ovlp      = work(2,i);
-    ComplexType old_eloc      = work(1,i);
-    ComplexType eloc          = work(9,i) + work(10,i) + work(11,i);
-    RealType scale            = 1.0;
-    ComplexType ratioOverlaps = std::exp(work(7,i) - old_ovlp);
+  for (int i = 0; i < nwalk; i++) {
+    ComplexType old_ovlp = ovlp(i);
+    ComplexType old_eloc = pseudo_eloc(i);
+    ComplexType eloc = new_e1(i) + new_exx(i) + new_ej(i);
+    RealType scale = 1.0;
+    ComplexType ratioOverlaps = std::exp(new_ovlp(i) - old_ovlp);
 
-    if (!std::isfinite((ratioOverlaps * work(8,i)).real()) && apply_constrain)
-    {
+    if (!std::isfinite((ratioOverlaps * mf_factor(i)).real()) &&
+        apply_constrain) {
       scale = 0.0;
-      eloc  = old_eloc;
+      eloc = old_eloc;
+    } else {
+      theta(i) = std::arg(ratioOverlaps) - mf_factor(i).imag();
+      scale =
+          (apply_constrain ? (std::max(0.0, std::cos(std::arg(ratioOverlaps) -
+                                                     mf_factor(i).imag())))
+                           : 1.0);
     }
-    else
-    { 
-      work(13,i) = std::arg(ratioOverlaps) - work(8,i).imag();
-      scale = (apply_constrain ? (std::max(0.0, std::cos(std::arg(ratioOverlaps) - work(8,i).imag()))) : 1.0);
-    }
-    if ((!std::isfinite(eloc.real())) || (std::abs(eloc.real()) < std::numeric_limits<RealType>::min()))
-    {
+    if ((!std::isfinite(eloc.real())) ||
+        (std::abs(eloc.real()) < std::numeric_limits<RealType>::min())) {
       scale = 0.0;
-      eloc  = old_eloc;
-    }
-    else
-    {
-      eloc = ComplexType( std::max( std::min(eloc.real(), 
-			Eshift + upper_cutoff_scale * std::sqrt(2.0 / dt)), 
-			Eshift - lower_cutoff_scale * std::sqrt(2.0 / dt)), eloc.imag());
+      eloc = old_eloc;
+    } else {
+      eloc = ComplexType(
+          std::max(std::min(eloc.real(),
+                            Eshift + upper_cutoff_scale * std::sqrt(2.0 / dt)),
+                   Eshift - lower_cutoff_scale * std::sqrt(2.0 / dt)),
+          eloc.imag());
     }
 
-    work(0,i) *= ComplexType(scale * std::exp(-dt * (0.5 * (eloc.real() + old_eloc.real()) - Eshift)), 0.0);
-    work(6,i) = std::exp(-ComplexType(0.0, dt) * (0.5 * (eloc.imag() + old_eloc.imag()))) / scale;
-    work(12,i) *= work(6,i); 
-    work(1,i) = eloc;
-    work(2,i) = work(7,i);
-    work(3,i) = work(9,i);
-    work(4,i) = work(10,i);
-    work(5,i) = work(11,i);
+    weight(i) *= ComplexType(
+        scale *
+            std::exp(-dt * (0.5 * (eloc.real() + old_eloc.real()) - Eshift)),
+        0.0);
+    weight_factor(i) = std::exp(-ComplexType(0.0, dt) *
+                                (0.5 * (eloc.imag() + old_eloc.imag()))) /
+                       scale;
+    phase(i) *= weight_factor(i);
+    pseudo_eloc(i) = eloc;
+    ovlp(i) = new_ovlp(i);
+    e1(i) = new_e1(i);
+    exx(i) = new_exx(i);
+    ej(i) = new_ej(i);
   }
 
-  w.setProperty(WEIGHT, work(0,all));
-  w.setProperty(PSEUDO_ELOC_, work(1,all));
-  w.setProperty(OVLP, work(2,all));
-  w.setProperty(E1_, work(3,all));
-  w.setProperty(EXX_, work(4,all));
-  w.setProperty(EJ_, work(5,all));
-  w.setProperty(PHASE, work(12,all));
-  w.setProperty(THETA, work(13,all));
-  if (BackProp)
-  {
+  w.setProperty(WEIGHT, weight);
+  w.setProperty(PSEUDO_ELOC_, pseudo_eloc);
+  w.setProperty(OVLP, ovlp);
+  w.setProperty(E1_, e1);
+  w.setProperty(EXX_, exx);
+  w.setProperty(EJ_, ej);
+  w.setProperty(PHASE, phase);
+  w.setProperty(THETA, theta);
+  if (BackProp) {
     auto pos = w.getHistoryPos();
     auto WFac = w.getWeightFactors();
-    WFac(all,pos) = work(6,all);
+    WFac(all, pos) = weight_factor;
     auto WHis = w.getWeightHistory();
-    WHis(all,pos) = work(0,all);
+    WHis(all, pos) = weight;
   }
 }
 
 } // namespace afqmc
 
 } // namespace sfqmc
-

--- a/src/arch/arch.cpp
+++ b/src/arch/arch.cpp
@@ -21,11 +21,10 @@
 
 #include "arch.h"
 
-#include <cstdlib>
-#include <thread>
 #include <nda/nda.hpp>
 
 #include "config.h"
+#include "utilities/threading.h"
 
 
 #if defined(ENABLE_CUDA)
@@ -65,49 +64,12 @@ namespace sfqmc {
 namespace arch
 {
 
-// File-scope flags recording whether each threading variable was already present
-// in the environment when SAFIRE started (i.e. the user provided it explicitly).
-static bool s_tblis_user_set = false;
-static bool s_omp_user_set   = false;
-
-bool tblis_threads_was_user_set() { return s_tblis_user_set; }
-bool omp_threads_was_user_set()   { return s_omp_user_set; }
-
-void check_thread_oversubscription(int tasks_per_node)
-{
-  auto parse_env_int = [](const char* name) -> int {
-    const char* val = std::getenv(name);
-    if (!val) return 1;
-    try { return std::max(1, std::stoi(val)); } catch (...) { return 1; }
-  };
-  const int omp_threads   = parse_env_int("OMP_NUM_THREADS");
-  const int tblis_threads = parse_env_int("TBLIS_NUM_THREADS");
-  const int hw_cpus       = static_cast<int>(std::thread::hardware_concurrency());
-  if (hw_cpus > 0) {
-    if (omp_threads * tasks_per_node > hw_cpus)
-      app_warning("OMP_NUM_THREADS={} x MPI tasks/node={} = {} threads > {} logical CPUs. "
-                  "CPU oversubscription detected. Consider reducing OMP_NUM_THREADS or "
-                  "the number of MPI tasks per node.",
-                  omp_threads, tasks_per_node, omp_threads * tasks_per_node, hw_cpus);
-    if (tblis_threads * tasks_per_node > hw_cpus)
-      app_warning("TBLIS_NUM_THREADS={} x MPI tasks/node={} = {} threads > {} logical CPUs. "
-                  "CPU oversubscription detected. Consider reducing TBLIS_NUM_THREADS or "
-                  "the number of MPI tasks per node.",
-                  tblis_threads, tasks_per_node, tblis_threads * tasks_per_node, hw_cpus);
-  }
-}
-
 void init(bool active_log, int output_level=2, int debug_level=2)
 {
   // setup loggers, can always be changed later
   setup_loggers(active_log, output_level, debug_level);
 
-  // Set TBLIS_NUM_THREADS and OMP_NUM_THREADS to 1 unless the user has already
-  // set them. This prevents accidental CPU oversubscription in MPI parallel runs.
-  s_tblis_user_set = (std::getenv("TBLIS_NUM_THREADS") != nullptr);
-  if (!s_tblis_user_set) ::setenv("TBLIS_NUM_THREADS", "1", 1);
-  s_omp_user_set = (std::getenv("OMP_NUM_THREADS") != nullptr);
-  if (!s_omp_user_set) ::setenv("OMP_NUM_THREADS", "1", 1);
+  sfqmc::utils::init_threading();
 
 #if defined(ENABLE_CUDA)
   cuda::init();

--- a/src/arch/arch.cpp
+++ b/src/arch/arch.cpp
@@ -22,14 +22,13 @@
 #include "arch.h"
 
 #include <cstdlib>
+#include <thread>
 #include <nda/nda.hpp>
 
 #include "config.h"
 
 
 #if defined(ENABLE_CUDA)
-
-// MAM: Consider setting OMP_NUM_THREADS and TBLIS threading variables to 1 here!
 
 #include "CUDA/cuda_init.h"
 #include "CUDA/cuda_sync.h"
@@ -66,16 +65,55 @@ namespace sfqmc {
 namespace arch
 {
 
+// File-scope flags recording whether each threading variable was already present
+// in the environment when SAFIRE started (i.e. the user provided it explicitly).
+static bool s_tblis_user_set = false;
+static bool s_omp_user_set   = false;
+
+bool tblis_threads_was_user_set() { return s_tblis_user_set; }
+bool omp_threads_was_user_set()   { return s_omp_user_set; }
+
+void check_thread_oversubscription(int tasks_per_node)
+{
+  auto parse_env_int = [](const char* name) -> int {
+    const char* val = std::getenv(name);
+    if (!val) return 1;
+    try { return std::max(1, std::stoi(val)); } catch (...) { return 1; }
+  };
+  const int omp_threads   = parse_env_int("OMP_NUM_THREADS");
+  const int tblis_threads = parse_env_int("TBLIS_NUM_THREADS");
+  const int hw_cpus       = static_cast<int>(std::thread::hardware_concurrency());
+  if (hw_cpus > 0) {
+    if (omp_threads * tasks_per_node > hw_cpus)
+      app_warning("OMP_NUM_THREADS={} x MPI tasks/node={} = {} threads > {} logical CPUs. "
+                  "CPU oversubscription detected. Consider reducing OMP_NUM_THREADS or "
+                  "the number of MPI tasks per node.",
+                  omp_threads, tasks_per_node, omp_threads * tasks_per_node, hw_cpus);
+    if (tblis_threads * tasks_per_node > hw_cpus)
+      app_warning("TBLIS_NUM_THREADS={} x MPI tasks/node={} = {} threads > {} logical CPUs. "
+                  "CPU oversubscription detected. Consider reducing TBLIS_NUM_THREADS or "
+                  "the number of MPI tasks per node.",
+                  tblis_threads, tasks_per_node, tblis_threads * tasks_per_node, hw_cpus);
+  }
+}
+
 void init(bool active_log, int output_level=2, int debug_level=2)
 {
   // setup loggers, can always be changed later
   setup_loggers(active_log, output_level, debug_level);
 
+  // Set TBLIS_NUM_THREADS and OMP_NUM_THREADS to 1 unless the user has already
+  // set them. This prevents accidental CPU oversubscription in MPI parallel runs.
+  s_tblis_user_set = (std::getenv("TBLIS_NUM_THREADS") != nullptr);
+  if (!s_tblis_user_set) ::setenv("TBLIS_NUM_THREADS", "1", 1);
+  s_omp_user_set = (std::getenv("OMP_NUM_THREADS") != nullptr);
+  if (!s_omp_user_set) ::setenv("OMP_NUM_THREADS", "1", 1);
+
 #if defined(ENABLE_CUDA)
   cuda::init();
 #endif
 
- // setup shared memory, memory buffers, etc, etc
+  // setup shared memory, memory buffers, etc, etc
 }
 
 // this is a problem if the cuda system is disabled before this is destroyed

--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -50,6 +50,9 @@ namespace arch
   void synchronize_if_set();
   void synchronize();
   void check_device_configuration();
+  bool tblis_threads_was_user_set();
+  bool omp_threads_was_user_set();
+  void check_thread_oversubscription(int tasks_per_node);
 
   // device streams
   extern std::vector<nda::devStream_t> device_streams;

--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -50,9 +50,6 @@ namespace arch
   void synchronize_if_set();
   void synchronize();
   void check_device_configuration();
-  bool tblis_threads_was_user_set();
-  bool omp_threads_was_user_set();
-  void check_thread_oversubscription(int tasks_per_node);
 
   // device streams
   extern std::vector<nda::devStream_t> device_streams;

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(safire_lib
     mpi_context.cpp
     parser.cpp
     freemem.cpp
+    threading.cpp
 )
 
 if(BUILD_UNIT_TESTS)

--- a/src/utilities/threading.cpp
+++ b/src/utilities/threading.cpp
@@ -63,30 +63,4 @@ void init_threading()
                 "be aware of potential CPU oversubscription in MPI runs.",
                 parse_env_int("TBLIS_NUM_THREADS"));
 }
-
-/// @copydoc sfqmc::utils::check_thread_oversubscription
-void check_thread_oversubscription(int tasks_per_node)
-{
-  auto parse_env_int = [](const char* name) -> int {
-    const char* val = std::getenv(name);
-    if (!val) return 1;
-    try { return std::max(1, std::stoi(val)); } catch (...) { return 1; }
-  };
-  const int omp_threads   = parse_env_int("OMP_NUM_THREADS");
-  const int tblis_threads = parse_env_int("TBLIS_NUM_THREADS");
-  const int hw_cpus       = static_cast<int>(std::thread::hardware_concurrency());
-  if (hw_cpus > 0) {
-    if (omp_threads * tasks_per_node > hw_cpus)
-      app_warning("OMP_NUM_THREADS={} x MPI tasks/node={} = {} threads > {} logical CPUs. "
-                  "CPU oversubscription detected. Consider reducing OMP_NUM_THREADS or "
-                  "the number of MPI tasks per node.",
-                  omp_threads, tasks_per_node, omp_threads * tasks_per_node, hw_cpus);
-    if (tblis_threads * tasks_per_node > hw_cpus)
-      app_warning("TBLIS_NUM_THREADS={} x MPI tasks/node={} = {} threads > {} logical CPUs. "
-                  "CPU oversubscription detected. Consider reducing TBLIS_NUM_THREADS or "
-                  "the number of MPI tasks per node.",
-                  tblis_threads, tasks_per_node, tblis_threads * tasks_per_node, hw_cpus);
-  }
-}
-
 } // namespace sfqmc::utils

--- a/src/utilities/threading.cpp
+++ b/src/utilities/threading.cpp
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the Apache License, Version 2.0 License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021-2025 The Simons Foundation, Inc.
+//
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "utilities/threading.h"
+
+#include <cstdlib>
+#include <thread>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "IO/app_loggers.h"
+
+namespace sfqmc::utils {
+
+// File-scope flags recording whether each threading variable was already present
+// in the environment when SAFIRE started (i.e. the user provided it explicitly).
+static bool s_tblis_user_set = false;
+static bool s_omp_user_set   = false;
+
+bool tblis_threads_was_user_set() { return s_tblis_user_set; }
+bool omp_threads_was_user_set()   { return s_omp_user_set; }
+
+/**
+ * @internal
+ * @brief Configure the threading environment for the current process.
+ *
+ * @details
+ * **Threading policy.**
+ * SAFIRE is an MPI-parallel code and does not itself use shared-memory
+ * threading (OpenMP, etc.).  Each MPI rank is expected to run as a
+ * single thread.  Allowing a BLAS or tensor-contraction backend to spawn
+ * additional threads would silently oversubscribe the CPU when many ranks
+ * share a node, degrading performance or causing resource-manager violations.
+ *
+ * This function therefore sets `OMP_NUM_THREADS` and `TBLIS_NUM_THREADS` to
+ * 1 — and calls `omp_set_num_threads(1)` when OpenMP is compiled in — unless
+ * the user has already placed those variables in the environment.  A user who
+ * sets them explicitly is assumed to understand the implications (e.g. they
+ * are intentionally using a multi-threaded BLAS on a node with few ranks) and
+ * is warned if the values exceed 1 so that the choice is visible in the log.
+ *
+ * **Future note.**
+ * For very large system sizes it may become beneficial to introduce intra-node
+ * threading.  If that is added, this function and the policy described here
+ * should be updated accordingly — this docstring is the authoritative
+ * reference for SAFIRE's threading policy.
+ */
+void init_threading()
+{
+  auto parse_env_int = [](const char* name) -> int {
+    const char* val = std::getenv(name);
+    if (!val) return 1;
+    try { return std::max(1, std::stoi(val)); } catch (...) { return 1; }
+  };
+
+  // Set OMP_NUM_THREADS and TBLIS_NUM_THREADS to 1 unless the user has already
+  // set them. This prevents accidental CPU oversubscription in MPI parallel runs.
+  s_omp_user_set = (std::getenv("OMP_NUM_THREADS") != nullptr);
+  if (!s_omp_user_set) {
+    ::setenv("OMP_NUM_THREADS", "1", 1);
+#ifdef _OPENMP
+    omp_set_num_threads(1);
+#endif
+  }
+  s_tblis_user_set = (std::getenv("TBLIS_NUM_THREADS") != nullptr);
+  if (!s_tblis_user_set) ::setenv("TBLIS_NUM_THREADS", "1", 1);
+
+  // Warn if user-set threading variables are > 1 (oversubscription awareness).
+  if (s_omp_user_set && parse_env_int("OMP_NUM_THREADS") > 1)
+    app_warning("OMP_NUM_THREADS={} is set in the environment. Assuming intentional; "
+                "be aware of potential CPU oversubscription in MPI runs.",
+                parse_env_int("OMP_NUM_THREADS"));
+  if (s_tblis_user_set && parse_env_int("TBLIS_NUM_THREADS") > 1)
+    app_warning("TBLIS_NUM_THREADS={} is set in the environment. Assuming intentional; "
+                "be aware of potential CPU oversubscription in MPI runs.",
+                parse_env_int("TBLIS_NUM_THREADS"));
+}
+
+/// @copydoc sfqmc::utils::check_thread_oversubscription
+void check_thread_oversubscription(int tasks_per_node)
+{
+  auto parse_env_int = [](const char* name) -> int {
+    const char* val = std::getenv(name);
+    if (!val) return 1;
+    try { return std::max(1, std::stoi(val)); } catch (...) { return 1; }
+  };
+  const int omp_threads   = parse_env_int("OMP_NUM_THREADS");
+  const int tblis_threads = parse_env_int("TBLIS_NUM_THREADS");
+  const int hw_cpus       = static_cast<int>(std::thread::hardware_concurrency());
+  if (hw_cpus > 0) {
+    if (omp_threads * tasks_per_node > hw_cpus)
+      app_warning("OMP_NUM_THREADS={} x MPI tasks/node={} = {} threads > {} logical CPUs. "
+                  "CPU oversubscription detected. Consider reducing OMP_NUM_THREADS or "
+                  "the number of MPI tasks per node.",
+                  omp_threads, tasks_per_node, omp_threads * tasks_per_node, hw_cpus);
+    if (tblis_threads * tasks_per_node > hw_cpus)
+      app_warning("TBLIS_NUM_THREADS={} x MPI tasks/node={} = {} threads > {} logical CPUs. "
+                  "CPU oversubscription detected. Consider reducing TBLIS_NUM_THREADS or "
+                  "the number of MPI tasks per node.",
+                  tblis_threads, tasks_per_node, tblis_threads * tasks_per_node, hw_cpus);
+  }
+}
+
+} // namespace sfqmc::utils

--- a/src/utilities/threading.cpp
+++ b/src/utilities/threading.cpp
@@ -32,31 +32,7 @@ static bool s_omp_user_set   = false;
 bool tblis_threads_was_user_set() { return s_tblis_user_set; }
 bool omp_threads_was_user_set()   { return s_omp_user_set; }
 
-/**
- * @internal
- * @brief Configure the threading environment for the current process.
- *
- * @details
- * **Threading policy.**
- * SAFIRE is an MPI-parallel code and does not itself use shared-memory
- * threading (OpenMP, etc.).  Each MPI rank is expected to run as a
- * single thread.  Allowing a BLAS or tensor-contraction backend to spawn
- * additional threads would silently oversubscribe the CPU when many ranks
- * share a node, degrading performance or causing resource-manager violations.
- *
- * This function therefore sets `OMP_NUM_THREADS` and `TBLIS_NUM_THREADS` to
- * 1 — and calls `omp_set_num_threads(1)` when OpenMP is compiled in — unless
- * the user has already placed those variables in the environment.  A user who
- * sets them explicitly is assumed to understand the implications (e.g. they
- * are intentionally using a multi-threaded BLAS on a node with few ranks) and
- * is warned if the values exceed 1 so that the choice is visible in the log.
- *
- * **Future note.**
- * For very large system sizes it may become beneficial to introduce intra-node
- * threading.  If that is added, this function and the policy described here
- * should be updated accordingly — this docstring is the authoritative
- * reference for SAFIRE's threading policy.
- */
+/// @copydoc sfqmc::utils::init_threading
 void init_threading()
 {
   auto parse_env_int = [](const char* name) -> int {

--- a/src/utilities/threading.cpp
+++ b/src/utilities/threading.cpp
@@ -51,7 +51,6 @@ void init_threading()
 #endif
   }
   s_tblis_user_set = (std::getenv("TBLIS_NUM_THREADS") != nullptr);
-  if (!s_tblis_user_set) ::setenv("TBLIS_NUM_THREADS", "1", 1);
 
   // Warn if user-set threading variables are > 1 (oversubscription awareness).
   if (s_omp_user_set && parse_env_int("OMP_NUM_THREADS") > 1)

--- a/src/utilities/threading.h
+++ b/src/utilities/threading.h
@@ -1,0 +1,67 @@
+////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the Apache License, Version 2.0 License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021-2025 The Simons Foundation, Inc.
+//
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace sfqmc::utils {
+
+  /**
+   * @brief Initialize the threading environment for the current process.
+   *
+   * @details
+   * Sets `OMP_NUM_THREADS` and `TBLIS_NUM_THREADS` to 1 unless the user has
+   * already placed those variables in the environment, and calls
+   * `omp_set_num_threads(1)` when OpenMP is compiled in.  Emits a warning if
+   * either variable is user-set to a value greater than 1.
+   *
+   * Must be called once during application startup, after loggers are
+   * initialized and before any threading-sensitive library calls.  See
+   * `check_thread_oversubscription` for the complementary MPI-aware check that
+   * should be called once MPI context is available.
+   */
+  void init_threading();
+
+  /**
+   * @internal
+   * @brief Warn if the current threading configuration would oversubscribe the node.
+   *
+   * @param tasks_per_node  Number of MPI ranks sharing this node, used to compute
+   *                        total threads = threads_per_rank × tasks_per_node.
+   *
+   * @details
+   * Because SAFIRE does not use shared-memory threading internally, each rank
+   * is normally configured with a single thread (see `init_threading`).
+   * However, a user may legitimately enable threading in a BLAS or
+   * tensor-contraction backend (e.g. to exploit multi-threaded MKL on a node
+   * with few MPI ranks).  This function provides a runtime sanity check in
+   * that scenario: it reads `OMP_NUM_THREADS` and `TBLIS_NUM_THREADS` from the
+   * environment and emits a warning whenever
+   *
+   *   threads_per_rank × tasks_per_node > hardware logical CPUs
+   *
+   * for either variable.  The check is a best-effort safeguard — it relies on
+   * `std::thread::hardware_concurrency()` which may return 0 on unusual
+   * platforms, in which case no warning is issued.
+   *
+   * If threading is ever adopted natively by SAFIRE, this function should be
+   * revisited alongside `init_threading`.
+   */
+  void check_thread_oversubscription(int tasks_per_node);
+
+  /// Returns true if `TBLIS_NUM_THREADS` was present in the environment at startup.
+  bool tblis_threads_was_user_set();
+
+  /// Returns true if `OMP_NUM_THREADS` was present in the environment at startup.
+  bool omp_threads_was_user_set();
+
+} // namespace sfqmc::utils

--- a/src/utilities/threading.h
+++ b/src/utilities/threading.h
@@ -19,7 +19,12 @@ namespace sfqmc::utils {
    * @brief Initialize the threading environment for the current process.
    *
    * @details
-   * Sets `OMP_NUM_THREADS` and `TBLIS_NUM_THREADS` to 1 unless the user has
+   * Because SAFIRE does not use shared-memory threading internally, each rank
+   * is normally configured with a single thread (see `init_threading`).
+   * However, a user may legitimately enable threading in a BLAS or
+   * tensor-contraction backend (e.g. to exploit multi-threaded MKL on a node
+   * with few MPI ranks).
+   * Sets `OMP_NUM_THREADS` to 1 unless the user has
    * already placed those variables in the environment, and calls
    * `omp_set_num_threads(1)` when OpenMP is compiled in.  Emits a warning if
    * either variable is user-set to a value greater than 1.
@@ -28,35 +33,11 @@ namespace sfqmc::utils {
    * initialized and before any threading-sensitive library calls.  See
    * `check_thread_oversubscription` for the complementary MPI-aware check that
    * should be called once MPI context is available.
+   *
+   * The check is a best-effort safeguard; it is the users responsibility to 
+   * ensure that the environment variables are set appropriately for their use case.  
    */
   void init_threading();
-
-  /**
-   * @internal
-   * @brief Warn if the current threading configuration would oversubscribe the node.
-   *
-   * @param tasks_per_node  Number of MPI ranks sharing this node, used to compute
-   *                        total threads = threads_per_rank × tasks_per_node.
-   *
-   * @details
-   * Because SAFIRE does not use shared-memory threading internally, each rank
-   * is normally configured with a single thread (see `init_threading`).
-   * However, a user may legitimately enable threading in a BLAS or
-   * tensor-contraction backend (e.g. to exploit multi-threaded MKL on a node
-   * with few MPI ranks).  This function provides a runtime sanity check in
-   * that scenario: it reads `OMP_NUM_THREADS` and `TBLIS_NUM_THREADS` from the
-   * environment and emits a warning whenever
-   *
-   *   threads_per_rank × tasks_per_node > hardware logical CPUs
-   *
-   * for either variable.  The check is a best-effort safeguard — it relies on
-   * `std::thread::hardware_concurrency()` which may return 0 on unusual
-   * platforms, in which case no warning is issued.
-   *
-   * If threading is ever adopted natively by SAFIRE, this function should be
-   * revisited alongside `init_threading`.
-   */
-  void check_thread_oversubscription(int tasks_per_node);
 
   /// Returns true if `TBLIS_NUM_THREADS` was present in the environment at startup.
   bool tblis_threads_was_user_set();

--- a/utils/tests/functional/dev_tools/results.py
+++ b/utils/tests/functional/dev_tools/results.py
@@ -200,9 +200,13 @@ class Results:
             )
             results.weight = np.array([weight, dweight])
 
-            # LogOvlpFactor
+            # Log Overlap: old name: LogOvlpFactor new name: LogOvlp, supporting both for now
+            column_name = (
+                "LogOvlpFactor" if "LogOvlpFactor" in open(scalar_file).read()
+                else "LogOvlp"
+            )
             log_ovlp, dlog_ovlp = analyze_scalar_data(
-                dict(fname=scalar_file, xaxis="time", nequil=nequil, column="LogOvlpFactor")
+                dict(fname=scalar_file, xaxis="time", nequil=nequil, column=column_name)
             )
             results.log_ovlp_factor = np.array([log_ovlp, dlog_ovlp])
 

--- a/utils/tests/functional/dev_tools/run_and_record.py
+++ b/utils/tests/functional/dev_tools/run_and_record.py
@@ -291,9 +291,9 @@ class AFQMCHelper:
         }
       }, ''' 
             input_text += '''
-      "population_control_interval": "10",
-      "measure_interval_multiplier": "1",
-      "walker_ortho_interval": "10",
+      "population_control_interval": 10,
+      "measure_interval_multiplier": 1,
+      "walker_ortho_interval": 10,
       "seed": 42
     }
   }

--- a/utils/tests/functional/dev_tools/test_infrastructure.py
+++ b/utils/tests/functional/dev_tools/test_infrastructure.py
@@ -177,16 +177,20 @@ class TestRule:
 def _wfn_is_implemented(case: AFQMCInputSet) -> bool:
     """
     Check if the wavefunction type is implemented.
-    
+
     Currently, only collinear PHMSD wavefunctions are implemented.
     NOMSD wavefunctions are implemented for all spin symmetries.
     """
+    if (
+        case.wavefunction.type == WavefunctionClass.PHMSD
+        and case.walker.spin_symm == SpinSymm.CLOSED
+    ):
+        # this was intentionally not implemented since it would require special handling
+        #     - i.e. perfect pairing
+        return False
     if case.wavefunction.type == WavefunctionClass.PHMSD:
         # currently, only collinear PHMSD wavefunctions are implemented
         return case.wavefunction.spin_symm == SpinSymm.COLLINEAR
-    if case.wavefunction.type == WavefunctionClass.PHMSD and case.walker.spin_symm == SpinSymm.CLOSED:
-        # this was intentionally not implemented since it would require special handling - i.e. perfect pairing
-        return False
     elif case.wavefunction.type == WavefunctionClass.NOMSD:
         return True
     else:


### PR DESCRIPTION
Change:

- addresses #97 by setting OMP_NUM_THREADS and TBLIS_NUM_THREADS to 1 by default if not set in the environment; if set, we keep the value in the environment, and in all cases we check and warn if the cpus are oversubscribed
- fixes unintended copy, with CPU execution, in constuct_X_impl
- fixes functional test rule that incorrectly included closed walkers with PHMSD trial wavefunctions
- updates the LogOvlpFactor (old name) data column to LogOvlp (new name) in test recorded; both names are now supported
- implements missing vHS_dims for KP3IndexFactorization