### PR TITLE
Misc. Bug fixes

### DIFF
--- a/docs/examples/models/02_stripes/index.md
+++ b/docs/examples/models/02_stripes/index.md
@@ -307,7 +307,7 @@ SzDmrg = np.loadtxt("data_10x4_Ne16U6.0_15360.dat",usecols=(1,))
 
 # now we'll average over the columns
 
-avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1))
+avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1)) / lattice.L[1]
 
 plt.errorbar(np.arange(lattice.L[0]),averageOverCols(Zs,*lattice.L),yerr=avg_delta_Sz,
              fmt='o-',label="AFQMC Free Electron")
@@ -468,7 +468,7 @@ for Ueff in Ueffs:
 for Ueff,rho in zip(Ueffs,rhos):
     Xs,Ys,Zs = spobs.local_spin(np.vstack(rho[0]),"collinear").real
     
-    avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1))
+    avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1)) / lattice.L[1]
     if Ueff==0:
         label = "Free Electron"
     else:
@@ -504,7 +504,7 @@ for Ueff,rho_avg,delta_rho,trial_rho in zip(Ueffs,rhos,deltas,trial_rhos):
 
 
     delta_Sz = np.sqrt(delta_rho[0,0].diagonal()**2+delta_rho[0,1].diagonal()**2 )
-    avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1))
+    avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1)) / lattice.L[1]
 
     xs.append(Ueff)
     ys.append(np.mean(np.abs(afqmc_sz-dmrg_sz)))
@@ -531,7 +531,7 @@ for Ueff,rho_avg,delta_rho,trial_rho in zip(Ueffs,rhos,deltas,trial_rhos):
 
 
     delta_Sz = np.sqrt(delta_rho[0,0].diagonal()**2+delta_rho[0,1].diagonal()**2 )
