### PR TITLE
Fix CI and add Docs deployment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ if(ENABLE_CUDA AND FETCH_CCCL)
         cccl
         GIT_REPOSITORY "https://github.com/NVIDIA/cccl.git"
         GIT_TAG        v3.3.3
-        SYSTEM
+        # do not add SYSTEM here because then the CUDA-included headers may have precedence
   )
   FetchContent_MakeAvailable(cccl)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,12 @@ include(CMakePrintHelpers)
 cmake_print_properties(TARGETS MPI::MPI_CXX PROPERTIES INTERFACE_LINK_LIBRARIES INTERFACE_INCLUDE_DIRECTORIES)
 
 ######################################################################
+# HDF5
+# we still use some of the raw HDF5 API. Remove once we no longer do.
+######################################################################
+find_package(HDF5 REQUIRED C HL)
+
+######################################################################
 # nda: a C++ library providing multi-dimensional array classes
 ######################################################################
 if(DEFINED NDA)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,48 +8,87 @@ timeout(time: 1, unit: 'HOURS') {
     buildPod(context: 'docker', dockerfile: 'Dockerfile_jenkins') {
       withEnv([
         "SRC=$WORKSPACE",
-        "BUILD=$WORKSPACE/build"
+        "BUILD=$WORKSPACE/build",
+        "BUILD_DEBUG=$WORKSPACE/build-debug"
       ]) {
-        stage('release') {
-          sh 'mkdir $BUILD'
-          sh '''
-            cd $BUILD && cmake $SRC \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX="." \
-              -DCOMPILE_NDA_TESTS=OFF \
-              -DENABLE_FFTW=ON \
-              -DENABLE_CPPTRACE=OFF \
-              -DENABLE_SPDLOG=ON \
-              -DCTEST_NPROC=$PARALLEL
-          '''
-          sh 'make -C $BUILD -j $PARALLEL'
-          warnError("Tests failed") {
-            sh 'cd $BUILD && ctest --output-on-failure'
+        parallel python: {
+          stage('build docs') {
+            sh '''
+              python3 -m venv $WORKSPACE/venv
+              cd $SRC/utils
+              . $WORKSPACE/venv/bin/activate
+              pip install .[DOCS]
+              cd $SRC/docs
+              make html
+            '''
           }
-        }
-        stage('asan_and_ubsan') {
-          sh '''
-            cd $BUILD && cmake $SRC \
-              -DCMAKE_BUILD_TYPE=Debug \
-              -DCMAKE_INSTALL_PREFIX="." \
-              -DCOMPILE_NDA_TESTS=OFF \
-              -DENABLE_FFTW=ON \
-              -DENABLE_CPPTRACE=OFF \
-              -DENABLE_SPDLOG=ON \
-              -DENABLE_ASAN=ON \
-              -DENABLE_UBSAN=ON \
-              -DCTEST_NPROC=$PARALLEL
-          '''
-          sh 'make -C $BUILD -j $PARALLEL'
-          warnError("Tests on Debug with ASAN and UBSAN failed") {
-            sh 'cd $BUILD && ctest --output-on-failure'
+          if (env.BRANCH_NAME in ['main', 'develop', 'overhaul'] || env.TAG_NAME) {
+            stage('deploy docs') {
+              def scm = scmGit(branches: [[name: 'refs/heads/gh-pages']],
+                userRemoteConfigs: [[credentialsId: 'github-jenkins', url: 'https://github.com/SFQMC/sfqmc.github.io.git']])
+              dir(path: 'sfqmc.github.io') {
+                checkout(changelog: false, poll: false, scm: scm)
+                sh '''#!/bin/bash -e
+                  rm -rf docs/$BRANCH_NAME
+                  mkdir -p docs/$BRANCH_NAME
+                  cp -a $SRC/docs/_build/html/. docs/$BRANCH_NAME
+                  if [ -n "$TAG_NAME" ]; then
+                    LATEST=$(git -C $SRC tag --sort=-v:refname | head -n1)
+                    ln -sfn "$LATEST" docs/stable
+                  fi
+                  git add -A docs
+                  if git diff --cached --quiet; then
+                    echo "No documentation changes to deploy."
+                  else
+                    GIT_COMMITTER_EMAIL="jenkins@flatironinstitute.org" GIT_COMMITTER_NAME="SAFIRE CI" git commit --author='SAFIRE CI <jenkins@flatironinstitute.org>' --allow-empty -m "Update SAFIRE docs from build $BUILD_NUMBER"
+                  fi
+                '''
+                gitPush(gitScm: scm, targetBranch: 'gh-pages', targetRepo: 'origin')
+              }
+            }
+          }
+        },
+        cpp_release: {
+          stage('release') {
+            sh 'mkdir $BUILD'
+            sh '''
+              cd $BUILD && cmake $SRC \
+                -GNinja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INSTALL_PREFIX="." \
+                -DCOMPILE_NDA_TESTS=OFF \
+                -DENABLE_CPPTRACE=OFF \
+                -DENABLE_SPDLOG=ON \
+            '''
+            sh 'ninja -C $BUILD -j $PARALLEL'
+            warnError("Tests failed") {
+              sh 'cd $BUILD && ctest --output-on-failure'
+            }
+          }
+        },
+        cpp_debug: {
+          stage('debug') {
+            sh 'mkdir $BUILD_DEBUG'
+            sh '''
+              cd $BUILD_DEBUG && cmake $SRC \
+                -GNinja \
+                -DCMAKE_BUILD_TYPE=Debug \
+                -DCMAKE_INSTALL_PREFIX="." \
+                -DCOMPILE_NDA_TESTS=OFF \
+                -DENABLE_CPPTRACE=OFF \
+                -DENABLE_SPDLOG=ON \
+            '''
+            sh 'ninja -C $BUILD_DEBUG -j $PARALLEL'
+            warnError("Tests on Debug with UBSAN failed") {
+              sh 'cd $BUILD_DEBUG && ctest --output-on-failure'
+            }
           }
         }
       }
     }
   },
   cuda: {
-    buildPod(context: 'docker', dockerfile: 'Dockerfile_jenkins_cuda', tag: 'cuda', gpus: 1) {
+    buildPod(context: 'docker', dockerfile: 'Dockerfile_jenkins_cuda', tag: 'cuda3', gpus: 1) {
       withEnv([
         "SRC=$WORKSPACE",
         "BUILD=$WORKSPACE/build"
@@ -58,18 +97,18 @@ timeout(time: 1, unit: 'HOURS') {
           sh 'mkdir $BUILD'
           sh '''
             cd $BUILD && cmake $SRC \
+              -GNinja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX="." \
               -DCOMPILE_NDA_TESTS=OFF \
-              -DENABLE_FFTW=ON \
               -DENABLE_CPPTRACE=OFF \
               -DENABLE_SPDLOG=ON \
-              -DCTEST_NPROC=4 \
-              -DENABLE_CUDA=ON
+              -DENABLE_CUDA=ON \
+              -DCUDA_ARCH=70
           '''
-          sh 'make -C $BUILD -j $PARALLEL'
+          sh 'ninja -C $BUILD -j $PARALLEL'
           warnError("Tests failed") {
-            sh 'cd $BUILD && ctest --output-on-failure'
+            sh 'cd $BUILD && CUDA_LAUNCH_BLOCKING=1 ctest --output-on-failure'
           }
         }
       }

--- a/docker/Dockerfile_jenkins
+++ b/docker/Dockerfile_jenkins
@@ -7,16 +7,17 @@ RUN apt-get update && apt-get install -y openssh-client git \
    gcc \
    g++ \
    cmake \
+   ninja-build \
    openmpi-bin \
    openmpi-common \
    libopenmpi-dev \
    libopenblas-dev \
-   libhdf5-openmpi-dev \
+   libhdf5-dev \
    python3 \
    python3-pip \
    libboost-dev \
    python3-mpi4py \
-   python3-h5py-mpi \
+   python3-h5py \
    python3-venv
 
 # necessary for building BLIS within TBLIS

--- a/docker/Dockerfile_jenkins_cuda
+++ b/docker/Dockerfile_jenkins_cuda
@@ -2,18 +2,27 @@ FROM docker.io/nvidia/cuda:12.8.1-devel-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y openssh-client git \
+RUN apt-get update && apt-get install -y \
+   openssh-client \
+   git \
    gcc \
    g++ \
    cmake \
+   ninja-build \
    openmpi-bin \
    openmpi-common \
    libopenmpi-dev \
    libopenblas-dev \
-   libhdf5-openmpi-dev \
+   libcutensor2 \
+   libcutensor-dev \
+   libhdf5-dev \
    python3 \
    python3-pip \
    libboost-dev \
    python3-mpi4py \
-   python3-h5py-mpi \
+   python3-h5py \
    python3-venv
+
+# necessary for building BLIS within TBLIS
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(safire_lib PUBLIC
   ${PROJECT_BINARY_DIR}/src/
 )
 
-target_link_libraries(safire_lib PUBLIC nda::nda_c mpi3 Boost::headers cxxopts::cxxopts safire_warnings)
+target_link_libraries(safire_lib PUBLIC nda::nda_c mpi3 Boost::headers cxxopts::cxxopts safire_warnings hdf5::hdf5 hdf5::hdf5_hl)
 
 if(ENABLE_CUDA)
   target_link_libraries(safire_lib PRIVATE CUDA::curand CUDA::cudart CCCL::CCCL)

--- a/src/arch/CUDA/cuda_init.cpp
+++ b/src/arch/CUDA/cuda_init.cpp
@@ -79,6 +79,8 @@ void init()
   cuda_check(cudaGetDevice(&devn), "cudaGetDevice()");
   app_debug(3,"MPI world rank: {}, node rank: {}, cuda device number: {}",
 	    world.rank(),node.rank(),devn);
+
+  check_probe_kernel();
 }
 
 void check_device_configuration()

--- a/src/arch/CUDA/cuda_init.cpp
+++ b/src/arch/CUDA/cuda_init.cpp
@@ -33,28 +33,30 @@
 #include "mpi3/communicator.hpp"
 #include "mpi3/shared_communicator.hpp"
 #include "utilities/check.hpp"
+#include "numerics/device_kernels/cuda/probe.cuh"
 
 
 namespace sfqmc {
 namespace cuda
 {
 
-void cuda_check(cudaError_t sucess, std::string message)
+
+void cuda_check(cudaError_t success, std::string message)
 {
-  if (sucess != cudaSuccess) {
-   app_error(" Cuda runtime error: {}",std::to_string(sucess));
+  if (success != cudaSuccess) {
+   app_error(" Cuda runtime error: {}",std::to_string(success));
    if(message != "")
      app_error(" message: {}",message);
-   app_error(" cudaGetErrorName: {}",std::string(cudaGetErrorName(sucess)));
-   app_error(" cudaGetErrorString: {}",std::string(cudaGetErrorString(sucess)));
+   app_error(" cudaGetErrorName: {}",std::string(cudaGetErrorName(success)));
+   app_error(" cudaGetErrorString: {}",std::string(cudaGetErrorString(success)));
    APP_ABORT(" Cuda runtime error"); 
   }
 }
 
-void curand_check(curandStatus_t sucess, std::string message)
+void curand_check(curandStatus_t success, std::string message)
 {
-  if (sucess != CURAND_STATUS_SUCCESS) {
-   app_error(" Curand runtime error: {}",std::to_string(sucess));
+  if (success != CURAND_STATUS_SUCCESS) {
+   app_error(" Curand runtime error: {}",std::to_string(success));
    if(message != "")
      app_error(" message: {}",message);
    APP_ABORT(" Curand runtime error");

--- a/src/arch/cuda_init.h
+++ b/src/arch/cuda_init.h
@@ -32,7 +32,7 @@ namespace cuda
 {
 
 void cuda_check(bool, ::std::string message = "");
-void cuda_check(cudaError_t sucess, ::std::string message = "");
+void cuda_check(cudaError_t success, ::std::string message = "");
 void init(); 
 
 }

--- a/src/numerics/device_kernels/cuda/CMakeLists.txt
+++ b/src/numerics/device_kernels/cuda/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(safire_lib
     phmsd_determinants.cu
     phmsd_energy.cu
     apply.cu
+    probe.cu
 #    symmetry_tools.cu
 #    potentials.cu
 #    kpoint_tools.cu

--- a/src/numerics/device_kernels/cuda/probe.cu
+++ b/src/numerics/device_kernels/cuda/probe.cu
@@ -1,0 +1,21 @@
+#include "configuration.hpp"
+#include "utilities/check.hpp"
+#include <format>
+
+__global__ void probe_kernel() {}
+
+void check_probe_kernel() {
+  probe_kernel<<<1, 1>>>();
+  auto err = cudaGetLastError();
+  if(err == cudaSuccess) {
+    err = cudaDeviceSynchronize();
+  }
+  
+  std::string tip = "";
+  if(err == cudaErrorNoKernelImageForDevice) {
+    cudaDeviceProp dev{};
+    cudaGetDeviceProperties(&dev, 0);
+    tip = std::format("\nTry compiling with -DCUDA_ARCH={}.", dev.major * 10 + dev.minor);
+  }
+  sfqmc::utils::check(err == cudaSuccess, "Problem launching CUDA kernels: {}: {}{}", cudaGetErrorName(err), cudaGetErrorString(err), tip);
+}

--- a/src/numerics/device_kernels/cuda/probe.cuh
+++ b/src/numerics/device_kernels/cuda/probe.cuh
@@ -1,0 +1,1 @@
+void check_probe_kernel();

--- a/tests/test_common.hpp
+++ b/tests/test_common.hpp
@@ -265,8 +265,8 @@ inline void run_test_with_files(F func, std::string hamil_file, std::string wfn_
   } else {
     auto [std_hamil_file, std_wfn_file, walker_type] = GENERATE_COPY(from_range(get_unit_tests_files(flags)));
 
-    app_log(0, "Running test with files: {}\n --hamil {} \\\n --wfn {}", 
-      name, hamil_file, wfn_file
+    app_log(0, "Running test with files: \"{}\"\n --hamil {} \\\n --wfn {}", 
+      name, std_hamil_file, std_wfn_file
     );
   
     run(std_hamil_file, std_wfn_file, walker_type);


### PR DESCRIPTION
This PR makes all unit tests pass on Jenkins for both the GPU and CPU versions. It also adds automatic generation and deployment of the documentation. For now without filling in notebook cells.

It turned out that compiling on debian-based distributions required some changes to the build system, most notably the detection of Cutensor in nda, which I adjusted on the nda/tensor branch.

There is also a handy check now that will fail at arch::init if we are trying to run on GPU but have not compiled for the correct CUDA arch.


- cmake: explicitly add raw HDF5 dependency
- ci: make it work and deploy docs
- temporarily try modified nda
- cmake: remove SYSTEM from cccl to make sure it doesn’t get overwritten by cuda
- arch: check for wrong cuda arch at the beginning
- arch: typo
- c++/tests: properly display hamil an wfn filenames