-    avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1))
+    avg_delta_Sz = np.sqrt((delta_Sz.reshape(*lattice.L)**2).sum(1)) / lattice.L[1]
 
     xs.append(Ueff)
     ys.append(np.mean(np.abs(afqmc_sz-trial_sz)))

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -147,9 +147,11 @@ public:
       for(int i=0; i<nsymQ; ++i) {
         int nc = Lbnk(i).extent(4); 
         (*Lbkn)(i) = std::move(memory::make_shared_array<MEM,ComplexType,5>(mpi,{nspin,nkpts,nocc_max,npol*nbnd,nc}));
-        if(writer) 
+        mpi->node_comm.barrier();
+        if(writer)
           nda::tensor::add(ComplexType(1.0),Lbnk(i)()(0,nda::ellipsis{}),"skanj",
                            ComplexType(0.0),(*Lbkn)(i)(),"skajn");
+        mpi->node_comm.barrier();
       }
     }
   }

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -297,7 +297,7 @@ public:
       {
         memory::buffered_array<MEM,ComplexType,2> Tuw(nu,nw);
         nda::blas::gemm(nda::transpose(Zuv),Guu,Tuw);
-        nda::tensor::contract(ComplexType(RealType(0.5 * scl * scl)),nda::conj(Guu),"uw",Tuw,"uw",
+        nda::tensor::contract(ComplexType(RealType(0.5 * scl * scl)),Guu,"uw",Tuw,"uw",
                               ComplexType(1.0),E(range(iw, iw + nw), 2),"w"); 
       }
       iw += nw;
@@ -434,7 +434,7 @@ public:
           EJn() = nda::transpose(Tuw());
         else
           nda::tensor::assign(Tuw,"uw",EJn,"wu");
-        nda::tensor::contract(ComplexType(RealType(0.5)),nda::conj(Guu),"uw",EJn,"wu",
+        nda::tensor::contract(ComplexType(RealType(0.5)),Guu,"uw",EJn,"wu",
                               ComplexType(1.0),E(range(iw, iw + nw), 2),"w"); 
       }
       iw += nw;

--- a/tests/test_hamiltonian_factory.cpp
+++ b/tests/test_hamiltonian_factory.cpp
@@ -34,6 +34,7 @@
 #include "utilities/Timer.hpp"
 #include "test_utils.hpp"
 #include "AFQMC/Hamiltonians/hdf5_helpers.hpp"
+#include "AFQMC/Utilities/readWfn.h"
 #include "numerics/sparse/sparse.hpp"
 
 using std::cerr;
@@ -49,6 +50,118 @@ extern std::string UTEST_HAMIL, UTEST_WFN;
 namespace sfqmc
 {
 using namespace afqmc;
+
+void thc_vs_chol_energy_agreement(
+    std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
+    std::string chol_file, std::string thc_file, std::string wfn_file)
+{
+  using nda::range;
+  auto all = range::all;
+
+  utils::check(utils::file_exists(chol_file), "Cholesky file not found: {}", chol_file);
+  utils::check(utils::file_exists(thc_file),  "THC file not found: {}",      thc_file);
+  utils::check(utils::file_exists(wfn_file),  "Wavefunction file not found: {}", wfn_file);
+
+  auto [NMO, nup, ndown] = read_info_from_wfn(wfn_file, "NOMSD");
+  WALKER_TYPES walker_type = getWalkerType(wfn_file, "NOMSD");
+  int npol = (walker_type == NONCOLLINEAR) ? 2 : 1;
+  int nel  = (walker_type == COLLINEAR)    ? nup + ndown : nup;
+
+  // Read the trial wavefunction PsiT from file
+  h5::file  wfn_f(wfn_file, 'r');
+  h5::group wfn_grp(wfn_f);
+  h5::group nomsd_grp = wfn_grp.open_group("Wavefunction").open_group("NOMSD");
+  auto PsiT = read_nomsd_wavefunction<HOST_MEMORY>(nomsd_grp, 1, walker_type, NMO, nup, ndown);
+
+  std::map<std::string, AFQMCInfo> InfoMap;
+  InfoMap.insert({"info0", AFQMCInfo{"info0", NMO, nup, ndown}});
+
+  // Build HamiltonianOperations from a file-backed Hamiltonian
+  auto make_ham_ops = [&](std::string hamil_file) {
+    ptree ham_pt;
+    ham_pt.put("name",     "ham0");
+    ham_pt.put("system",   "info0");
+    ham_pt.put("filename", hamil_file);
+    HamiltonianFactory HamFac(InfoMap);
+    HamFac.push("ham0", ham_pt);
+    auto& ham = HamFac.getHamiltonian(mpi, "ham0");
+    return ham.template getHamiltonianOperations<HOST_MEMORY>(walker_type, mpi, PsiT);
+  };
+
+  auto H_chol = make_ham_ops(chol_file);
+  auto H_thc  = make_ham_ops(thc_file);
+
+  // Fixed random G (seed 0) — identical for both energy evaluations
+  nda::array<ComplexType, 2> G(1, nel * npol * NMO);
+  sfqmc::utils::fillRandomArray(G);
+
+  // hermitize for sane 1-rdm
+  G() = 0.5*(G + nda::conj(nda::transpose(G)));
+
+  auto eval_energy = [&](auto& H) -> nda::array<ComplexType, 2> {
+    nda::array<ComplexType, 2> E(1, 3);
+    H.energy(E, G, 0, true, true, true);
+    return E;
+  };
+
+  auto E_chol = eval_energy(H_chol);
+  auto E_thc  = eval_energy(H_thc);
+
+  app_log(0, "  THC vs Chol (NMO={} nup={} ndown={} walker={}):",
+          NMO, nup, ndown, walkerTypeToString(walker_type));
+  app_log(0, "    Chol: E1={:+.8e}  EXX={:+.8e}  EJ={:+.8e}",
+          std::real(E_chol(0,0)), std::real(E_chol(0,1)), std::real(E_chol(0,2)));
+  app_log(0, "    THC:  E1={:+.8e}  EXX={:+.8e}  EJ={:+.8e}",
+          std::real(E_thc(0,0)),  std::real(E_thc(0,1)),  std::real(E_thc(0,2)));
+
+  // E1 must match exactly: both files use the same one-body H0 and nuclear data.
+  CHECK_THAT(E_thc(all, 0), utils::Approx(E_chol(all, 0)));
+  // Two-body terms are allowed to differ by the factorization approximation error.
+  CHECK_THAT(E_thc(all, 1), utils::Approx(E_chol(all, 1), 1e-2, 1e-2));
+  CHECK_THAT(E_thc(all, 2), utils::Approx(E_chol(all, 2), 1e-2, 1e-2));
+
+  nda::array<ComplexType, 2> G_phys(1, nel * npol * NMO);
+  G_phys() = ComplexType(0.0);
+  {
+    long const nspin = (walker_type == COLLINEAR) ? 2 : 1;
+    int  offset = 0;
+    for (int is = 0; is < nspin; ++is) {
+      const auto& pt = PsiT(0, is);
+      for (long a = 0; a < pt.shape(0); ++a) {
+        auto row  = pt[a];
+        auto cols = row.columns();
+        auto vals = row.values();
+        for (long k = 0; k < row.nnz(); ++k)
+          G_phys(0, (offset + a) * NMO * npol + cols(k)) = std::conj(vals(k));
+      }
+      offset += static_cast<int>(pt.shape(0));
+    }
+  }
+
+  auto eval_phys_energy = [&](auto& H) -> nda::array<ComplexType, 2> {
+    nda::array<ComplexType, 2> E(1, 3);
+    H.energy(E, G_phys, 0, true, true, true);
+    return E;
+  };
+
+  auto E_chol_phys = eval_phys_energy(H_chol);
+  auto E_thc_phys  = eval_phys_energy(H_thc);
+
+  app_log(0, "  Physical G (initial walker = PsiT):");
+  app_log(0, "    Chol: E1={:+.8e}  EXX={:+.8e}  EJ={:+.8e}",
+          std::real(E_chol_phys(0,0)), std::real(E_chol_phys(0,1)), std::real(E_chol_phys(0,2)));
+  app_log(0, "    THC:  E1={:+.8e}  EXX={:+.8e}  EJ={:+.8e}",
+          std::real(E_thc_phys(0,0)),  std::real(E_thc_phys(0,1)),  std::real(E_thc_phys(0,2)));
+
+  // For a physical density matrix the direct Coulomb energy must be > 0.
+  CHECK(std::real(E_chol_phys(0,2)) > 0.0);
+  CHECK(std::real(E_thc_phys(0,2))  > 0.0);
+  // THC and Cholesky must agree on all energy components
+  CHECK_THAT(E_thc_phys(all, 0), utils::Approx(E_chol_phys(all, 0)));
+  CHECK_THAT(E_thc_phys(all, 1), utils::Approx(E_chol_phys(all, 1), 1e-2, 1e-2));
+  CHECK_THAT(E_thc_phys(all, 2), utils::Approx(E_chol_phys(all, 2), 1e-2, 1e-2));
+
+}
 
 template<MEMORY_SPACE MEM>
 void hamiltonian_factory_build(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
@@ -85,5 +198,16 @@ TEST_CASE("hamiltonian_factory: build", "[hamiltonian_factory]")
   }, UTEST_HAMIL, UTEST_WFN, TestFiles::RHF | TestFiles::UHF | TestFiles::GHF | TestFiles::NOMSD | TestFiles::PHMSD | TestFiles::FINITE_T | TestFiles::ALL_SYSTEMS);
 }
 
+
+TEST_CASE("thc_vs_chol_energy", "[thc_chol_energy_agreement]")
+{
+  auto& mpi = utils::make_unit_test_mpi_context();
+
+  std::string pre = std::string(PROJECT_SOURCE_DIR_STR) + "/tests/unit_test_files/C_1x1x1_ks_basis/";
+    thc_vs_chol_energy_agreement(mpi,
+      pre + "ham_chol_1e-5.h5",
+      pre + "ham_thc_1e-6.h5",
+      pre + "wfn_mf_pbe.h5");
+}
 
 } // namespace sfqmc

--- a/utils/tests/functional/dev_tools/test_infrastructure.py
+++ b/utils/tests/functional/dev_tools/test_infrastructure.py
@@ -200,7 +200,7 @@ def _wfn_is_implemented(case: AFQMCInputSet) -> bool:
 def _not_closed_thc_with_noncollinear_wfn(case: AFQMCInputSet) -> bool:
     """
     Filter out closed THC Hamiltonians with non-collinear wavefunctions.
-    
+
     This combination is known to be not implemented.
     """
     if case.hamiltonian.type == HamiltonianClass.THC and \
@@ -228,19 +228,6 @@ def _compatible_spin_H_walker(case: AFQMCInputSet) -> bool:
     (Higher enum value means less spin symmetry)
     """
     return case.walker.spin_symm >= case.hamiltonian.spin_symm
-
-
-def _noncollinear_walker_wfn_must_match(case: AFQMCInputSet) -> bool:
-    """
-    Ensure that non-collinear walkers are only used with non-collinear wavefunctions,
-    and vice versa.
-
-    Note: This is not desirable behavior, but it is how SAFIRE is currently implemented.
-    Future versions may relax this restriction.
-    """
-    noncollinear_walker = case.walker.spin_symm == SpinSymm.NONCOLLINEAR
-    noncollinear_wfn = case.wavefunction.spin_symm == SpinSymm.NONCOLLINEAR
-    return noncollinear_walker == noncollinear_wfn
 
 # Define all rules with human-readable descriptions
 WFN_IS_IMPLEMENTED = TestRule(
@@ -281,6 +268,13 @@ COMPATIBLE_SPIN_H_WALKER = TestRule(
     check_func=_compatible_spin_H_walker
 )
 
+COMPATIBLE_SPIN_WALKER_WFN = TestRule(
+    name="Walker-Wavefunction Spin Compatibility",
+    description="Ensures the walker spin symmetry is compatible with the wavefunction. "
+                "The walker must have equal or less spin symmetry.",
+    check_func=lambda case: case.walker.spin_symm >= case.wavefunction.spin_symm
+)
+
 COMPATIBLE_FULLYPOLARIZED_WFN = TestRule(
     name="Fully Polarized Wavefunction Compatibility",
     description="Ensures that fully polarized wavefunctions and walkers are only used together. "
@@ -291,12 +285,6 @@ COMPATIBLE_FULLYPOLARIZED_WFN = TestRule(
         (case.wavefunction.spin_symm != SpinSymm.FULLYPOLARIZED and
          case.walker.spin_symm != SpinSymm.FULLYPOLARIZED)
     )
-)
-
-NONCOLLINEAR_WALKER_WFN_MUST_MATCH = TestRule(
-    name="Non-collinear Walker-Wavefunction Symmetry Match",
-    description="Ensures that non-collinear walkers are only used with non-collinear wavefunctions, and vice versa.",
-    check_func=_noncollinear_walker_wfn_must_match
 )
 
 def get_all_rules() -> List[TestRule]:
@@ -315,7 +303,7 @@ def get_all_rules() -> List[TestRule]:
         NOT_CLOSED_THC_WITH_NONCOLLINEAR_WFN,
         NOT_CLOSED_FOR_LATTICE_HAMILTONIANS,
         COMPATIBLE_FULLYPOLARIZED_WFN,
-        NONCOLLINEAR_WALKER_WFN_MUST_MATCH,
+        COMPATIBLE_SPIN_WALKER_WFN,
     ]
 
 
@@ -323,7 +311,7 @@ def check_rules(case: AFQMCInputSet, rules: List[TestRule],
                 verbose: bool = False) -> bool:
     """
     Check if a test case passes all provided rules.
-    
+
     Parameters
     ----------
     case : AFQMCInputSet
@@ -332,19 +320,19 @@ def check_rules(case: AFQMCInputSet, rules: List[TestRule],
         Rules to apply
     verbose : bool, optional
         If True, print detailed information about failed rules
-        
+
     Returns
     -------
     bool
         True if the case passes all rules, False otherwise
     """
     if verbose:
-        print(f"\n=== Checking rules for test case ===")
+        print("\n=== Checking rules for test case ===")
         print(f"Hamiltonian: {case.hamiltonian.type.name}, spin={case.hamiltonian.spin_symm.name}")
         print(f"Wavefunction: {case.wavefunction.type.name}, spin={case.wavefunction.spin_symm.name}")
         print(f"Walker: {case.walker.name}, spin={case.walker.spin_symm.name}")
         print()
-    
+
     passed = True
     for rule in rules:
         result = rule(case)
@@ -355,11 +343,11 @@ def check_rules(case: AFQMCInputSet, rules: List[TestRule],
                 print(f"         {rule.description}")
         if not result:
             passed = False
-    
+
     if verbose:
         print(f"\nOverall: {'PASS' if passed else 'FAIL'}")
         print("=" * 40)
-    
+
     return passed
 
 


### PR DESCRIPTION
- adds a unit test to check the correctness of Cholesky and THC factorizations against each other
- fixes a small bug with big consequences in the energy evaluation of the THC Hamiltonian
- addresses #95 by adding a functional test rule : walkers are not allowed to be downgraded relative to the wavefunction 
- removes a now redundant functional test rule that is covered by the new rule
- adds a missing MPI barrier in the K-point factorized Cholesky
- triages issue #73 : still requires improvements to the error analysis tooling before it is considered fixed

