### PR TITLE
Fix remaining walker type promitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,16 +236,13 @@ endif()
 # cpptrace 
 ######################################################################
 if(ENABLE_CPPTRACE)
-  block()
-    set(CMAKE_SKIP_INSTALL_RULES ON)
-    FetchContent_Declare(
-      cpptrace
-      GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-      GIT_TAG        v0.8.2
-      SYSTEM
-    )
-    FetchContent_MakeAvailable(cpptrace)
-  endblock()
+  FetchContent_Declare(
+    cpptrace
+    GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+    GIT_TAG        v0.8.2
+    SYSTEM
+  )
+  FetchContent_MakeAvailable(cpptrace)
 endif(ENABLE_CPPTRACE)
 
 ######################################################################

--- a/src/AFQMC/AFQMCFactory.cpp
+++ b/src/AFQMC/AFQMCFactory.cpp
@@ -112,21 +112,15 @@ bool AFQMCFactory<MEM>::parse(const ptree pt_in)
 template<MEMORY_SPACE MEM>
 bool AFQMCFactory<MEM>::execute(std::string type, const ptree pt_in)
 {
-  char fileroot[256];
-
-  for(auto& it : pt_in)
+  for(auto& [cname, pt] : pt_in)
   {
-    std::string cname = it.first;
-    ptree pt = it.second;
     if (cname == "execute")
     {
-      snprintf(fileroot, sizeof(fileroot), "%s.s%03d", project_title.c_str(), m_series);
-      	
       // execute driver
-      if (!DriverFac.executeDriver(type, std::string(fileroot), m_series, pt))
+      if (!DriverFac.executeDriver(type, std::format("{}.s{:03d}", project_title, m_series), m_series, pt))
       {
         app_error("Error in DriverFactory::executeDriver::run()");
- 	app_error_flush();
+        app_error_flush();
         return false;
       }
 

--- a/src/AFQMC/AFQMCFactory.h
+++ b/src/AFQMC/AFQMCFactory.h
@@ -87,9 +87,11 @@ public:
     app_log(1, "    -- MPI nodes      : {} ", mpi->internode_comm.size());
     app_log(1, "    -- MPI tasks      : {} ", mpi->comm.size());
     app_log(1, "    -- Compute Device    : {} ", (MEM==DEVICE_MEMORY?"gpu":"cpu")); 
-    app_log(1, "    -- TBLIS_NUM_THREADS : {} {}", std::getenv("TBLIS_NUM_THREADS"),
+    const char* tblis_env = std::getenv("TBLIS_NUM_THREADS");
+    const char* omp_env = std::getenv("OMP_NUM_THREADS");
+    app_log(1, "    -- TBLIS_NUM_THREADS : {} {}", tblis_env ? tblis_env : "(unset)",
             sfqmc::utils::tblis_threads_was_user_set() ? "(user-provided)" : "");
-    app_log(1, "    -- OMP_NUM_THREADS   : {} {}\n\n", std::getenv("OMP_NUM_THREADS"),
+    app_log(1, "    -- OMP_NUM_THREADS   : {} {}\n\n", omp_env ? omp_env : "(unset)",
             sfqmc::utils::omp_threads_was_user_set() ? "(user-provided)" : "");
     // parse input
     utils::check(parse(pt), " Error in AFQMCFactory: Problems parsing the input file. ");

--- a/src/AFQMC/AFQMCFactory.h
+++ b/src/AFQMC/AFQMCFactory.h
@@ -74,7 +74,7 @@ public:
        InfoMap(),
        HamFac(InfoMap),
        WSetFac(InfoMap),
-       WfnFac(InfoMap),
+       WfnFac{},
        PropFac(InfoMap),
        DriverFac(mpi, InfoMap, WSetFac, PropFac, WfnFac, HamFac) 
   {

--- a/src/AFQMC/Drivers/DriverFactory.cpp
+++ b/src/AFQMC/Drivers/DriverFactory.cpp
@@ -288,7 +288,7 @@ bool DriverFactory<MEM>::executeAFQMCDriver(std::string title, int m_series, ptr
     Hamiltonian& ham0 = HamFac.getHamiltonian(mpi, ham_name);
 
     // build wavefunction
-    [[maybe_unused]] auto& wfn0 = WfnFac.getWavefunction(mpi, wfn_name, walker_type, &ham0, nWalkers);
+    WfnFac.getWavefunction(mpi, wfn_name, walker_type, &ham0, nWalkers);
   }
 
   // wfn builder should not use Hamiltonian pointer now

--- a/src/AFQMC/Drivers/DriverFactory.h
+++ b/src/AFQMC/Drivers/DriverFactory.h
@@ -129,7 +129,7 @@ public:
           pt1.put_child("cs_system_"+std::to_string(i),*sys_pt);
         } else {
           utils::check(false," wavefunction definition or declaration required in cs_system_N.");
-	}
+        }
       } else {
         utils::check(false,"cs_system_N not found."); 
       }

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -28,6 +28,7 @@
 #include "numerics/nda_functions.hpp"
 #include "numerics/operations/tensor.hpp"
 #include "detail/one_body.hpp"
+#include "AFQMC/Utilities/wfn_utils.hpp"
 
 namespace sfqmc
 {
@@ -49,7 +50,7 @@ public:
           WALKER_TYPES type,
           int nbnd_,
           int q0,
-          nda::array<int,2>&& nocc_,
+          nda::array<nda::array<int,1>,2>&& nocc_,
           nda::array<int,1>&& minusq_,
           nda::array<int,2>&& qk_to_k2_,
           nda::array<int,1>&& qmap_,
@@ -65,9 +66,9 @@ public:
         walker_type(type),
         nkpts(nocc_.extent(1)),
         nbnd(nbnd_),
-        nup(nda::sum(nocc_(0,nda::range::all))),
-        ndown(walker_type==COLLINEAR ? nda::sum(nocc_(1,nda::range::all)) : 0),
-        nocc_max(nda::max_element(nocc_)),
+        nup(nelec_for_spin(nocc_,0)),
+        ndown(walker_type==COLLINEAR ? nelec_for_spin(nocc_,1) : 0),
+        nocc_max(max_nocc_per_kpoint(nocc_)),
         nchol_max(0),
         nocc(std::move(nocc_)),
         minusq(std::move(minusq_)),
@@ -217,9 +218,7 @@ public:
     int nwalk = G.extent(0);
     int nspin  = (walker_type == COLLINEAR) ? 2 : 1;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nup = nda::sum(nocc(0,all));
-    int ndown = (walker_type==COLLINEAR ? nda::sum(nocc(1,all)) : 0);
-    int nel  = (walker_type == COLLINEAR ? nup+ndown : nup); // NONCOLLINEAR has ndown=0 
+    int nel  = (walker_type == COLLINEAR ? nup+ndown : nup); // NONCOLLINEAR has ndown=0
     int nqpts = LQ.extent(0);
     utils::check(E.shape() == std::array<long,2>{nwalk,3}, "Size mismatch.");
     utils::check(G.extent(1) == nel*npol*nkpts*nbnd, "Size mismatch.");
@@ -427,8 +426,6 @@ public:
     int is = (spin_component == Alpha ? 0 : 1);
     int nwalk = G.extent(0);
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nup = nda::sum(nocc(0,all));
-    int ndown = (walker_type==COLLINEAR ? nda::sum(nocc(1,all)) : 0);
     int nel  = (is==0 ? nup : ndown);
     int nqpts = LQ.extent(0);
     utils::check(E.shape() == std::array<long,2>{nwalk,3}, "Size mismatch.");
@@ -917,8 +914,9 @@ protected:
   int nchol_max=0;
   int ncvecs=0;     // total number of cholesky vectors
 
-  nda::array<int,2> nocc;
-         
+  // For each (spin,kpoint): the list of occupied PsiT row indices at that kpoint.
+  nda::array<nda::array<int,1>,2> nocc;
+
   // BZ information
   nda::array<int,1> minusq;
   nda::array<int,2> qk_to_k2;
@@ -958,35 +956,48 @@ protected:
   // Changes the layout of G:
   //    From: G(nwalk,nel_tot,npol,nkpts,nbnd)
   //    To:   GKK(nkpts,nkpts,nwalk*nocc_max,npol*nbnd)
-  void Gc_to_GKKwaj(int is, int n0, nda::MemoryArrayOfRank<5> auto const& G,
+  // `base` is the offset of spin `is`'s block in the occupied dimension of G; the
+  // occupied orbital `a` of kpoint ik1 lives at G-row base+nocc(is,ik1)(a).
+  void Gc_to_GKKwaj(int is, int base, nda::MemoryArrayOfRank<5> auto const& G,
                         nda::MemoryArrayOfRank<4> auto && GKK)
   {
     using nda::range;
     auto all  = range::all;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nwalk = G.extent(0); 
- 
+    int nwalk = G.extent(0);
+
     auto G6d = nda::reshape(GKK,std::array<long,6>{nkpts,nkpts,nwalk,nocc_max,npol,nbnd});
     GKK() = ComplexType(0.0);
-    if constexpr (MEM==HOST_MEMORY) {
-      for(int ik1=0; ik1<nkpts; ++ik1) 
-      {
-        int nk1 = nocc(is,ik1);
-        for(int ik2=0; ik2<nkpts; ++ik2) 
-        { 
-          for(int ip=0; ip<npol; ++ip) 
-            for(int iw=0; iw<nwalk; ++iw) 
-              G6d(ik1,ik2,iw,range(nk1),ip,all) = G(iw,range(n0,n0+nk1),ip,ik2,all);
-        } 
-        n0 += nk1;
-      }
-    } else {
-      for(int ik1=0; ik1<nkpts; ++ik1) 
-      {
-        int nk1 = nocc(is,ik1);
-        nda::tensor::add(ComplexType(1.0),G(all,range(n0,n0+nk1),all,all,all),"wapkj",
-                         ComplexType(0.0),G6d(ik1,all,all,range(nk1),all,all),"kwapj");
-        n0 += nk1;
+    for(int ik1=0; ik1<nkpts; ++ik1)
+    {
+      auto const& rows = nocc(is,ik1);
+      int nk1 = int(rows.size());
+      if(nk1==0) continue;
+      bool contig = contiguous_rows(rows);
+      if constexpr (MEM==HOST_MEMORY) {
+        for(int ik2=0; ik2<nkpts; ++ik2)
+        {
+          for(int ip=0; ip<npol; ++ip)
+            for(int iw=0; iw<nwalk; ++iw) {
+              if(contig) {
+                int r0 = base + rows(0);
+                G6d(ik1,ik2,iw,range(nk1),ip,all) = G(iw,range(r0,r0+nk1),ip,ik2,all);
+              } else {
+                for(int a=0; a<nk1; ++a)
+                  G6d(ik1,ik2,iw,a,ip,all) = G(iw,base+rows(a),ip,ik2,all);
+              }
+            }
+        }
+      } else {
+        if(contig) {
+          int r0 = base + rows(0);
+          nda::tensor::add(ComplexType(1.0),G(all,range(r0,r0+nk1),all,all,all),"wapkj",
+                           ComplexType(0.0),G6d(ik1,all,all,range(nk1),all,all),"kwapj");
+        } else {
+          for(int a=0; a<nk1; ++a)
+            nda::tensor::add(ComplexType(1.0),G(all,range(base+rows(a),base+rows(a)+1),all,all,all),"wapkj",
+                             ComplexType(0.0),G6d(ik1,all,all,range(a,a+1),all,all),"kwapj");
+        }
       }
     }
   }
@@ -994,7 +1005,8 @@ protected:
   // Changes the layout of G:
   //    From: G(nwalk,nel_tot,npol,nkpts,nbnd)
   //    To:   GQK(nkpts,nwalk,nkpts,nocc_max,npol*nbnd)
-  void Gc_to_GQKwaj(int is, int n0, int iq, nda::MemoryArrayOfRank<5> auto const& G,
+  // `base` is the offset of spin `is`'s block in the occupied dimension of G.
+  void Gc_to_GQKwaj(int is, int base, int iq, nda::MemoryArrayOfRank<5> auto const& G,
                     nda::MemoryArrayOfRank<4> auto && GQK)
   {
     using nda::range;
@@ -1005,14 +1017,22 @@ protected:
     auto G5d = nda::reshape(GQK,std::array<long,5>{nwalk,nkpts,nocc_max,npol,nbnd});
     GQK() = ComplexType(0.0);
     arch::set_device_synchronization(false);
-    int nk0 = n0;
     for(int ik=0; ik<nkpts; ++ik)
     {
       int k2 = qk_to_k2(iq,ik);
-      int nk = nocc(is,ik);
-      for(int ip=0; ip<npol; ++ip) 
-        math::accumulate(ComplexType(1.0),G(all,range(nk0,nk0+nk),ip,k2,all),G5d(all,ik,range(nk),ip,all));
-      nk0 += nk;
+      auto const& rows = nocc(is,ik);
+      int nk = int(rows.size());
+      if(nk==0) continue;
+      bool contig = contiguous_rows(rows);
+      for(int ip=0; ip<npol; ++ip) {
+        if(contig) {
+          int r0 = base + rows(0);
+          math::accumulate(ComplexType(1.0),G(all,range(r0,r0+nk),ip,k2,all),G5d(all,ik,range(nk),ip,all));
+        } else {
+          for(int a=0; a<nk; ++a)
+            math::accumulate(ComplexType(1.0),G(all,range(base+rows(a),base+rows(a)+1),ip,k2,all),G5d(all,ik,range(a,a+1),ip,all));
+        }
+      }
     }
     arch::set_device_synchronization(true);
   }

--- a/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
@@ -789,7 +789,7 @@ protected:
     bool has_rot = _Xsiu_rot_.has_value();
     // [nstot][nkpts][nptot*nbnd][nu]
     const auto Xsiu = ( has_rot ? (*_Xsiu_rot_)() : _Xsiu_());
-    // [nstot][nptot][nkpts][nocc_max][nu]
+    // [nspin][npol][nkpts][nocc_max][nu]  (walker dims, not interaction dims)
     const auto Ysau = ( has_rot ? (*_Ydsau_rot_)()(idet,nda::ellipsis{}) :
                                  _Ydsau_()(idet,nda::ellipsis{}) );
     long nw   = G.extent(0);
@@ -805,16 +805,17 @@ protected:
       for( int is=0; is<nspin; is++ ) {
         memory::buffered_array<MEM,ComplexType,2> Tau(nelec[is],nu);    
         for( int ip=0; ip<npol; ip++ ) {
+          auto [is_,ip_] = interaction_block(is,ip,npol,nstot,nptot);
           for(int iw=0; iw<nw; ++iw) {
-        
+
             for(int k2=0; k2<nkpts; k2++) {
-              auto Xju = Xsiu(is%nstot,k2,range((ip%nptot)*nbnd,(ip%nptot+1)*nbnd),all);
+              auto Xju = Xsiu(is_,k2,range(ip_*nbnd,(ip_+1)*nbnd),all);
               nda::blas::gemm(G(iw,range(is*nup,nup+is*ndown),ip,k2,all),Xju,Tau);
 
               for(int k1=0; k1<nkpts; k1++) {
                 auto const& rows = nocc_per_kp(is,k1);
                 int nel_k = int(rows.size());
-                auto Yau = Ysau(is%nstot,ip%nptot,k1,range(nel_k),all);
+                auto Yau = Ysau(is,ip,k1,range(nel_k),all);
                 for(int i=0; i<nel_k; ++i)
                   GKK(k1,k2,iw,all) += ComplexType(a) * Tau(rows(i),all) * Yau(i,all);
               }  //k1
@@ -841,7 +842,7 @@ protected:
     bool has_rot = _Xsiu_rot_.has_value();
     // [nstot][nkpts][nptot*nbnd][nu]
     const auto Xsiu = ( has_rot ? (*_Xsiu_rot_)() : _Xsiu_());
-    // [nstot][nptot][nkpts][nocc_max][nu]
+    // [nspin][npol][nkpts][nocc_max][nu]  (walker dims, not interaction dims)
     const auto Ysau = ( has_rot ? (*_Ydsau_rot_)()(idet,nda::ellipsis{}) :
                                  _Ydsau_()(idet,nda::ellipsis{}) );
     long nw   = G.extent(0);
@@ -856,16 +857,17 @@ protected:
     if constexpr (MEM==HOST_MEMORY) {
       memory::buffered_array<MEM,ComplexType,2> Tau(nelec[is],nu);
       memory::buffered_array<MEM,ComplexType,2> Tau_k(nelec[is],nu);
+      auto [is_,ip_] = interaction_block(is,p2,npol,nstot,nptot);
       for(int iw=0; iw<nw; ++iw) {
 
         for(int k2=0; k2<nkpts; k2++) {
-          auto Xju = Xsiu(is%nstot,k2,range((p2%nptot)*nbnd,(p2%nptot+1)*nbnd),all);
+          auto Xju = Xsiu(is_,k2,range(ip_*nbnd,(ip_+1)*nbnd),all);
           nda::blas::gemm(G(iw,range(is*nup,nup+is*ndown),p2,k2,all),Xju,Tau);
 
           for(int k1=0; k1<nkpts; k1++) {
             auto const& rows = nocc_per_kp(is,k1);
             int nel_k = int(rows.size());
-            auto Yau = Ysau(is%nstot,p1%nptot,k1,range(nel_k),all);
+            auto Yau = Ysau(is,p1,k1,range(nel_k),all);
             if(contiguous_rows(rows)) {
               int r0 = rows(0);
               nda::blas::gemm(ComplexType(a),nda::transpose(Yau),Tau(range(r0,r0+nel_k),all),

--- a/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
@@ -888,61 +888,6 @@ protected:
     return GKK;
   }
 
-  // Computes Guv and Guu for a set of walkers
-  // rotMuv is partitioned along 'u'
-  // G[w][nel*nmo]
-  // Guv[w][nu][nv]
-  // Twav[w][nel][nv]
-  void get_Guv(int ispin, int p1, int p2, int k1, int k2, 
-         nda::MemoryArrayOfRank<5> auto const& G, 
-         nda::MemoryArrayOfRank<3> auto && Guv, 
-         nda::MemoryArrayOfRank<1> auto && Tbuff, int idet)
-  {
-// MAM: in GPU implementation, do multiple k1 or k2 simultaneously
-    using nda::range;
-    auto all = range::all;
-    int nstot = hij.extent(0);
-    int nptot = hij.extent(2)/nbnd;
-    long p2_ = long(p2)%nptot;
-    int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nel  = (walker_type == COLLINEAR ? nup+ndown : nup); // NONCOLLINEAR has ndown=0 
-    auto const& rows = nocc_per_kp(ispin,k1);
-    int nel_k1 = int(rows.size());
-    bool has_rot = _Xsiu_rot_.has_value();
-    const auto Xiu = ( has_rot ? (*_Xsiu_rot_)()(ispin%nstot,k2,range(p2_*nbnd,(p2_+1)*nbnd),all) : 
-                                  _Xsiu_()(ispin%nstot,k2,range(p2_*nbnd,(p2_+1)*nbnd),all) );
-    const auto Yau = ( has_rot ? (*_Ydsau_rot_)()(idet,ispin,p1,k1,range(nel_k1),all) : 
-                                 _Ydsau_()(idet,ispin,p1,k1,range(nel_k1),all) );
-    int nw   = int(G.extent(0));
-    int nu = Xiu.extent(1);
-
-    // G5d[w][a][j]
-    utils::check(G.shape() == std::array<long,5>{nw,nel,npol,nkpts,nbnd}, "THC::get_Guv: Shape mismatch");
-    utils::check(Tbuff.size() >= nw*nel_k1*nu, "THC::get_Guv: Twav size mismatch.");
-    memory::array_view<MEM,ComplexType,3> Twav(std::array<long,3>{nw,nel_k1,nu},Tbuff.data());
-
-    // Twav[w][a][v] = sum_j G[w][a][j] X[j][v]
-    if(contiguous_rows(rows)) {
-      int r0 = ispin*nup + rows(0);
-      auto Gwai = G(all,range(r0,r0+nel_k1),p2,k2,all);
-      nda::tensor::contract(Gwai,"wai",Xiu,"iv",Twav,"wav");
-    } else {
-      memory::buffered_array<MEM,ComplexType,3> Gg(nw,nel_k1,nbnd);
-      for(int aa=0; aa<nel_k1; ++aa)
-        Gg(all,aa,all) = G(all,ispin*nup+rows(aa),p2,k2,all);
-      nda::tensor::contract(Gg,"wai",Xiu,"iv",Twav,"wav");
-    }
-    // G[w][u][v] = sum_a X[a][u] Twav[w][a][v]
-    nda::tensor::contract(Yau,"au",Twav,"wav",Guv,"wuv");
-
-//    over a range of k2
-//    auto Gwai = G(all,range(ispin*nup+n0,ispin*nup+n0+nel_k1),p2,all,all);
-//    // Twav[w][a][k2][v] = sum_j G[w][a][k2][j] X[j][v]
-//    nda::tensor::contract(Gwai,"waki",Xiu,"kiv",Twav,"wakv");
-//    // G[w][u][v] = sum_a X[a][u] Twav[w][a][v]
-//    nda::tensor::contract(Yau,"au",Twav,"wakv",Guv,"wkuv");
-  }
-
 protected:
   std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> mpi;
 

--- a/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
@@ -27,6 +27,7 @@
 #include "numerics/shared_array/const_shared_array.hpp"
 #include "numerics/nda_functions.hpp"
 #include "detail/one_body.hpp"
+#include "AFQMC/Utilities/wfn_utils.hpp"
 
 namespace sfqmc
 {
@@ -62,7 +63,7 @@ public:
          int ndn_, 
          int nkpts_,
          int q0_,
-         nda::array<int,2>&& nocc_per_kp_,
+         nda::array<nda::array<int,1>,2>&& nocc_per_kp_,
          nda::array<int,1>&& minusq_,
          nda::array<int,2>&& qk_to_k2_,
          memory::const_shared_array<HOST_MEMORY,ComplexType,4>&& hij_,
@@ -111,7 +112,7 @@ public:
     int nptot = hij.extent(2)/nbnd;
     int ndet = haj.extent(0);
     int nqpts_ibz = _Luv_.extent(0);
-    auto nocc_max = nda::max_element(nocc_per_kp);
+    auto nocc_max = max_nocc_per_kpoint(nocc_per_kp);
     utils::check(vexx.shape() == std::array<long,4>{nstot*nptot,nkpts,nbnd,nbnd},"KPTHCOps: Size mismatch"); 
     utils::check(hij.shape() == std::array<long,4>{nstot,nkpts,nptot*nbnd,nptot*nbnd},"KPTHCOps: Size mismatch"); 
     utils::check(haj.shape() == std::array<long,3>{ndet,nel,npol*NMO},"KPTHCOps: Size mismatch"); 
@@ -810,13 +811,12 @@ protected:
               auto Xju = Xsiu(is%nstot,k2,range((ip%nptot)*nbnd,(ip%nptot+1)*nbnd),all);
               nda::blas::gemm(G(iw,range(is*nup,nup+is*ndown),ip,k2,all),Xju,Tau);
 
-              int n0 = 0; 
               for(int k1=0; k1<nkpts; k1++) {
-                int nel_k = nocc_per_kp(is,k1);
+                auto const& rows = nocc_per_kp(is,k1);
+                int nel_k = int(rows.size());
                 auto Yau = Ysau(is%nstot,ip%nptot,k1,range(nel_k),all);
                 for(int i=0; i<nel_k; ++i)
-                  GKK(k1,k2,iw,all) += ComplexType(a) * Tau(n0+i,all) * Yau(i,all);
-                n0 += nel_k;
+                  GKK(k1,k2,iw,all) += ComplexType(a) * Tau(rows(i),all) * Yau(i,all);
               }  //k1
             } // k2 
 
@@ -854,22 +854,30 @@ protected:
     GKK() = ComplexType(0.0);
     ComplexType a = (walker_type == CLOSED) ? ComplexType(2.0) : ComplexType(1.0);
     if constexpr (MEM==HOST_MEMORY) {
-      memory::buffered_array<MEM,ComplexType,2> Tau(nelec[is],nu);    
+      memory::buffered_array<MEM,ComplexType,2> Tau(nelec[is],nu);
+      memory::buffered_array<MEM,ComplexType,2> Tau_k(nelec[is],nu);
       for(int iw=0; iw<nw; ++iw) {
-      
+
         for(int k2=0; k2<nkpts; k2++) {
           auto Xju = Xsiu(is%nstot,k2,range((p2%nptot)*nbnd,(p2%nptot+1)*nbnd),all);
           nda::blas::gemm(G(iw,range(is*nup,nup+is*ndown),p2,k2,all),Xju,Tau);
 
-          int n0 = 0; 
           for(int k1=0; k1<nkpts; k1++) {
-            int nel_k = nocc_per_kp(is,k1);
+            auto const& rows = nocc_per_kp(is,k1);
+            int nel_k = int(rows.size());
             auto Yau = Ysau(is%nstot,p1%nptot,k1,range(nel_k),all);
-            nda::blas::gemm(ComplexType(a),nda::transpose(Yau),Tau(range(n0,n0+nel_k),all),
-                            ComplexType(1.0),GKK(k1,k2,iw,all,all));
-            n0 += nel_k;
+            if(contiguous_rows(rows)) {
+              int r0 = rows(0);
+              nda::blas::gemm(ComplexType(a),nda::transpose(Yau),Tau(range(r0,r0+nel_k),all),
+                              ComplexType(1.0),GKK(k1,k2,iw,all,all));
+            } else {
+              auto Tk = Tau_k(range(nel_k),all);
+              for(int i=0; i<nel_k; ++i) Tk(i,all) = Tau(rows(i),all);
+              nda::blas::gemm(ComplexType(a),nda::transpose(Yau),Tk,
+                              ComplexType(1.0),GKK(k1,k2,iw,all,all));
+            }
           }  //k1
-        } // k2 
+        } // k2
 
       } // iw
     } else {
@@ -896,8 +904,8 @@ protected:
     long p2_ = long(p2)%nptot;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int nel  = (walker_type == COLLINEAR ? nup+ndown : nup); // NONCOLLINEAR has ndown=0 
-    int n0 = ( k1==0 ? 0 : nda::sum(nocc_per_kp(ispin,range(k1))) );
-    int nel_k1 = nocc_per_kp(ispin,k1);
+    auto const& rows = nocc_per_kp(ispin,k1);
+    int nel_k1 = int(rows.size());
     bool has_rot = _Xsiu_rot_.has_value();
     const auto Xiu = ( has_rot ? (*_Xsiu_rot_)()(ispin%nstot,k2,range(p2_*nbnd,(p2_+1)*nbnd),all) : 
                                   _Xsiu_()(ispin%nstot,k2,range(p2_*nbnd,(p2_+1)*nbnd),all) );
@@ -911,9 +919,17 @@ protected:
     utils::check(Tbuff.size() >= nw*nel_k1*nu, "THC::get_Guv: Twav size mismatch.");
     memory::array_view<MEM,ComplexType,3> Twav(std::array<long,3>{nw,nel_k1,nu},Tbuff.data());
 
-    auto Gwai = G(all,range(ispin*nup+n0,ispin*nup+n0+nel_k1),p2,k2,all);
     // Twav[w][a][v] = sum_j G[w][a][j] X[j][v]
-    nda::tensor::contract(Gwai,"wai",Xiu,"iv",Twav,"wav");
+    if(contiguous_rows(rows)) {
+      int r0 = ispin*nup + rows(0);
+      auto Gwai = G(all,range(r0,r0+nel_k1),p2,k2,all);
+      nda::tensor::contract(Gwai,"wai",Xiu,"iv",Twav,"wav");
+    } else {
+      memory::buffered_array<MEM,ComplexType,3> Gg(nw,nel_k1,nbnd);
+      for(int aa=0; aa<nel_k1; ++aa)
+        Gg(all,aa,all) = G(all,ispin*nup+rows(aa),p2,k2,all);
+      nda::tensor::contract(Gg,"wai",Xiu,"iv",Twav,"wav");
+    }
     // G[w][u][v] = sum_a X[a][u] Twav[w][a][v]
     nda::tensor::contract(Yau,"au",Twav,"wav",Guv,"wuv");
 
@@ -934,7 +950,8 @@ protected:
   int nelec[2];
   int nkpts, nbnd;
 
-  nda::array<int,2> nocc_per_kp;
+  // For each (spin,kpoint): the list of occupied PsiT row indices at that kpoint.
+  nda::array<nda::array<int,1>,2> nocc_per_kp;
 
   // BZ information
   nda::array<int,1> minusq;

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -220,10 +220,9 @@ public:
       Guu() = ComplexType(0.0);
       for (int ispin = 0; ispin < nspin; ++ispin)
       {
-        long is_ = long(ispin)%nspin_in_H; 
         for (int p1 = 0; p1 < npol; ++p1)
         {
-          long ip1_ = long(p1)%npol_in_H; 
+          auto [is_,ip1_] = interaction_block(ispin,p1,npol,nspin_in_H,npol_in_H);
           for (int p2 = 0; p2 < npol; ++p2)
           {
             // Buffer space
@@ -368,10 +367,9 @@ public:
       memory::buffered_array<MEM,ComplexType,2> Guu(nu,nw);
       Guu() = ComplexType(0.0);
 
-      long is_ = long(ispin)%nspin_in_H; 
       for (int p1 = 0; p1 < npol; ++p1)
       {
-        long ip1_ = long(p1)%npol_in_H; 
+        auto [is_,ip1_] = interaction_block(ispin,p1,npol,nspin_in_H,npol_in_H);
         for (int p2 = 0; p2 < npol; ++p2)
         {
           // Buffer space
@@ -666,7 +664,8 @@ protected:
     for( int is=0; is<nspin; is++ ) {
       for( int ip=0; ip<npol; ip++ ) {
         
-        auto Xiu = Xsiu(is%nspin_in_H,range(ip%npol_in_H*NMO,(ip%npol_in_H+1)*NMO),all);
+        auto [is_,ip_] = interaction_block(is,ip,npol,nspin_in_H,npol_in_H);
+        auto Xiu = Xsiu(is_,range(ip_*NMO,(ip_+1)*NMO),all);
         auto Yau = Ysau(is,ip,range(nelec[is]),all);
 
         if constexpr (MEM==HOST_MEMORY) {
@@ -762,15 +761,15 @@ protected:
   {
     using nda::range;
     auto all = range::all;
-    long nspin_in_H = _Xsiu_().shape()[0]; 
-    long npol_in_H = _Xsiu_().shape()[1]/NMO; 
-    long ip_ = long(p2)%npol_in_H;
-    range M_rng(ip_*NMO,(ip_+1)*NMO);
+    long nspin_in_H = _Xsiu_().shape()[0];
+    long npol_in_H = _Xsiu_().shape()[1]/NMO;
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
-    int nel  = G.extent(1); 
+    auto [is_,ip_] = interaction_block(ispin,p2,npol,nspin_in_H,npol_in_H);
+    range M_rng(ip_*NMO,(ip_+1)*NMO);
+    int nel  = G.extent(1);
     bool has_rot = _Xsiu_rot_.has_value();
-    const auto Xiu = ( has_rot ? (*_Xsiu_rot_)()(ispin%nspin_in_H,M_rng,all) : 
-                                  _Xsiu_()(ispin%nspin_in_H,M_rng,all) );
+    const auto Xiu = ( has_rot ? (*_Xsiu_rot_)()(is_,M_rng,all) :
+                                  _Xsiu_()(is_,M_rng,all) );
     const auto Yau = ( has_rot ? (*_Ydsau_rot_)()(idet,ispin,p1,range(nelec[ispin]),all) : 
                                  _Ydsau_()(idet,ispin,p1,range(nelec[ispin]),all) );
     int nw = int(G.extent(0));

--- a/src/AFQMC/HamiltonianOperations/detail/one_body.hpp
+++ b/src/AFQMC/HamiltonianOperations/detail/one_body.hpp
@@ -49,6 +49,14 @@ void broadcast_one_body(nda::ArrayOfRank<5> auto const& src, nda::ArrayOfRank<5>
   }
 }
 
+// Maps a walker (spin is, pol ip) to the (spin, pol) block of an interaction tensor stored
+// with native symmetry (nspin_in_H, npol_in_H). Folds collinear spin blocks into
+// noncollinear polarization blocks, consistent with broadcast_one_body() above.
+inline std::array<int,2> interaction_block(int is, int ip, int npol, int nspin_in_H, int npol_in_H) {
+  int c = (is*npol + ip) % (nspin_in_H * npol_in_H);
+  return {c / npol_in_H, c % npol_in_H};
+}
+
 // comuptes H' = H + meanfield_shift + vexx. The meanfield shift was created as vHS(vMF) so it already includes dt.
 void add_one_body_shifts(RealType dt, nda::ArrayOfRank<3> auto const& hij, nda::ArrayOfRank<4> auto const& meanfield_shift, nda::ArrayOfRank<3> auto const& vexx, nda::ArrayOfRank<5> auto&& dest) {
   auto all = nda::range::all;

--- a/src/AFQMC/HamiltonianOperations/detail/one_body.hpp
+++ b/src/AFQMC/HamiltonianOperations/detail/one_body.hpp
@@ -2,6 +2,8 @@
 
 #include "AFQMC/config.h"
 #include "utilities/check_shape.hpp"
+#include "utilities/mpi_context.h"
+#include "numerics/shared_array/const_shared_array.hpp"
 
 namespace sfqmc::afqmc {
 
@@ -104,6 +106,37 @@ void kpoint_add_one_body_shifts(RealType dt, nda::ArrayOfRank<4> auto const& hij
       }
     }
   }
+}
+
+template<MEMORY_SPACE MEM, std::size_t N>
+auto half_rotate_hamiltonian(utils::mpi_context_t<mpi3::communicator>& mpi, std::array<long,N> nel, int nspin, int npol, int nspin_in_H1, int npol_in_H1, int NMO, nda::ArrayOfRank<2> auto const &PsiT, nda::ArrayOfRank<3> auto const& H1) {
+  using nda::range;
+  auto all = range::all;
+  int ndet = PsiT.extent(0);
+
+  memory::const_shared_array<MEM, ComplexType, 3> haj;
+  {
+    // temporary broadcast H1 to walker_type
+    auto hc = memory::share_from_root(mpi, [&]() {
+      memory::array<MEM, ComplexType, 5> hc{nspin, npol, NMO, npol, NMO};
+      broadcast_one_body(nda::reshape(H1(), nspin_in_H1, npol_in_H1, NMO, npol_in_H1, NMO), hc);
+      return hc;
+    });
+  
+    haj = std::move(memory::share_from_ranks<MEM,ComplexType,3,1>(mpi,
+        {ndet, nel[0]+nel[1], npol*NMO},
+        [&](std::array<long,1> idx, auto&& block) {
+      auto [id] = idx;
+    
+      for(long is=0; is<nspin; ++is) {
+        auto Aai = math::sparse::to_array<'N'>(PsiT(id,is));
+        auto h_ = block(range(is*nel[0],nel[0]+is*nel[1]),all);
+        nda::blas::gemm(Aai,nda::reshape(hc(), nspin, npol*NMO, npol*NMO)(is, all, all), h_);
+      }
+    }));
+  }
+  mpi.shared_windows.collective_free_unused();
+  return haj;
 }
 
 }

--- a/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
+++ b/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
@@ -139,32 +139,32 @@ Hamiltonian HamiltonianFactory::fromHDF5(std::shared_ptr<utils::mpi_context_t<mp
   {
     if(mpi->comm.root())
       utils::check(format == "coqui", "Error: format: {} not yet implemented with this hamiltonian type.", format);
-    return Hamiltonian(KPTHCHamiltonian(AFinfo, pt, NuclearCoulombEnergy, FrozenCoreEnergy));
+    return Hamiltonian(KPTHCHamiltonian(pt, NuclearCoulombEnergy, FrozenCoreEnergy));
   }
   else if (htype == KPFactorized)
   {
     if(mpi->comm.root())
       utils::check(format == "coqui" or format == "std", "Error: format: {} not yet implemented with this hamiltonian type.", format);
-    return Hamiltonian(KPFactorizedHamiltonian(AFinfo, pt, NuclearCoulombEnergy, FrozenCoreEnergy));
+    return Hamiltonian(KPFactorizedHamiltonian(pt, NuclearCoulombEnergy, FrozenCoreEnergy));
   }
   else if (htype == RealDenseFactorized)
   {
     // CoQui does not generate real cholesky yet, it is hardwired to be complex
     if(mpi->comm.root())
       utils::check(format == "std", "Error: format: {} not yet implemented with this hamiltonian type.", format);
-    return Hamiltonian(RealDenseHamiltonian(AFinfo, pt, NuclearCoulombEnergy, FrozenCoreEnergy));
+    return Hamiltonian(RealDenseHamiltonian(pt, NuclearCoulombEnergy, FrozenCoreEnergy));
   }
   else if ( htype == ModelHamiltonian ) 
   {
     if(mpi->comm.root())
       utils::check(format == "std", "Error: format: {} not yet implemented with this hamiltonian type.", format);
-    return Hamiltonian(ModelHamOpsGenerator(AFinfo, pt, NuclearCoulombEnergy, FrozenCoreEnergy));
+    return Hamiltonian(ModelHamOpsGenerator(pt, NuclearCoulombEnergy, FrozenCoreEnergy));
   }
   else if ( htype == THC )
   {
     if(mpi->comm.root())
       utils::check(format == "coqui", "Error: format: {} not yet implemented with this hamiltonian type.", format);
-    return Hamiltonian(THCHamiltonian(AFinfo, pt, NuclearCoulombEnergy, FrozenCoreEnergy));
+    return Hamiltonian(THCHamiltonian(pt, NuclearCoulombEnergy, FrozenCoreEnergy));
   }
 
   utils::check(false, " Error in HamiltonianFactory::fromHDF5(): Unknown Hamiltonian Type. ");

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -334,15 +334,14 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
     });
   } // Q
 
- // kpoint dependent occupations
-  nda::array<int,2> nocc(nspin,nkpts);
-  if(mpi->comm.root())
-    nocc = nocc_per_kpoint(type,nkpts,PsiT);
-  mpi->broadcast(nocc);
-  auto nocc_max = nda::max_element(nocc);
-  utils::check(nel_up == nda::sum(nocc(0,all)), "Error: Mismatch in number of electrons: nel_up:{} sum(nel_up(k)):{}",nel_up,nda::sum(nocc(0,all)));
+ // kpoint dependent occupations: for each (spin,kpoint), the list of PsiT row
+ // indices occupying that kpoint. Computed on every rank (depends only on PsiT,
+ // which is replicated), so no broadcast of the ragged list-of-lists is needed.
+  auto nocc = nocc_per_kpoint(type,nkpts,PsiT);
+  auto nocc_max = max_nocc_per_kpoint(nocc);
+  utils::check(nel_up == nelec_for_spin(nocc,0), "Error: Mismatch in number of electrons: nel_up:{} sum(nel_up(k)):{}",nel_up,nelec_for_spin(nocc,0));
   if(type == COLLINEAR)
-    utils::check(nel_dn == nda::sum(nocc(1,all)), "Error: Mismatch in number of electrons: ndown:{} sum(ndown(k)):{}",nel_dn,nda::sum(nocc(1,all)));
+    utils::check(nel_dn == nelec_for_spin(nocc,1), "Error: Mismatch in number of electrons: ndown:{} sum(ndown(k)):{}",nel_dn,nelec_for_spin(nocc,1));
 
   /* half-rotate LQ and H1:
    * Given that PsiT = H(SM),
@@ -361,13 +360,13 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         [&](std::array<long,3> idx, auto&& block) {
       auto [id,is,ik] = idx;
       int is_ = is%nspin_in_H1;
-      int n0 = ( ik==0 ? 0 : nda::sum(nocc(is,range(ik))) );
-      int nk = nocc(is,ik);
+      auto const& rows = nocc(is,ik);
+      int nk = int(rows.size());
       for(long ip=0; ip<npol; ++ip) {
         int ip_ = ip%npol_in_H1;
         if(Q <= Qm) {
           // L[Q,k,k2=k-Q]
-          auto Aai = math::sparse::to_array<'N'>(PsiT(id,is),range(n0,n0+nk),
+          auto Aai = math::sparse::to_array<'N'>(PsiT(id,is),rows,
                                                  range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
           auto Lijn = LQ(Q)()(is_,ip_,ik,all,all,all);
           auto L_ = block(range(nk),all,range(ip*nbnd,(ip+1)*nbnd));
@@ -376,7 +375,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         } else {
           // L[Q,k,k2=k-Q]
           int k2 = qk_to_k2(Q,ik);
-          auto Abj = math::sparse::to_array<'N'>(PsiT(id,is),range(n0,n0+nk),
+          auto Abj = math::sparse::to_array<'N'>(PsiT(id,is),rows,
                                                  range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
           auto Lljn = LQ(Qm)()(is_,ip_,k2,all,all,all);
           auto L_ = block(range(nk),all,range(ip*nbnd,(ip+1)*nbnd));
@@ -398,12 +397,12 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         auto [id,is,k2] = idx;
         int is_ = is%nspin_in_H1;
         int ik = k2_to_k(k2);
-        int n0b = ( k2==0 ? 0 : nda::sum(nocc(is,range(k2))) );
-        int nb = nocc(is,k2);
+        auto const& rows = nocc(is,k2);
+        int nb = int(rows.size());
         for(long ip=0; ip<npol; ++ip) {
           int ip_ = ip%npol_in_H1;
           // conj(L[Q,k,k2](lj,n)) * A[k2]bj
-          auto Abj = math::sparse::to_array<'N'>(PsiT(id,is),range(n0b,n0b+nb),
+          auto Abj = math::sparse::to_array<'N'>(PsiT(id,is),rows,
                                                  range(ip*NMO+k2*nbnd,ip*NMO+(k2+1)*nbnd));
           auto Lljn = LQ(Q)()(is_,ip_,ik,all,all,all);
           auto L_ = block(range(nb),all,range(ip*nbnd,(ip+1)*nbnd));

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -63,7 +63,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   long nel_up = PsiT(0,0).extent(0);
   long NMO = PsiT(0,0).extent(1)/npol;
   utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.extent(1)%npol != 0");
-  utils::check(nspin_in_PsiT==1 or nspin_in_PsiT==nspin, "Size mismatch");
+  utils::check(nspin_in_PsiT==nspin, "Size mismatch");
   utils::check(ndet==1, "Error: ndet > 1 not yet implemented in KPFactorizedHamiltonian::getHamiltonianOperations.");
   long nel_dn = ( type == FULLYPOLARIZED or type == NONCOLLINEAR ? 0l :
               (type == CLOSED ? nel_up : PsiT(0,nspin_in_PsiT-1).extent(0) ) );
@@ -77,8 +77,8 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   utils::check(nel_up >= nel_dn, base_error + "nel_up:{} < nel_dn:{} not allowed.",nel_up,nel_dn);
 
   // Hamiltonian variables
-  int nspin_in_file = nspin;
-  int npol_in_file = npol;
+  int nspin_in_H1 = nspin;
+  int npol_in_H1 = npol;
   // BZ variables
   int nkpts = 1;
   int nqpts = 1;
@@ -115,21 +115,21 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         utils::check(nqpts == nkpts, base_error + "nqpts != nkpts, nqpts:{}, nkpts:{}",nqpts,nkpts);
         h5::h5_read_attribute(bz,"number_of_qpoints_ibz",nqpts_ibz);
         // nbnd
-        int nbnd_in_file{};
-        h5::h5_read_attribute(hgrp,"number_of_bands",nbnd_in_file);  // per kpoint
+        int nbnd_in_H1{};
+        h5::h5_read_attribute(hgrp,"number_of_bands",nbnd_in_H1);  // per kpoint
         // check nbnd 
         nbnd = long(NMO/nkpts);
         utils::check(NMO%nkpts==0, base_error + "NMO%nkpts != 0, NMO: {}, nkpts: {}",NMO,nkpts);
-        utils::check((NMO/nkpts)==nbnd_in_file, base_error + "nbnd: {} differs from file: {}",nbnd,nbnd_in_file);
-        // read nspin_in_file
-        h5::h5_read_attribute(hgrp,"number_of_spins",nspin_in_file);
-        // read npol_in_file
+        utils::check((NMO/nkpts)==nbnd_in_H1, base_error + "nbnd: {} differs from file: {}",nbnd,nbnd_in_H1);
+        // read nspin_in_H1
+        h5::h5_read_attribute(hgrp,"number_of_spins",nspin_in_H1);
+        // read npol_in_H1
 //        h5::h5_read_attribute(bz,"number_of_polarizations",n);
-//        npol_in_file=long(n);
+//        npol_in_H1=long(n);
         // TODO: does this format even support polarizations?
-        npol_in_file = 1;
+        npol_in_H1 = 1;
 
-        utils::check(walkerDimsAreConvertible(nspin_in_file, npol_in_file, nspin, npol), "Hamiltonian with nspin: {}, npol: {} cannot be broadcasted to {}", nspin_in_file, npol_in_file, walkerTypeToString(type));
+        utils::check(walkerDimsAreConvertible(nspin_in_H1, npol_in_H1, nspin, npol), "Hamiltonian with nspin: {}, npol: {} cannot be broadcasted to {}", nspin_in_H1, npol_in_H1, walkerTypeToString(type));
         minusq.resize(nkpts);
         nda::h5_read(bz,"qminus",minusq);
         qk_to_k2.resize(nkpts,nkpts);
@@ -156,7 +156,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         // interaction
         h5::group igrp = grp.open_group("Interaction");
 
-        auto expected_shape = std::to_array<long>({nspin_in_file * npol_in_file, nkpts, nbnd, nbnd});
+        auto expected_shape = std::to_array<long>({nspin_in_H1 * npol_in_H1, nkpts, nbnd, nbnd});
         nchol.resize(nkpts); 
         for(int Q=0; Q<nkpts; ++Q) {
           auto l = h5::array_interface::get_dataset_info(igrp,"Vq"+std::to_string(Q));
@@ -174,8 +174,8 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       //      was/is limited to spin independent basis sets. Generalize this if needed...
       // Current implementation is limited to cases with a consistent number of bands 
       // per kpoint, unlikely we will go back to the more general case.
-      nspin_in_file = 1;
-      npol_in_file  = 1;
+      nspin_in_H1 = 1;
+      npol_in_H1  = 1;
       h5::group hgrp = grp.open_group("Hamiltonian");
       std::vector<int> Idata(8);
       h5::h5_read(hgrp,"dims",Idata);
@@ -223,8 +223,8 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
     }
   } // root
 
-  mpi->comm.broadcast_value(nspin_in_file);
-  mpi->comm.broadcast_value(npol_in_file);
+  mpi->comm.broadcast_value(nspin_in_H1);
+  mpi->comm.broadcast_value(npol_in_H1);
   mpi->comm.broadcast_value(nbnd);
   mpi->comm.broadcast_value(nkpts);
   mpi->comm.broadcast_value(nkpts_ibz);
@@ -256,12 +256,12 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   // Read hamiltonian components from h5. Only root reads
   // H0: /System/H0:   [nspin][nkpts][npol*nbnd][npol*nbnd]
   auto H1 = memory::share_from_root(*mpi, [&]() {
-    nda::array<ComplexType,4> H1_h(nspin_in_file,nkpts,npol_in_file*nbnd,npol_in_file*nbnd);
+    nda::array<ComplexType,4> H1_h(nspin_in_H1,nkpts,npol_in_H1*nbnd,npol_in_H1*nbnd);
     h5::group grp = h5::group(file);
 
     if(format == "std") {
 
-      utils::check(npol_in_file==1 and nspin_in_file==1, "KPFactorized: std format requires nspin_in_file==1 and npol_in_file==1.");
+      utils::check(npol_in_H1==1 and nspin_in_H1==1, "KPFactorized: std format requires nspin_in_H1==1 and npol_in_H1==1.");
 
       h5::group hgrp = grp.open_group("Hamiltonian");
 
@@ -278,7 +278,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       if(nkpts_ibz == nkpts) {
         utils::h5_read(sgrp,"H0",H1_h());
       } else {
-        nda::array<ComplexType,4> H1_ibz(nspin_in_file, nkpts_ibz, npol_in_file*nbnd, npol_in_file*nbnd);
+        nda::array<ComplexType,4> H1_ibz(nspin_in_H1, nkpts_ibz, npol_in_H1*nbnd, npol_in_H1*nbnd);
         utils::h5_read(sgrp,"H0",H1_ibz());
 
         nda::vector<int> kp_to_ibz(nkpts);
@@ -300,7 +300,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   });
 
   app_log(2, "KPFactorizedHamiltonian: Allocating Lijn: {} GB",
-    number_of_allocated_Q*nspin_in_file*npol_in_file*nkpts*nbnd*nbnd*nchol_av*GBx);
+    number_of_allocated_Q*nspin_in_H1*npol_in_H1*nkpts*nbnd*nbnd*nchol_av*GBx);
   // L(Q)(ispin*ip,ik,i,j,n): Since each qpoint has its own nchol
   // Entries with Q > minusq(Q) are never read and stay default-constructed (empty)
   nda::array<memory::const_shared_array<MEM,ComplexType,6>,1> LQ(nkpts);
@@ -310,7 +310,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
     }
     // too much memory? replace by share_from_ranks?
     LQ(Q) = memory::share_from_root(*mpi, [&]() {
-      nda::array<ComplexType,6> L_h(nspin_in_file,npol_in_file,nkpts,nbnd,nbnd,nchol(Q));
+      nda::array<ComplexType,6> L_h(nspin_in_H1,npol_in_H1,nkpts,nbnd,nbnd,nchol(Q));
       h5::group grp = h5::group(file);
 
       if(format == "std") {
@@ -321,11 +321,11 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         // normalization (1/sqrt(nkpts)) assummed to be included
       } else if(format == "coqui") {
         h5::group igrp = grp.open_group("Interaction");
-        nda::array<ComplexType,5> L(nchol(Q),nspin_in_file*npol_in_file,nkpts,nbnd,nbnd);
+        nda::array<ComplexType,5> L(nchol(Q),nspin_in_H1*npol_in_H1,nkpts,nbnd,nbnd);
         utils::h5_read(igrp,"Vq"+std::to_string(Q),L);
-        utils::check_shape(L, "Vq", nchol(Q), nspin_in_file*npol_in_file, nkpts, nbnd, nbnd);
-        auto L2d = nda::reshape(L,std::array<long,2>{nchol(Q),nspin_in_file*npol_in_file*nkpts*nbnd*nbnd});
-        auto LQ2d = nda::reshape(L_h(),std::array<long,2>{nspin_in_file*npol_in_file*nkpts*nbnd*nbnd,nchol(Q)});
+        utils::check_shape(L, "Vq", nchol(Q), nspin_in_H1*npol_in_H1, nkpts, nbnd, nbnd);
+        auto L2d = nda::reshape(L,std::array<long,2>{nchol(Q),nspin_in_H1*npol_in_H1*nkpts*nbnd*nbnd});
+        auto LQ2d = nda::reshape(L_h(),std::array<long,2>{nspin_in_H1*npol_in_H1*nkpts*nbnd*nbnd,nchol(Q)});
         LQ2d() = nda::transpose(L2d());
         // normalize
         nda::tensor::scale(ComplexType(1.0/std::sqrt(RealType(nkpts))), L_h());
@@ -350,7 +350,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
    *  where a includes the kpoint index implicitly, e.g. a:{0,nup/ndown}
    */
   app_log(2, "KPFactorizedHamiltonian: Allocating Lank: {} GB",
-        (number_of_symmetric_Q+nkpts)*ndet*nspin_in_file*npol_in_file*nel_up*nbnd*nchol_av*GBx);
+        (number_of_symmetric_Q+nkpts)*ndet*nspin_in_H1*npol_in_H1*nel_up*nbnd*nchol_av*GBx);
   nda::array<memory::const_shared_array<MEM,ComplexType,6>,1> Lank(nkpts);
   nda::array<memory::const_shared_array<MEM,ComplexType,6>,1> Lbnk(number_of_symmetric_Q);
 // should be nspin_in_PsiT instead of nspin!!!
@@ -360,14 +360,14 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         {ndet,nspin,nkpts,nocc_max,nchol(Q),npol*nbnd},
         [&](std::array<long,3> idx, auto&& block) {
       auto [id,is,ik] = idx;
-      int is_ = is%nspin_in_file;
+      int is_ = is%nspin_in_H1;
       int n0 = ( ik==0 ? 0 : nda::sum(nocc(is,range(ik))) );
       int nk = nocc(is,ik);
       for(long ip=0; ip<npol; ++ip) {
-        int ip_ = ip%npol_in_file;
+        int ip_ = ip%npol_in_H1;
         if(Q <= Qm) {
           // L[Q,k,k2=k-Q]
-          auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),range(n0,n0+nk),
+          auto Aai = math::sparse::to_array<'N'>(PsiT(id,is),range(n0,n0+nk),
                                                  range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
           auto Lijn = LQ(Q)()(is_,ip_,ik,all,all,all);
           auto L_ = block(range(nk),all,range(ip*nbnd,(ip+1)*nbnd));
@@ -376,7 +376,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         } else {
           // L[Q,k,k2=k-Q]
           int k2 = qk_to_k2(Q,ik);
-          auto Abj = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),range(n0,n0+nk),
+          auto Abj = math::sparse::to_array<'N'>(PsiT(id,is),range(n0,n0+nk),
                                                  range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
           auto Lljn = LQ(Qm)()(is_,ip_,k2,all,all,all);
           auto L_ = block(range(nk),all,range(ip*nbnd,(ip+1)*nbnd));
@@ -396,14 +396,14 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
           {ndet,nspin,nkpts,nocc_max,nchol(Q),npol*nbnd},
           [&](std::array<long,3> idx, auto&& block) {
         auto [id,is,k2] = idx;
-        int is_ = is%nspin_in_file;
+        int is_ = is%nspin_in_H1;
         int ik = k2_to_k(k2);
         int n0b = ( k2==0 ? 0 : nda::sum(nocc(is,range(k2))) );
         int nb = nocc(is,k2);
         for(long ip=0; ip<npol; ++ip) {
-          int ip_ = ip%npol_in_file;
+          int ip_ = ip%npol_in_H1;
           // conj(L[Q,k,k2](lj,n)) * A[k2]bj
-          auto Abj = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),range(n0b,n0b+nb),
+          auto Abj = math::sparse::to_array<'N'>(PsiT(id,is),range(n0b,n0b+nb),
                                                  range(ip*NMO+k2*nbnd,ip*NMO+(k2+1)*nbnd));
           auto Lljn = LQ(Q)()(is_,ip_,ik,all,all,all);
           auto L_ = block(range(nb),all,range(ip*nbnd,(ip+1)*nbnd));
@@ -415,45 +415,30 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   }  // Q
 
   // haj(idet,a_is_ik,j_ip_ik) = sum_j PsiT(idet,is)(a_is,i) H1(is,ik,i,j_ip)
-  long nel[] = {nel_up, (type == COLLINEAR ? nel_dn : 0l) };
-  auto haj = memory::share_from_ranks<MEM,ComplexType,3,1>(*mpi,
-      {ndet, nel[0]+nel[1], npol*NMO},
-      [&](std::array<long,1> idx, auto&& block) {
-    auto [id] = idx;
-    for(long is=0; is<nspin; ++is) {
-      for(long ik=0; ik<nkpts; ++ik) {
-        int n0 = ( ik==0 ? 0 : nda::sum(nocc(is,range(ik))) );
-        int nk = nocc(is,ik);
-        for(long ip1=0; ip1<npol; ++ip1) {
-          int ip1_ = ip1%npol_in_file;
-          auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),range(n0,n0+nk),range(ip1*NMO+ik*nbnd,ip1*NMO+(ik+1)*nbnd));
-          // haj = PsiT * H1
-          for(long ip2=0; ip2<npol; ++ip2) {
-            int ip2_ = ip2%npol_in_file;
-            auto h_ = block(range(is*nel_up+n0,is*nel_up+n0+nk),nda::range(ip2*NMO+ik*nbnd,ip2*NMO+(ik+1)*nbnd));
-            if constexpr (MEM==HOST_MEMORY) {
-              auto hij = H1()(is%nspin_in_file,ik,range(ip1_*nbnd,(ip1_+1)*nbnd),range(ip2_*nbnd,(ip2_+1)*nbnd));
-              nda::blas::gemm(one,Aai,hij,one,h_);
-            } else {
-              memory::array<MEM,ComplexType,2> hij(H1()(is%nspin_in_file,ik,range(ip1_*nbnd,(ip1_+1)*nbnd),range(ip2_*nbnd,(ip2_+1)*nbnd)));
-              nda::blas::gemm(one,Aai,hij,one,h_);
-            }
-          } // ip2
-        } // ip1
-      } // ik
-    }  // is
+  auto nel = std::to_array<long>({nel_up, (type == COLLINEAR ? nel_dn : 0l)});
+
+  auto hfull = memory::share_from_root(*mpi, [&](){
+    memory::array<MEM,ComplexType,3> hfull(nspin_in_H1, npol_in_H1*nkpts*nbnd, npol_in_H1*nkpts*nbnd);
+    hfull() = 0;
+    auto hfull7 = nda::reshape(hfull, nspin_in_H1, npol_in_H1, nkpts, nbnd, npol_in_H1, nkpts, nbnd);
+    for(int ik = 0; ik < nkpts; ik++) {
+      hfull7(all, all, ik, all, all, ik, all) = nda::reshape(H1(), nspin_in_H1, nkpts, npol_in_H1, nbnd, npol_in_H1, nbnd)(all, ik, all, all, all, all);
+    }
+
+    return hfull;
   });
+  auto haj = half_rotate_hamiltonian<MEM>(*mpi, nel, nspin, npol, nspin_in_H1, npol_in_H1, NMO, PsiT(), hfull());
 
   // calculate vn0
   // v0(s,k,i,l) = -0.5*sum_k,q sum_j <i_k,j_k-q|j_k-q,l_k>
   //         = -0.5 sum_kq sum_j,n L[Q](s,k,i,j,n) conj( L[Q](s,k,l,j) )
   auto v0 = memory::share_from_ranks<HOST_MEMORY,ComplexType,4,2>(*mpi,
-      {nspin_in_file*npol_in_file, nkpts, nbnd, nbnd},
+      {nspin_in_H1*npol_in_H1, nkpts, nbnd, nbnd},
       [&](std::array<long,2> idx, auto&& block) {
     memory::buffered_array<MEM,ComplexType,2> vt(nbnd,nbnd);
     auto [isp,ik] = idx;
-    long is_ = isp/npol_in_file;
-    long ip_ = isp%npol_in_file;
+    long is_ = isp/npol_in_H1;
+    long ip_ = isp%npol_in_H1;
     vt() = zero;
     for(long Q=0; Q<nkpts; Q++) {
       if(Q<=minusq(Q)) {

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -66,8 +66,7 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.extent(1)%npol != 0");
   utils::check(nspin_in_PsiT==nspin, "Size mismatch");
   utils::check(ndet==1, "Error: ndet > 1 not yet implemented in KPFactorizedHamiltonian::getHamiltonianOperations.");
-  long nel_dn = ( type == FULLYPOLARIZED or type == NONCOLLINEAR ? 0l :
-              (type == CLOSED ? nel_up : PsiT(0,nspin_in_PsiT-1).extent(0) ) );
+  long nel_dn = (type == COLLINEAR ? PsiT(0,1).extent(0) : 0l);
   for(int i=0; i<ndet; ++i) {
     for(int ip=0; ip<npol; ++ip) {
       utils::check_shape(PsiT(i,0), "PsiT", nel_up, npol*NMO);

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -35,6 +35,7 @@
 #include "KPFactorizedHamiltonian.h"
 #include "AFQMC/Utilities/wfn_utils.hpp"
 #include "AFQMC/Hamiltonians/hdf5_helpers.hpp"
+#include "AFQMC/HamiltonianOperations/detail/one_body.hpp"
 
 #include "numerics/sparse/sparse.hpp"
 #include "numerics/shared_array/const_shared_array.hpp"
@@ -352,18 +353,16 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         (number_of_symmetric_Q+nkpts)*ndet*nspin_in_H1*npol_in_H1*nel_up*nbnd*nchol_av*GBx);
   nda::array<memory::const_shared_array<MEM,ComplexType,6>,1> Lank(nkpts);
   nda::array<memory::const_shared_array<MEM,ComplexType,6>,1> Lbnk(number_of_symmetric_Q);
-// should be nspin_in_PsiT instead of nspin!!!
   for(int Q=0; Q<nkpts; ++Q) {
     int Qm = minusq(Q);
     Lank(Q) = memory::share_from_ranks<MEM,ComplexType,6,3>(*mpi,
         {ndet,nspin,nkpts,nocc_max,nchol(Q),npol*nbnd},
         [&](std::array<long,3> idx, auto&& block) {
       auto [id,is,ik] = idx;
-      int is_ = is%nspin_in_H1;
       auto const& rows = nocc(is,ik);
       int nk = int(rows.size());
       for(long ip=0; ip<npol; ++ip) {
-        int ip_ = ip%npol_in_H1;
+        auto [is_,ip_] = interaction_block(is,ip,npol,nspin_in_H1,npol_in_H1);
         if(Q <= Qm) {
           // L[Q,k,k2=k-Q]
           auto Aai = math::sparse::to_array<'N'>(PsiT(id,is),rows,
@@ -395,12 +394,11 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
           {ndet,nspin,nkpts,nocc_max,nchol(Q),npol*nbnd},
           [&](std::array<long,3> idx, auto&& block) {
         auto [id,is,k2] = idx;
-        int is_ = is%nspin_in_H1;
         int ik = k2_to_k(k2);
         auto const& rows = nocc(is,k2);
         int nb = int(rows.size());
         for(long ip=0; ip<npol; ++ip) {
-          int ip_ = ip%npol_in_H1;
+          auto [is_,ip_] = interaction_block(is,ip,npol,nspin_in_H1,npol_in_H1);
           // conj(L[Q,k,k2](lj,n)) * A[k2]bj
           auto Abj = math::sparse::to_array<'N'>(PsiT(id,is),rows,
                                                  range(ip*NMO+k2*nbnd,ip*NMO+(k2+1)*nbnd));

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.h
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.h
@@ -33,17 +33,15 @@ namespace sfqmc
 {
 namespace afqmc
 {
-class KPFactorizedHamiltonian : public AFQMCInfo 
+class KPFactorizedHamiltonian
 {
 public:
 
-  KPFactorizedHamiltonian(AFQMCInfo const& info,
-                          ptree pt_in,
+  KPFactorizedHamiltonian(ptree pt_in,
                           ComplexType nucE = 0,
                           ComplexType fzcE = 0)
-      : AFQMCInfo(info),
-	NuclearCoulombEnergy(nucE),
-	FrozenCoreEnergy(fzcE),	
+      : NuclearCoulombEnergy(nucE),
+      	FrozenCoreEnergy(fzcE),	
         fileName("")
   {
     // convert user input to verbose input
@@ -52,7 +50,6 @@ public:
     app_log(2, "{}", io::to_string(pt));
     // initialize using verbose input
     fileName  = pt.get<std::string>("filename");
-    name      = pt.get<std::string>("name");
     buffer_size = pt.get<int>("buffer_size");
   }
 

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -36,6 +36,7 @@
 #include "KPTHCHamiltonian.h"
 #include "AFQMC/Utilities/wfn_utils.hpp"
 #include "AFQMC/Hamiltonians/hdf5_helpers.hpp"
+#include "AFQMC/HamiltonianOperations/detail/one_body.hpp"
 
 #include "numerics/sparse/sparse.hpp"
 #include "numerics/shared_array/const_shared_array.hpp"
@@ -72,7 +73,7 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   long nel_up = PsiT(0,0).extent(0);
   long NMO = PsiT(0,0).extent(1)/npol;
   utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.size(1)%npol != 0");
-  utils::check(nspin_in_PsiT==1 or nspin_in_PsiT==nspin, "Size mismatch");
+  utils::check(nspin_in_PsiT==nspin, "Size mismatch");
   utils::check(ndet==1, "Error: ndet > 1 not yet implemented in KPTHCHamiltonian::getHamiltonianOperations.");
   long nel_dn = ( type == FULLYPOLARIZED or type == NONCOLLINEAR ? 0l :
               (type == CLOSED ? nel_up : PsiT(0,nspin_in_PsiT-1).extent(0) ) );
@@ -85,8 +86,8 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   utils::check(nel_up >= nel_dn, base_error + "nel_up:{} < nel_dn:{} not allowed.",nel_up,nel_dn);
 
   // THC variables
-  long nspin_in_file = nspin;
-  long npol_in_file = npol;
+  long nspin_in_H1 = nspin;
+  long npol_in_H1 = npol;
   // ISDF variables
   long nu = 1; // number of interpolating points/vectors
   long nv = 1; // number of columns of Vuv matrix
@@ -138,13 +139,13 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       utils::check(NMO%nkpts==0, base_error + "NMO%nkpts != 0, NMO:{}, nkpts:{}",NMO,nkpts);
       utils::check((NMO/nkpts)==n, base_error + "nbnd:{} differs from file n:{}",nbnd,n);
       nbnd = long(NMO/nkpts);
-      // read nspin_in_file
+      // read nspin_in_H1
       h5::h5_read_attribute(*hgrp,"number_of_spins",n);
-      nspin_in_file = long(n);
-      // read npol_in_file
+      nspin_in_H1 = long(n);
+      // read npol_in_H1
 //      h5::h5_read_attribute(bz,"number_of_polarizations",n);
-//      npol_in_file=long(n);
-      utils::check(walkerDimsAreConvertible(nspin_in_file, npol_in_file, nspin, npol), "Hamiltonian with nspin: {}, npol: {} cannot be broadcasted to {}", nspin_in_file, npol_in_file, walkerTypeToString(type));
+//      npol_in_H1=long(n);
+      utils::check(walkerDimsAreConvertible(nspin_in_H1, npol_in_H1, nspin, npol), "Hamiltonian with nspin: {}, npol: {} cannot be broadcasted to {}", nspin_in_H1, npol_in_H1, walkerTypeToString(type));
       minusq.resize(nkpts);
       nda::h5_read(bz,"qminus",minusq);
       qk_to_k2.resize(nkpts,nkpts);
@@ -173,13 +174,13 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       // check consistency
 // MAM: fix this, integer types in h5 file are not consistent!!!
       long n;
-      // read nspin_in_file
+      // read nspin_in_H1
       h5::h5_read_attribute(igrp,"number_of_spins",n);
-      utils::check(nspin_in_file==n,
+      utils::check(nspin_in_H1==n,
                    base_error + " Incompatible nspin:{} in h5::/Interaction.",n);
-      // read npol_in_file
+      // read npol_in_H1
 //      h5::h5_read_attribute(igrp,"number_of_polarizations",n);
-//      utils::check(npol_in_file==n,
+//      utils::check(npol_in_H1==n,
 //                   base_error + " Incompatible npol:{} in h5::/Interaction.",n);
       // nbnd 
       h5::h5_read_attribute(igrp,"number_of_bands",n);
@@ -193,7 +194,7 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       // now read dimensions
       auto lX = h5::array_interface::get_dataset_info(igrp,"collocation_matrix");
       nu = lX.lengths[3];
-      utils::check_shape(lX, "collocation_matrix", nspin_in_file, nkpts, nbnd, nu);
+      utils::check_shape(lX, "collocation_matrix", nspin_in_H1, nkpts, nbnd, nu);
       auto lL = h5::array_interface::get_dataset_info(igrp,"factorized_coulomb_matrix");
       nv = lL.lengths[2];
       utils::check_shape(lL, "factorized_coulomb_matrix", nqpts_ibz, nu, nv);
@@ -201,7 +202,7 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         have_rot_coul = 1;
         auto lXr = h5::array_interface::get_dataset_info(igrp,"collocation_matrix_half_rotated");
         nu_rot = lXr.lengths[3];
-        utils::check_shape(lXr, "collocation_matrix_half_rotated", nspin_in_file, nkpts, nbnd, nu_rot);
+        utils::check_shape(lXr, "collocation_matrix_half_rotated", nspin_in_H1, nkpts, nbnd, nu_rot);
         auto lZr = h5::array_interface::get_dataset_info(igrp,"half_rotated_coulomb_matrix");
         nv_rot = lZr.lengths[2];
         utils::check_shape(lZr, "half_rotated_coulomb_matrix", nqpts_ibz, nu_rot, nv_rot);
@@ -215,8 +216,8 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       }
     }
   }
-  mpi->comm.broadcast_value(nspin_in_file);
-  mpi->comm.broadcast_value(npol_in_file);
+  mpi->comm.broadcast_value(nspin_in_H1);
+  mpi->comm.broadcast_value(npol_in_H1);
   mpi->comm.broadcast_value(nu);
   mpi->comm.broadcast_value(nv);
   mpi->comm.broadcast_value(nu_rot);
@@ -250,7 +251,7 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   // read H1.
   // H0: /System/H0:   [nspin][nkpts][npol*nbnd][npol*nbnd]   Only needed in host memory
   auto H1 = memory::share_from_root(*mpi, [&]() {
-    nda::array<ComplexType,4> A(nspin_in_file,nkpts,npol_in_file*nbnd,npol_in_file*nbnd);
+    nda::array<ComplexType,4> A(nspin_in_H1,nkpts,npol_in_H1*nbnd,npol_in_H1*nbnd);
     utils::h5_read(*hgrp,"H0",A);
     return A;
   });
@@ -261,7 +262,7 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   // Xrot: /Interaction/collocation_matrix_half_rotated:  [nspins,nkpts,nbnd,Nu]
   // Zrot: /Interaction/half_rotated_coulomb_matrix:      [Nq][Nu][Nv]
   auto Xsiu = share_read("collocation_matrix",
-                         std::array<long,4>{nspin_in_file,nkpts,npol_in_file*nbnd,nu});
+                         std::array<long,4>{nspin_in_H1,nkpts,npol_in_H1*nbnd,nu});
   auto Luv = share_read("factorized_coulomb_matrix",std::array<long,3>{nqpts_ibz,nu,nv});
   std::optional<decltype(Luv)> Zuv = std::nullopt;
   // half-rotated
@@ -269,7 +270,7 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   std::optional<decltype(Luv)> Zuv_rot = std::nullopt;
   if(have_rot_coul) {
     Xsiu_rot = share_read("collocation_matrix_half_rotated",
-                          std::array<long,4>{nspin_in_file,nkpts,npol_in_file*nbnd,nu_rot});
+                          std::array<long,4>{nspin_in_H1,nkpts,npol_in_H1*nbnd,nu_rot});
     Zuv_rot = share_read("half_rotated_coulomb_matrix",std::array<long,3>{nqpts_ibz,nu_rot,nu_rot});
   } else {
     Zuv = share_read("coulomb_matrix",std::array<long,3>{nqpts_ibz,nu,nu});
@@ -289,8 +290,8 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       {ndet,nspin,npol,nkpts,nocc_max,nu},
       [&](std::array<long,4> idx, auto&& block) {
         auto [id,is,ip,ik] = idx;
-        long is_ = is%nspin_in_file;
-        long ip_ = ip%npol_in_file;
+        long is_ = is%nspin_in_H1;
+        long ip_ = ip%npol_in_H1;
         int n0 = ( ik==0 ? 0 : nda::sum(nocc(is,range(ik))) );
         int nel = nocc(is,ik);
         auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),range(n0,n0+nel),range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
@@ -312,11 +313,11 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   memory::buffered_array<MEM,ComplexType,2> Wuv(nu,nu);
   memory::buffered_array<MEM,ComplexType,2> vt(nbnd,nbnd);
   auto v0 = memory::share_from_ranks<HOST_MEMORY,ComplexType,4,2>(*mpi,
-      std::array<long,4>{nspin_in_file*npol_in_file, nkpts, nbnd, nbnd},
+      std::array<long,4>{nspin_in_H1*npol_in_H1, nkpts, nbnd, nbnd},
       [&](std::array<long,2> idx, auto&& block) {
         auto [isp,ik] = idx;
-        long is = isp/npol_in_file;
-        long ip = isp%npol_in_file;
+        long is = isp/npol_in_H1;
+        long ip = isp%npol_in_H1;
         // sum over q
         Tuv() = ComplexType(0.0);
         Wuv() = ComplexType(0.0);
@@ -344,33 +345,19 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   // MAM: this uses a lot more memory/compute, but can be batched into a single call (energy eval)
   // time the two versions and change to k-dependent haj if the timing in gpu is not that different
   // You can also write a kernel that dispatches all the gemms from device side using the new library
-  long nel[] = {nel_up, (type == COLLINEAR ? nel_dn : 0l) };
-  auto haj = memory::share_from_ranks<MEM,ComplexType,3,1>(*mpi,
-      std::array<long,3>{ndet, nel[0]+nel[1], npol*NMO},
-      [&](std::array<long,1> idx, auto&& block) {
-        auto [id] = idx;
-        for(long is=0; is<nspin; ++is) {
-          for(long ik=0; ik<nkpts; ++ik) {
-            int n0 = ( ik==0 ? 0 : nda::sum(nocc(is,range(ik))) );
-            int nk = nocc(is,ik);
-            for(long ip1=0; ip1<npol; ++ip1) {
-              int ip1_ = ip1%npol_in_file;
-              auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),range(n0,n0+nk),range(ip1*NMO+ik*nbnd,ip1*NMO+(ik+1)*nbnd));
-              for(long ip2=0; ip2<npol; ++ip2) {
-                int ip2_ = ip2%npol_in_file;
-                auto h_ = block(range(is*nel_up+n0,is*nel_up+n0+nk),nda::range(ip2*NMO+ik*nbnd,ip2*NMO+(ik+1)*nbnd));
-                if constexpr (MEM==HOST_MEMORY) {
-                  auto hij = H1()(is%nspin_in_file,ik,range(ip1_*nbnd,(ip1_+1)*nbnd),range(ip2_*nbnd,(ip2_+1)*nbnd));
-                  nda::blas::gemm(ComplexType(1.0),Aai,hij,ComplexType(1.0),h_);
-                } else {
-                  memory::array<MEM,ComplexType,2> hij(H1()(is%nspin_in_file,ik,range(ip1_*nbnd,(ip1_+1)*nbnd),range(ip2_*nbnd,(ip2_+1)*nbnd)));
-                  nda::blas::gemm(ComplexType(1.0),Aai,hij,ComplexType(1.0),h_);
-                }
-              }
-            }
-          }  // ik
-        }  // is
-      });
+  auto nel = std::to_array<long>({nel_up, (type == COLLINEAR ? nel_dn : 0l)});
+
+  auto hfull = memory::share_from_root(*mpi, [&](){
+    memory::array<MEM,ComplexType,3> hfull(nspin_in_H1, npol_in_H1*nkpts*nbnd, npol_in_H1*nkpts*nbnd);
+    hfull() = 0;
+    auto hfull7 = nda::reshape(hfull, nspin_in_H1, npol_in_H1, nkpts, nbnd, npol_in_H1, nkpts, nbnd);
+    for(int ik = 0; ik < nkpts; ik++) {
+      hfull7(all, all, ik, all, all, ik, all) = nda::reshape(H1(), nspin_in_H1, nkpts, npol_in_H1, nbnd, npol_in_H1, nbnd)(all, ik, all, all, all, all);
+    }
+
+    return hfull;
+  });
+  auto haj = half_rotate_hamiltonian<MEM>(*mpi, nel, nspin, npol, nspin_in_H1, npol_in_H1, NMO, PsiT(), hfull());
 
   ComplexType E0 = NuclearCoulombEnergy + FrozenCoreEnergy;
   return HamiltonianOperations<MEM>(KPTHCOps<MEM>(mpi,type,NMO,nel_up,nel_dn,nkpts,Q0_index,std::move(nocc),

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -289,11 +289,10 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       {ndet,nspin,npol,nkpts,nocc_max,nu},
       [&](std::array<long,4> idx, auto&& block) {
         auto [id,is,ip,ik] = idx;
-        long is_ = is%nspin_in_H1;
-        long ip_ = ip%npol_in_H1;
+        auto [is_,ip_] = interaction_block(is,ip,npol,nspin_in_H1,npol_in_H1);
         auto const& rows = nocc(is,ik);
         int nel = int(rows.size());
-        auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),rows,range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
+        auto Aai = math::sparse::to_array<'N'>(PsiT(id,is),rows,range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
         auto Yau = block(range(nel),all);
         auto Xiu = Xsiu()(is_,ik,range(ip_*nbnd,(ip_+1)*nbnd),all);
         nda::tensor::contract(Aai,"ai", nda::conj(Xiu),"iu",Yau,"au");

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -275,15 +275,14 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   } else {
     Zuv = share_read("coulomb_matrix",std::array<long,3>{nqpts_ibz,nu,nu});
   }
-  // kpoint dependent occupations
-  nda::array<int,2> nocc(nspin,nkpts);
-  if(mpi->comm.root())
-    nocc = nocc_per_kpoint(type,nkpts,PsiT);
-  mpi->broadcast(nocc);
-  auto nocc_max = nda::max_element(nocc);
-  utils::check(nel_up == nda::sum(nocc(0,all)), "Error: Mismatch in number of electrons: nel_up:{} sum(nel_up(k)):{}",nel_up,nda::sum(nocc(0,all)));
+  // kpoint dependent occupations: for each (spin,kpoint), the list of PsiT row
+  // indices occupying that kpoint. Computed on every rank (depends only on PsiT,
+  // which is replicated), so no broadcast of the ragged list-of-lists is needed.
+  auto nocc = nocc_per_kpoint(type,nkpts,PsiT);
+  auto nocc_max = max_nocc_per_kpoint(nocc);
+  utils::check(nel_up == nelec_for_spin(nocc,0), "Error: Mismatch in number of electrons: nel_up:{} sum(nel_up(k)):{}",nel_up,nelec_for_spin(nocc,0));
   if(type == COLLINEAR)
-    utils::check(nel_dn == nda::sum(nocc(1,all)), "Error: Mismatch in number of electrons: ndown:{} sum(ndown(k)):{}",nel_dn,nda::sum(nocc(1,all)));
+    utils::check(nel_dn == nelec_for_spin(nocc,1), "Error: Mismatch in number of electrons: ndown:{} sum(ndown(k)):{}",nel_dn,nelec_for_spin(nocc,1));
 
   // Y = PsiT*conj(X): (since PsiT is already conjugated/transposed)
   auto Ydsau = memory::share_from_ranks<MEM,ComplexType,6,4>(*mpi,
@@ -292,9 +291,9 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
         auto [id,is,ip,ik] = idx;
         long is_ = is%nspin_in_H1;
         long ip_ = ip%npol_in_H1;
-        int n0 = ( ik==0 ? 0 : nda::sum(nocc(is,range(ik))) );
-        int nel = nocc(is,ik);
-        auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),range(n0,n0+nel),range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
+        auto const& rows = nocc(is,ik);
+        int nel = int(rows.size());
+        auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT),rows,range(ip*NMO+ik*nbnd,ip*NMO+(ik+1)*nbnd));
         auto Yau = block(range(nel),all);
         auto Xiu = Xsiu()(is_,ik,range(ip_*nbnd,(ip_+1)*nbnd),all);
         nda::tensor::contract(Aai,"ai", nda::conj(Xiu),"iu",Yau,"au");

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -75,8 +75,7 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.size(1)%npol != 0");
   utils::check(nspin_in_PsiT==nspin, "Size mismatch");
   utils::check(ndet==1, "Error: ndet > 1 not yet implemented in KPTHCHamiltonian::getHamiltonianOperations.");
-  long nel_dn = ( type == FULLYPOLARIZED or type == NONCOLLINEAR ? 0l :
-              (type == CLOSED ? nel_up : PsiT(0,nspin_in_PsiT-1).extent(0) ) );
+  long nel_dn = (type == COLLINEAR ? PsiT(0,1).extent(0) : 0l);
   for(int i=0; i<ndet; ++i) 
     for(int ip=0; ip<npol; ++ip) {
       utils::check_shape(PsiT(i,0), "PsiT", nel_up, NMO);

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.h
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.h
@@ -28,18 +28,16 @@ namespace sfqmc
 {
 namespace afqmc
 {
-class KPTHCHamiltonian : public AFQMCInfo 
+class KPTHCHamiltonian
 {
 public:
 
-  KPTHCHamiltonian(AFQMCInfo const& info,
-                 ptree pt_in,
-                 ComplexType nucE = 0,
-                 ComplexType fzcE = 0)
-      : AFQMCInfo(info), 
-        NuclearCoulombEnergy(nucE),
+  KPTHCHamiltonian(ptree pt_in,
+                   ComplexType nucE = 0,
+                   ComplexType fzcE = 0)
+      : NuclearCoulombEnergy(nucE),
         FrozenCoreEnergy(fzcE),
-	fileName("")
+      	fileName("")
   {
     // convert user input to verbose input
     ptree pt = interpret_inputs(pt_in);
@@ -47,7 +45,6 @@ public:
     app_log(2, "{}", io::to_string(pt));
     // initialize using verbose input
     fileName  = pt.get<std::string>("filename");
-    name      = pt.get<std::string>("name");
   }
 
   ~KPTHCHamiltonian() {}

--- a/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.cpp
+++ b/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.cpp
@@ -98,6 +98,7 @@ ModelHamOpsGenerator::getHamiltonianOperations_impl(WALKER_TYPES type,
   int ndet   = PsiT.extent(0); 
   int nspin  = ((type == COLLINEAR or type == COLLINEAR_FT) ? 2 : 1);
   int npol   = ((type == NONCOLLINEAR or type == NONCOLLINEAR_FT) ? 2 : 1);
+  int NMO = PsiT(0, 0).extent(1)/npol;
   int nel_up = PsiT(0,0).extent(0); 
   int nel_dn = ( type == COLLINEAR or type == COLLINEAR_FT ? PsiT(0,1).extent(0) : 0 ); 
   int nspin_in_PsiT = PsiT.extent(1);

--- a/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.h
+++ b/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.h
@@ -13,17 +13,13 @@
 
 #pragma once
 
-#include <iostream>
 #include <vector>
-#include <map>
-#include <fstream>
 
 #include "IO/ptree/ptree_utilities.hpp"
 #include "IO/app_loggers.h"
 #include "utilities/mpi_context.h"
     
 #include "AFQMC/config.h"
-#include "nda/h5.hpp"
 
 #include "AFQMC/HamiltonianOperations/HamiltonianOperations.h"
 
@@ -31,15 +27,13 @@ namespace sfqmc
 {
 namespace afqmc
 {
-class ModelHamOpsGenerator : public AFQMCInfo 
+class ModelHamOpsGenerator
 {
 public:
-  ModelHamOpsGenerator(AFQMCInfo const& info,
-                       ptree pt_in,
+  ModelHamOpsGenerator(ptree pt_in,
                        ComplexType nucE = 0,
                        ComplexType fzcE = 0)
-      : AFQMCInfo(info), 
-        NuclearCoulombEnergy(nucE), 
+      : NuclearCoulombEnergy(nucE), 
         FrozenCoreEnergy(fzcE)
   {
     // convert user input to verbose input
@@ -48,7 +42,6 @@ public:
     app_log(2, "{}", io::to_string(pt));
     // initialize using verbose input
     fileName  = pt.get<std::string>("filename");
-    name      = pt.get<std::string>("name");
     shift_1body = pt.get<bool>("shift_1body");
   }
 

--- a/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.icc
+++ b/src/AFQMC/Hamiltonians/ModelHamOpsGenerator.icc
@@ -29,12 +29,12 @@ SparseEnergy<MEM,REAL> ModelHamOpsGenerator::make_SparseEnergy(
   using csrM = math::sparse::csr_matrix<ValueType, HOST_MEMORY, int, int>;
   auto all = range::all;
   int npol = (type == NONCOLLINEAR or type == NONCOLLINEAR_FT ? 2 : 1 );
+  int NMO = hij.extent(0)/2;
   long M = NMO;
   long M2 = npol*M; 
   long Madd = M2-M; 
 
-  utils::check(hij.extent(0) == 2*NMO, "Size mismaych");
-  utils::check(hij.extent(1) == M2, "Size mismatch");
+  utils::check_shape(hij, "hij", 2*NMO, M2);
 
   nda::array<long,1> n2IJ;
 
@@ -453,16 +453,17 @@ nda::array<long,1> ModelHamOpsGenerator::find_occupied_pairs(WALKER_TYPES type,
   utils::check(type != CLOSED, " Error: Model Hamiltonians not allowed with CLOSED walkers. ");
   using nda::range;
   int npol = (type == NONCOLLINEAR or type == NONCOLLINEAR_FT ? 2 : 1 );
-  long M = long(NMO);
+  utils::check(not U.empty() or not J.empty(), "Error: both U and J empty.");
+  long M = U.empty() ? long(J[0].shape(1)) : long(U[0].shape(1));
   long M2 = npol*M;
   long Madd = M2-M;
 
   nda::array<long,1> n2IJ;
   {
     std::vector<long> IJ;
-    IJ.reserve(20*NMO);
+    IJ.reserve(20*M);
     // to avoid adding too many copies
-    std::vector<bool> Idone(2*NMO, false);
+    std::vector<bool> Idone(2*M, false);
 
     // General formula for COLLINEAR and NONCOLLINEAR
     // IJ = i*M2+j            for up/up
@@ -588,7 +589,7 @@ void ModelHamOpsGenerator::addComponent( WALKER_TYPES wtype, PropagatorTypes pty
   RealType sign = (ChargePropg) ? RealType(1.0) : RealType(-1.0);
   int nIJ = n2IJ.extent(0);
   int nFields = 0;
-  long M = long(NMO);
+  long M = long(U.extent(1));
 
   // count number of fields. +2 for (i!=j) and +1 for (i==j) terms.
   {

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -70,8 +70,7 @@ RealDenseHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   utils::check(nspin==1 or npol==1, base_error + "Both nspin and npol can not be >1 simultaneously."); 
 
   // MAM: should this be zero with CLOSED shell???
-  int nact_dn = ( type == FULLYPOLARIZED or type == NONCOLLINEAR ? 0l :
-              (type == CLOSED ? nact_up : PsiT(0,nspin_in_PsiT-1).extent(0) ) );
+  int nact_dn = (type == COLLINEAR ? PsiT(0,1).extent(0) : 0l);
 
   std::vector<long> Idata(8);
   ComplexType E0;

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -41,6 +41,7 @@
 #include "numerics/sparse/sparse.hpp"
 #include "numerics/shared_array/const_shared_array.hpp"
 #include "AFQMC/Hamiltonians/hdf5_helpers.hpp"
+#include "AFQMC/HamiltonianOperations/detail/one_body.hpp"
 #include "RealDenseHamiltonian.h"
 
 namespace sfqmc
@@ -67,7 +68,7 @@ RealDenseHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   int nspin_in_H1 = 1, npol_in_H1 = 1; // read/broadcast below
   int nspin_in_H2 = 1, npol_in_H2 = 1; // read/broadcast below
   utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.size(1)%npol != 0");
-  utils::check(nspin_in_PsiT == 1 or nspin_in_PsiT == nspin, base_error + "Size mismatch PsiT");
+  utils::check(nspin_in_PsiT == nspin, base_error + "Size mismatch PsiT");
   utils::check(nspin==1 or npol==1, base_error + "Both nspin and npol can not be >1 simultaneously."); 
 
   // MAM: should this be zero with CLOSED shell???
@@ -126,15 +127,15 @@ RealDenseHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       auto l = h5::array_interface::get_dataset_info(vgrp,"L");
       if(l.rank()==2) {
         //[nspin_in_H2*npol_in_H2*NMO*NMO]][ncv]
-        if( nspin > 1 ) nspin_in_H2 = l.lengths[0] / (NMO*NMO); 
-        if( npol > 1 ) npol_in_H2 = l.lengths[0] / (NMO*NMO); 
+        if( nspin_in_H1 > 1 ) nspin_in_H2 = l.lengths[0] / (NMO*NMO); 
+        if( npol_in_H1 > 1 ) npol_in_H2 = l.lengths[0] / (NMO*NMO); 
         utils::check( l.lengths[0] == nspin_in_H2*npol_in_H2*NMO*NMO, 
                       base_error + "Inconsistent size of DenseFactorized/L:({}, {}). Incompatible with nspin_in_H2:{}, npol_in_H2:{}, NMO:{} found in hcore",l.lengths[0],l.lengths[1],nspin_in_H2,npol_in_H2,NMO);
       } else if(l.rank()==3 or l.rank()==4) {
         //rank:3 [nspin_in_H2*npol_in_H2][NMO*NMO]][ncv]
         //rank:4 [nspin_in_H2*npol_in_H2][NMO][NMO]][ncv]
-        if( nspin > 1 ) nspin_in_H2 = l.lengths[0]; 
-        if( npol > 1 ) npol_in_H2 = l.lengths[0];  
+        if( nspin_in_H1 > 1 ) nspin_in_H2 = l.lengths[0]; 
+        if( npol_in_H1 > 1 ) npol_in_H2 = l.lengths[0];  
         utils::check( l.lengths[0] == nspin_in_H2*npol_in_H2, 
                       base_error +  "Inconsistent size of DenseFactorized/L:({}, ...). Incompatible with nspin_in_H2:{}, npol_in_H2:{} found in hcore",l.lengths[0],nspin_in_H2,npol_in_H2);
       } else {
@@ -187,57 +188,24 @@ RealDenseHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   
   mpi->comm.barrier();
 
-  long nel[] = {nact_up, (type == COLLINEAR ? nact_dn : 0l) };
-// use nspin_in_PsiT and propagate into HamOps
-  auto haj = memory::share_from_ranks<MEM,ComplexType,3,1>(*mpi,
-      {ndet, nel[0]+nel[1], npol*NMO},
-      [&](std::array<long,1> idx, auto&& block) {
-    auto [id] = idx;
-    for(long is=0; is<nspin; ++is) {
-      auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT));
-      int is_f = is%nspin_in_H1;
-      auto h_ = block(range(is*nact_up,nact_up+is*nact_dn),all);
-      nda::array<ComplexType,2> hc(npol*NMO,npol*NMO);
-      hc() = ComplexType(0.0);
-      if(npol_in_H1==1) {
-        for(int p=0; p<npol; p++) {
-          for(int a=0; a<NMO; a++) {
-            for(int b=0; b<NMO; b++) {
-              hc(p*NMO+a,p*NMO+b) = ComplexType(H1()(is_f,a,b));
-            }
-          }
-        }
-      } else {
-        for(int a=0; a<npol*NMO; a++) {
-          for(int b=0; b<npol*NMO; b++) {
-            hc(a,b) = ComplexType(H1()(is_f,a,b));
-          }
-        }
-      }
-      if constexpr (MEM==HOST_MEMORY) {
-        nda::blas::gemm(Aai,hc,h_);
-      } else {
-        memory::array<MEM,ComplexType,2> hc_d(hc);
-        nda::blas::gemm(Aai,hc_d,h_);
-      }
-    }
-  });
-
+  auto nel = std::to_array<long>({nact_up, (type == COLLINEAR ? nact_dn : 0l)});
+  auto haj = half_rotate_hamiltonian<MEM>(*mpi, nel, nspin, npol, nspin_in_H1, npol_in_H1, NMO, PsiT(), H1());
+  
   nda::array<memory::const_shared_array<MEM,ComplexType,5>,1> Lnak(nspin);
   for(int is = 0; is < nspin; is++) {
     Lnak(is) = memory::share_from_ranks<MEM,ComplexType,5,1>(*mpi,
         {ndet,npol,ncv,nel[is],NMO},
         [&,is](std::array<long,1> idx, auto&& block) {
       auto [id] = idx;
-      auto Aai = math::sparse::to_array<'N'>(PsiT(id,is%nspin_in_PsiT));
-      int is_f = is%nspin_in_H2;
+      auto Aai = math::sparse::to_array<'N'>(PsiT(id,is));
       auto Aai_r = memory::to_real_view(Aai);
       auto L_r = memory::to_real_view(block);
       for(int p=0; p<npol; ++p) {
-        int ip_f = p%npol_in_H2;
+        int ip_f = (is*npol + p) % (nspin_in_H2*npol_in_H2);
+
         nda::range rng(ip_f*NMO,(ip_f+1)*NMO);
         auto Aai_is = Aai_r(all,nda::range(p*NMO,(p+1)*NMO),all);
-        nda::tensor::contract(RealType(1.0),Aai_is,"aic",Likn()(is_f,rng,rng,all),"ijn",
+        nda::tensor::contract(RealType(1.0),Aai_is,"aic",Likn()(ip_f,all,all,all),"ijn",
                               RealType(0.0),L_r(p,all,all,all,all),"najc");
       }
     });

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -49,8 +49,6 @@ namespace sfqmc
 namespace afqmc
 {
 
-// NOTE: remove AFQMCInfo object from Hamiltonian generators, NMO/nup/ndown should be provided by calling routine
-
 template<MEMORY_SPACE MEM> HamiltonianOperations<MEM> 
 RealDenseHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
                  std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> mpi,
@@ -68,7 +66,7 @@ RealDenseHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
   int nspin_in_H1 = 1, npol_in_H1 = 1; // read/broadcast below
   int nspin_in_H2 = 1, npol_in_H2 = 1; // read/broadcast below
   utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.size(1)%npol != 0");
-  utils::check(nspin_in_PsiT == nspin, base_error + "Size mismatch PsiT");
+  utils::check(nspin_in_PsiT == nspin, base_error + "nspin mismatch in PsiT {} != {} expected", nspin_in_PsiT, nspin);
   utils::check(nspin==1 or npol==1, base_error + "Both nspin and npol can not be >1 simultaneously."); 
 
   // MAM: should this be zero with CLOSED shell???

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -203,7 +203,6 @@ RealDenseHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
       for(int p=0; p<npol; ++p) {
         int ip_f = (is*npol + p) % (nspin_in_H2*npol_in_H2);
 
-        nda::range rng(ip_f*NMO,(ip_f+1)*NMO);
         auto Aai_is = Aai_r(all,nda::range(p*NMO,(p+1)*NMO),all);
         nda::tensor::contract(RealType(1.0),Aai_is,"aic",Likn()(ip_f,all,all,all),"ijn",
                               RealType(0.0),L_r(p,all,all,all,all),"najc");

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.h
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.h
@@ -34,15 +34,13 @@ namespace sfqmc
 {
 namespace afqmc
 {
-class RealDenseHamiltonian : public AFQMCInfo 
+class RealDenseHamiltonian
 {
 public:
-  RealDenseHamiltonian(AFQMCInfo const& info,
-                          ptree pt_in,
-                          ComplexType nucE = 0,
-                          ComplexType fzcE = 0)
-      : AFQMCInfo(info),
-        NuclearCoulombEnergy(nucE),
+  RealDenseHamiltonian(ptree pt_in,
+                       ComplexType nucE = 0,
+                       ComplexType fzcE = 0)
+      : NuclearCoulombEnergy(nucE),
         FrozenCoreEnergy(fzcE),
         fileName(""),
         max_memory_MB(2000)
@@ -53,7 +51,6 @@ public:
     app_log(2, "{}", io::to_string(pt));
     // initialize using verbose input
     fileName  = pt.get<std::string>("filename");
-    name      = pt.get<std::string>("name");
     max_memory_MB = pt.get<int>("max_memory");
   }
 

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
@@ -36,6 +36,7 @@
 
 #include "THCHamiltonian.h"
 #include "AFQMC/Hamiltonians/hdf5_helpers.hpp"
+#include "AFQMC/HamiltonianOperations/detail/one_body.hpp"
 
 #include "numerics/sparse/sparse.hpp"
 #include "numerics/shared_array/const_shared_array.hpp"
@@ -86,8 +87,8 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
   utils::check(nup >= ndn, base_error + "nup:{} < ndn:{} not allowed.",nup,ndn);
 
   // THC variables
-  long nspin_in_file = nspin;
-  long npol_in_file = 1;
+  long nspin_in_H1 = nspin;
+  long npol_in_H1 = 1;
   long nu = 0; // number of interpolating points/vectors
   long nv = 0; // number of columns of Vuv matrix
   long nu_rot = 0; // number of interpolating points/vectors
@@ -114,13 +115,12 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
       // check nkpts
       h5::h5_read_attribute(bz,"number_of_kpoints",n);
       utils::check(n==1, base_error + "nkpts:1 differs from number_of_kpoints:{} in file",n);
-      // read nspin_in_file
-      h5::h5_read_attribute(*hgrp,"number_of_spins",n);
-      // nspin_in_file = long(n);
-      // read npol_in_file
+      // read nspin_in_H1
+      h5::h5_read_attribute(*hgrp,"number_of_spins",nspin_in_H1);
+      // read npol_in_H1
       // h5::h5_read_attribute(bz,"number_of_polarizations",n);
-      // npol_in_file=long(n);
-      utils::check(walkerDimsAreConvertible(nspin_in_file, npol_in_file, nspin, npol), "Hamiltonian with nspin: {}, npol: {} cannot be broadcasted to {}", nspin_in_file, npol_in_file, walkerTypeToString(type));
+      // npol_in_H1=long(n);
+      utils::check(walkerDimsAreConvertible(nspin_in_H1, npol_in_H1, nspin, npol), "Hamiltonian with nspin: {}, npol: {} cannot be broadcasted to {}", nspin_in_H1, npol_in_H1, walkerTypeToString(type));
     }
     // read from /Interaction 
     {
@@ -128,13 +128,11 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
       // check consistency
 // MAM: fix this, integer types in h5 file are not consistent!!!
       long n;
-      // read nspin_in_file
-      h5::h5_read_attribute(igrp,"number_of_spins",nspin_in_file);
-      // utils::check(nspin_in_file==n,
-      //              base_error + " Incompatible nspin:{} in h5::/Interaction.",n);
-      // read npol_in_file
+      long nspin_in_H2= h5::read_attribute<long>(igrp,"number_of_spins");
+      utils::check(nspin_in_H2 == nspin_in_H1, "Incompatible number_of_spins in Interaction {} and onebody Hamiltonian {}", nspin_in_H2, nspin_in_H1);
+      
 //      h5::h5_read_attribute(igrp,"number_of_polarizations",n);
-//      utils::check(npol_in_file==n,
+//      utils::check(npol_in_H1==n,
 //                   base_error + " Incompatible npol:{} in h5::/Interaction.",n);
       // NMO
       h5::h5_read_attribute(igrp,"number_of_bands",n);
@@ -149,7 +147,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
 // MAM: right now only correct for Real==false, dimensions are assumed different for real case
       auto lX = h5::array_interface::get_dataset_info(igrp,"collocation_matrix");
       nu = lX.lengths[3];
-      utils::check_shape(lX, "collocation_matrix", nspin_in_file, 1, NMO, nu);
+      utils::check_shape(lX, "collocation_matrix", nspin_in_H1, 1, NMO, nu);
       auto lL = h5::array_interface::get_dataset_info(igrp,"factorized_coulomb_matrix");
       nv = lL.lengths[2];
       utils::check_shape(lL, "factorized_coulomb_matrix", 1, nu, nv);
@@ -157,7 +155,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
         have_rot_coul = true;
         auto lXr = h5::array_interface::get_dataset_info(igrp,"collocation_matrix_half_rotated");
         nu_rot = lXr.lengths[3];
-        utils::check_shape(lXr, "collocation_matrix_half_rotated", nspin_in_file, 1, NMO, nu_rot);
+        utils::check_shape(lXr, "collocation_matrix_half_rotated", nspin_in_H1, 1, NMO, nu_rot);
         auto lZr = h5::array_interface::get_dataset_info(igrp,"half_rotated_coulomb_matrix");
         nv_rot = lZr.lengths[2];
         utils::check_shape(lZr, "half_rotated_coulomb_matrix", 1, nu_rot, nv_rot);
@@ -171,8 +169,8 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
       }
     }
   }
-  mpi->comm.broadcast_value(nspin_in_file);
-  mpi->comm.broadcast_value(npol_in_file);
+  mpi->comm.broadcast_value(nspin_in_H1);
+  mpi->comm.broadcast_value(npol_in_H1);
   mpi->comm.broadcast_value(nu);
   mpi->comm.broadcast_value(nv);
   mpi->comm.broadcast_value(nu_rot);
@@ -220,7 +218,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
   // read H1.
   // H0: /System/H0:   [nspin][npol*nbnd][npol*nbnd]   Only needed in host memory
   auto H1 = memory::share_from_root(*mpi, [&]() {
-    nda::array<ComplexType,3> A(nspin_in_file,npol_in_file*NMO,npol_in_file*NMO);
+    nda::array<ComplexType,3> A(nspin_in_H1,npol_in_H1*NMO,npol_in_H1*NMO);
     read_helper(1,*hgrp,"H0",A);
     return A;
   });
@@ -232,7 +230,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
   // Zrot: /Interaction/half_rotated_coulomb_matrix:      [Nq][Nu][Nv]
 // MAM: right now only correct for Real==false, dimensions are assumed different for real case
   auto Xsiu = share_read(1,"collocation_matrix",
-                         std::array<long,3>{nspin_in_file,npol_in_file*NMO,nu});
+                         std::array<long,3>{nspin_in_H1,npol_in_H1*NMO,nu});
   auto Luv = share_read(2,"factorized_coulomb_matrix",std::array<long,2>{nu,nv});
   std::optional<decltype(Luv)> Zuv = std::nullopt;
   // half-rotated
@@ -241,7 +239,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
   if(have_rot_coul) {
     Zuv_rot = share_read(2,"half_rotated_coulomb_matrix",std::array<long,2>{nu_rot,nu_rot});
     Xsiu_rot = share_read(1,"collocation_matrix_half_rotated",
-                          std::array<long,3>{nspin_in_file,npol_in_file*NMO,nu_rot});
+                          std::array<long,3>{nspin_in_H1,npol_in_H1*NMO,nu_rot});
   } else {
     Zuv = share_read(2,"coulomb_matrix",std::array<long,2>{nu,nu});
   }
@@ -252,15 +250,15 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
       [&](std::array<long,2> idx, auto&& block) {
         using matrix_t = memory::buffered_array<MEM,ComplexType,2>;
         auto [id, is] = idx;
-        long is_ = is%nspin_in_file;
+        long is_ = is%nspin_in_H1;
         long nel = (is==0 ? nup : ndn);
         auto Aai = math::sparse::to_array<'N'>(PsiT(id,is));
-        // need to loop over npol since npol_in_file might be != than npol
+        // need to loop over npol since npol_in_H1 might be != than npol
         if constexpr (REAL) {
           auto Yau = matrix_t(nel,nu);
           auto Xiu = matrix_t(NMO,nu);
           for(long ip=0; ip<npol; ++ip) {
-            long ip_ = ip%npol_in_file;
+            long ip_ = ip%npol_in_H1;
             math::copy(Xsiu()(is_,range(ip_*NMO,(ip_+1)*NMO),all),Xiu);
             // for simplicity, make calculations with copies at full precision
             nda::tensor::contract(Aai(all,range(ip*NMO,(ip+1)*NMO)),"ai",
@@ -271,7 +269,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
         } else {
           for(long ip=0; ip<npol; ++ip) {
             auto Yau = block(ip,range(nel),all);
-            long ip_ = ip%npol_in_file;
+            long ip_ = ip%npol_in_H1;
             auto Xiu = Xsiu()(is_,range(ip_*NMO,(ip_+1)*NMO),all);
             nda::tensor::contract(Aai(all,range(ip*NMO,(ip+1)*NMO)),"ai",
                             nda::conj(Xiu),"iu",Yau,"au");
@@ -293,7 +291,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
     utils::check(false, "Finish");
   }
   auto v0 = memory::share_reduced<HOST_MEMORY,ComplexType,3>(*mpi,
-      std::array<long,3>{nspin_in_file*npol_in_file, NMO, NMO},
+      std::array<long,3>{nspin_in_H1*npol_in_H1, NMO, NMO},
       [&](auto&& partial) {
         auto [u0, u1] = itertools::chunk_range(0, nu, mpi->comm.size(), mpi->comm.rank());
         memory::buffered_array<MEM,ValueType,3> vt(partial.shape());
@@ -303,8 +301,8 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
           memory::buffered_array<MEM,ValueType,2> Tiv(NMO,nu);
           Wuv() = ValueType(0.0);
           Tiv() = ValueType(0.0);
-          for(long is=0, isp=0; is<nspin_in_file; is++) {
-            for(long ip=0; ip<npol_in_file; ip++, isp++) {
+          for(long is=0, isp=0; is<nspin_in_H1; is++) {
+            for(long ip=0; ip<npol_in_H1; ip++, isp++) {
               if(u0==u1) { continue; }
               auto Xiu = Xsiu()(is,range(ip*NMO,(ip+1)*NMO),range(u0,u1));
               auto Xiv = Xsiu()(is,range(ip*NMO,(ip+1)*NMO),all);
@@ -320,28 +318,8 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
         partial = nda::to_host(vt);
       });
 
-  // haj(idet,a_is,j_ip2) = sum_i PsiT(idet,is)(a_is,ip1*NMO+i) H1(is,ip1*NMO+i,ip2*NMO+j)
-  long nel[] = {nup, (type == COLLINEAR ? ndn : 0l) };
-  auto haj = memory::share_from_ranks<MEM,ComplexType,3,1>(*mpi,
-      {ndet, nel[0]+nel[1], npol*NMO},
-      [&](std::array<long,1> idx, auto&& block) {
-        auto [id] = idx;
-        for(long is=0; is<nspin; ++is) {
-          long nelec_is = (is == 0 ? nup : ndn);
-          for(long ip1=0; ip1<npol; ++ip1) {
-            int ip1_ = ip1%npol_in_file;
-            auto Aai = math::sparse::to_array<'N'>(PsiT(id,is),range(0,nelec_is),range(ip1*NMO,(ip1+1)*NMO));
-            // haj = PsiT * H1
-            for(long ip2=0; ip2<npol; ++ip2) {
-              int ip2_ = ip2%npol_in_file;
-              auto h_ = block(range(is*nup,is*nup+nelec_is),range(ip2*NMO,(ip2+1)*NMO));
-              auto hij = memory::to_memory_space<MEM>(
-                  H1()(is%nspin_in_file,range(ip1_*NMO,(ip1_+1)*NMO),range(ip2_*NMO,(ip2_+1)*NMO)));
-              nda::blas::gemm(ComplexType(1.0),Aai,hij,ComplexType(1.0),h_);
-            } // ip2
-          } // ip1
-        }  // is
-      });
+  auto nel = std::to_array<long>({nup, (type == COLLINEAR ? ndn : 0l) });
+  auto haj = half_rotate_hamiltonian<MEM>(*mpi, nel, nspin, npol, nspin_in_H1, npol_in_H1, NMO, PsiT(), H1());
 
   ComplexType E0 = NuclearCoulombEnergy + FrozenCoreEnergy;
   return HamiltonianOperations<MEM>(THCOps<MEM, REAL>(mpi,type,NMO,nup,ndn,

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
@@ -250,7 +250,6 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
       [&](std::array<long,2> idx, auto&& block) {
         using matrix_t = memory::buffered_array<MEM,ComplexType,2>;
         auto [id, is] = idx;
-        long is_ = is%nspin_in_H1;
         long nel = (is==0 ? nup : ndn);
         auto Aai = math::sparse::to_array<'N'>(PsiT(id,is));
         // need to loop over npol since npol_in_H1 might be != than npol
@@ -258,7 +257,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
           auto Yau = matrix_t(nel,nu);
           auto Xiu = matrix_t(NMO,nu);
           for(long ip=0; ip<npol; ++ip) {
-            long ip_ = ip%npol_in_H1;
+            auto [is_,ip_] = interaction_block(is,ip,npol,nspin_in_H1,npol_in_H1);
             math::copy(Xsiu()(is_,range(ip_*NMO,(ip_+1)*NMO),all),Xiu);
             // for simplicity, make calculations with copies at full precision
             nda::tensor::contract(Aai(all,range(ip*NMO,(ip+1)*NMO)),"ai",
@@ -269,7 +268,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
         } else {
           for(long ip=0; ip<npol; ++ip) {
             auto Yau = block(ip,range(nel),all);
-            long ip_ = ip%npol_in_H1;
+            auto [is_,ip_] = interaction_block(is,ip,npol,nspin_in_H1,npol_in_H1);
             auto Xiu = Xsiu()(is_,range(ip_*NMO,(ip_+1)*NMO),all);
             nda::tensor::contract(Aai(all,range(ip*NMO,(ip+1)*NMO)),"ai",
                             nda::conj(Xiu),"iu",Yau,"au");

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
@@ -75,9 +75,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
   utils::check(PsiT(0,0).extent(1)%npol==0, base_error + "Psi.size(1)%npol != 0");
   utils::check(PsiT.extent(1) == nspin, "Size mismatch");
   utils::check(ndet==1, "Error: ndet > 1 not yet implemented in THCHamiltonian::getHamiltonianOperations.");
-  // MAM: should this be zero with CLOSED shell???
-  long ndn = ( type == FULLYPOLARIZED or type == NONCOLLINEAR ? 0l :
-              (type == CLOSED ? nup : PsiT(0,1).extent(0) ) );
+  long ndn = (type == COLLINEAR ? PsiT(0,1).extent(0) : 0l);
   for(int i=0; i<ndet; ++i) 
     for(int ip=0; ip<npol; ++ip) {
       utils::check_shape(PsiT(i,0), "PsiT", nup, npol*NMO);
@@ -116,7 +114,7 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
       h5::h5_read_attribute(bz,"number_of_kpoints",n);
       utils::check(n==1, base_error + "nkpts:1 differs from number_of_kpoints:{} in file",n);
       // read nspin_in_H1
-      h5::h5_read_attribute(*hgrp,"number_of_spins",nspin_in_H1);
+      nspin_in_H1 = h5::h5_read_attribute<int>(*hgrp,"number_of_spins");
       // read npol_in_H1
       // h5::h5_read_attribute(bz,"number_of_polarizations",n);
       // npol_in_H1=long(n);

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.h
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.h
@@ -34,7 +34,7 @@ namespace sfqmc
 {
 namespace afqmc
 {
-class THCHamiltonian : public AFQMCInfo 
+class THCHamiltonian
 {
 public:
 
@@ -42,12 +42,10 @@ public:
     utils::check(false, "Default constructor of THCHamiltonian not allowed.");
   }
 
-  THCHamiltonian(AFQMCInfo const& info,
-                 ptree pt_in,
+  THCHamiltonian(ptree pt_in,
                  ComplexType nucE = 0,
                  ComplexType fzcE = 0)
-      : AFQMCInfo(info), 
-        NuclearCoulombEnergy(nucE),
+      : NuclearCoulombEnergy(nucE),
         FrozenCoreEnergy(fzcE),
 	fileName("")
   {
@@ -57,7 +55,6 @@ public:
     app_log(2, "{}", io::to_string(pt));
     // initialize using verbose input
     fileName  = pt.get<std::string>("filename");
-    name      = pt.get<std::string>("name");
   }
 
   ~THCHamiltonian() {}

--- a/src/AFQMC/Utilities/readWfn.cpp
+++ b/src/AFQMC/Utilities/readWfn.cpp
@@ -297,25 +297,21 @@ ph_excitations<int, ComplexType, MEM> build_ph_struct(nda::array<ComplexType,1> 
 }
 
 
-void checkCommonDims(std::vector<int> const& dims, int NMO, int nup, int ndown, int& ndets_to_read) {
-  utils::check(NMO==dims[0], "Inconsistent NMO: given {} != {} in file", NMO, dims[0]);
-  std::array nels = {nup, ndown};
-  utils::check(nels == std::array{dims[1],dims[2]}, "Inconsistent (nup,ndown): given {} != {} in file", nels, std::array{dims[1], dims[2]});
-
-  if(ndets_to_read < 1) ndets_to_read = dims[4];
-  if(ndets_to_read > dims[4]) {
-    app_warning("Found less determinants than requested, adjusting request: requested {} > {} in file.", ndets_to_read, dims[4]);
-    ndets_to_read = dims[4];
+int get_number_of_determinants(std::vector<int> const& dims, int requested) {
+  if(requested < 1) {
+    return dims[4];
   }
+  if(requested > dims[4]) {
+    app_warning("Found less determinants than requested, adjusting request: requested {} > {} in file.", requested, dims[4]);
+    return dims[4];
+  }
+  return requested;
 }
 
 /*
  * Read trial wavefunction information from file.
  */
 void getCommonInput(h5::group& grp,
-                    int NMO,
-                    int nup,
-                    int ndown,
                     int& ndets_to_read,
                     nda::array<ComplexType,1>& ci,
                     WALKER_TYPES& walker_type)
@@ -323,7 +319,7 @@ void getCommonInput(h5::group& grp,
   // check for consistency in parameters
   std::vector<int> dims(5);
   h5::read(grp,"dims",dims);
-  checkCommonDims(dims, NMO, nup, ndown, ndets_to_read);
+  ndets_to_read = get_number_of_determinants(dims, ndets_to_read);
   app_log(1," - Number of determinants in trial wavefunction: {} ", ndets_to_read);
   ci.resize(ndets_to_read);
   nda::array<ComplexType,1> ci_t(dims[4]);

--- a/src/AFQMC/Utilities/readWfn.cpp
+++ b/src/AFQMC/Utilities/readWfn.cpp
@@ -120,7 +120,7 @@ void read_ph_wavefunction_hdf(h5::group& grp,
    *   - 1: excitations out of a UHF reference (not yet working)
    */
   WALKER_TYPES wtype;
-  getCommonInput(grp, NMO, nup, ndown, ndets, ci_coeff, wtype);
+  getCommonInput(grp, ndets, ci_coeff, wtype);
   // make first coefficient positive (or maybe largest???)
   ci_coeff() *= ( std::real(ci_coeff(0)) < 0.0 ? -1.0 : 1.0 );  
   utils::check(wtype != CLOSED, " walker_type==CLOSED not yet implemented for PHMSD Trial wavefunctions.");

--- a/src/AFQMC/Utilities/readWfn.h
+++ b/src/AFQMC/Utilities/readWfn.h
@@ -87,6 +87,8 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
   long nel[] = {nup, ndown};
   WALKER_TYPES wfn_type = afqmc::initWALKER_TYPES(dims[3]);
 
+  utils::check(walkerTypeIsConvertible(wfn_type, walker_type), "{} trial wavefunction is not compatible with {} walkers", walkerTypeToString(wfn_type), walkerTypeToString(walker_type));
+
   if(wfn_type == walker_type) {
     for(int id=0, k=0; id<ndets; ++id) {
       for(int is=0; is<nspin; ++is, ++k) {
@@ -96,7 +98,6 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
       } 
     }
   } else if(wfn_type == COLLINEAR) { 
-    utils::check(walker_type == NONCOLLINEAR, "walker_type=={} incompatible with wfn_type:{}", walkerTypeToString(walker_type), walkerTypeToString(wfn_type));
     // upgrade from COLLINEAR to NONCOLLINEAR
     for(int id=0; id<ndets; ++id) {
       h5::group ugrp = grp.open_group("PsiT_"+std::to_string(2*id));
@@ -105,7 +106,7 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
       auto dn = math::sparse::HDF2CSR<ComplexType,HOST_MEMORY,int,int>(dgrp);
       utils::check(up.extent(1) == NMO, "Shape mismatch");
       utils::check(dn.extent(1) == NMO, "Shape mismatch");
-      utils::check(up.extent(0) + dn.extent(1) == nel[0], "Shape mismatch");
+      utils::check(up.extent(0) + dn.extent(0) == nel[0], "Shape mismatch");
       // combining, shift dn by NMO 
       psi(id,0) = math::sparse::combine_csr(up,dn,NMO);
     }

--- a/src/AFQMC/Utilities/readWfn.h
+++ b/src/AFQMC/Utilities/readWfn.h
@@ -54,12 +54,9 @@ ph_excitations<int, ComplexType, MEM> build_ph_struct(nda::array<ComplexType,1> 
                                                  int nup,
                                                  int ndown);
 
-void checkCommonDims(std::vector<int> const& dims, int NMO, int nup, int ndown, int& ndets_to_read);
+int get_number_of_determinants(std::vector<int> const& dims, int requested);
 
 void getCommonInput(h5::group& g,
-                    int NMO,
-                    int NAEA,
-                    int NAEB,
                     int& ndets_to_read,
                     nda::array<ComplexType,1>& ci,
                     WALKER_TYPES& walker_type);
@@ -71,31 +68,31 @@ std::tuple<int,int,int,int> getWavefunctionDims(std::string filename);
 
 
 template<MEMORY_SPACE MEM>
-auto read_nomsd_wavefunction(h5::group& grp,int ndets,
+auto read_nomsd_wavefunction(h5::group& grp,int requested_ndets,
                             WALKER_TYPES walker_type, int NMO, int nup, int ndown)
 {
   using csr = PsiT_Matrix<MEM>;
   long nspin = (walker_type == COLLINEAR ? 2 : 1);
   long npol = (walker_type == NONCOLLINEAR ? 2 : 1);
-  long Mtot = npol*NMO;
 
   std::vector<int> dims(5);
   h5::h5_read(grp,"dims",dims);
-  checkCommonDims(dims, NMO, nup, ndown, ndets);
+  int ndets = get_number_of_determinants(dims, requested_ndets);
 
   // keep in on host at first
   nda::array<csr, 2> psi(ndets,nspin);
-  long nel[] = {nup, ndown};
   WALKER_TYPES wfn_type = afqmc::initWALKER_TYPES(dims[3]);
 
   utils::check(walkerTypeIsConvertible(wfn_type, walker_type), "{} trial wavefunction is not compatible with {} walkers", walkerTypeToString(wfn_type), walkerTypeToString(walker_type));
+
+  auto nel = std::to_array({nup, ndown});
 
   if(wfn_type == walker_type) {
     for(int id=0, k=0; id<ndets; ++id) {
       for(int is=0; is<nspin; ++is, ++k) {
         h5::group pgrp = grp.open_group("PsiT_"+std::to_string(k));
         psi(id,is) = std::move(math::sparse::HDF2CSR<ComplexType,MEM,int,int>(pgrp));
-        utils::check(psi(id,is).shape() == std::array<long,2>{nel[is],Mtot}, "Shape mismatch");
+        utils::check_shape(psi(id,is), std::format("psi({},{})", id, is), nel[is], npol*NMO);
       } 
     }
   } else if(wfn_type == COLLINEAR) { 
@@ -105,10 +102,9 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
       auto up = math::sparse::HDF2CSR<ComplexType,HOST_MEMORY,int,int>(ugrp);
       h5::group dgrp = grp.open_group("PsiT_"+std::to_string(2*id+1));
       auto dn = math::sparse::HDF2CSR<ComplexType,HOST_MEMORY,int,int>(dgrp);
-      utils::check_shape(up, "up", nel[0], NMO);
-      utils::check_shape(dn, "dn", nel[1], NMO);
       // combining, shift dn by NMO 
       psi(id,0) = math::sparse::combine_csr(up,dn,NMO);
+      utils::check_shape(psi(id,0), std::format("psi({},0)",id), nup, npol*NMO);
     }
   } else {
     utils::check(wfn_type == CLOSED, "Logic error: wfn_type: {}, walker_type: {}", walkerTypeToString(wfn_type), walkerTypeToString(walker_type)); 
@@ -119,8 +115,9 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
       for(int id=0; id<ndets; ++id) {
         h5::group pgrp = grp.open_group("PsiT_"+std::to_string(id));
         psi(id,0) = std::move(math::sparse::HDF2CSR<ComplexType,MEM,int,int>(pgrp));
-        utils::check_shape(psi(id,0), "psi", nel[0], NMO);
+        utils::check_shape(psi(id,0), std::format("psi({},0)",id), nup, npol*NMO);
         psi(id,1) = psi(id,0);
+        utils::check_shape(psi(id,1), std::format("psi({},1)",id), ndown, npol*NMO);
       }
     } else {
       // upgrade from CLOSED to NONCOLLINEAR 
@@ -131,6 +128,7 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
         utils::check(2*up.extent(0) == nel[0], "Shape mismatch");
         // combining, shift dn by NMO 
         psi(id,0) = math::sparse::combine_csr(up,up,NMO);
+        utils::check_shape(psi(id,0), std::format("psi({},0)",id), nup, npol*NMO);
       }
     }
   }

--- a/src/AFQMC/Utilities/readWfn.h
+++ b/src/AFQMC/Utilities/readWfn.h
@@ -27,6 +27,7 @@
 
 #include "nda/h5.hpp"
 #include "utilities/h5_utils.hpp"
+#include "utilities/check_shape.hpp"
 #include "numerics/sparse/sparse.hpp"
 #include "AFQMC/Wavefunctions/Excitations.hpp"
 
@@ -104,9 +105,8 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
       auto up = math::sparse::HDF2CSR<ComplexType,HOST_MEMORY,int,int>(ugrp);
       h5::group dgrp = grp.open_group("PsiT_"+std::to_string(2*id+1));
       auto dn = math::sparse::HDF2CSR<ComplexType,HOST_MEMORY,int,int>(dgrp);
-      utils::check(up.extent(1) == NMO, "Shape mismatch");
-      utils::check(dn.extent(1) == NMO, "Shape mismatch");
-      utils::check(up.extent(0) + dn.extent(0) == nel[0], "Shape mismatch");
+      utils::check_shape(up, "up", nel[0], NMO);
+      utils::check_shape(dn, "dn", nel[1], NMO);
       // combining, shift dn by NMO 
       psi(id,0) = math::sparse::combine_csr(up,dn,NMO);
     }
@@ -119,7 +119,7 @@ auto read_nomsd_wavefunction(h5::group& grp,int ndets,
       for(int id=0; id<ndets; ++id) {
         h5::group pgrp = grp.open_group("PsiT_"+std::to_string(id));
         psi(id,0) = std::move(math::sparse::HDF2CSR<ComplexType,MEM,int,int>(pgrp));
-        utils::check(psi(id,0).shape() == std::array<long,2>{nel[0],NMO}, "Shape mismatch");
+        utils::check_shape(psi(id,0), "psi", nel[0], NMO);
         psi(id,1) = psi(id,0);
       }
     } else {

--- a/src/AFQMC/Utilities/wfn_utils.hpp
+++ b/src/AFQMC/Utilities/wfn_utils.hpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <algorithm>
 #include <ctype.h>
 
 #include "AFQMC/config.h"
@@ -31,7 +32,13 @@
 namespace sfqmc::afqmc
 {
 
-// assumes a block diagonal PsiT
+// For each (spin, kpoint), returns the list of global PsiT row indices (occupied
+// orbitals) whose Bloch orbital lives at that kpoint. The rows of each list are in
+// increasing global-row order. This does NOT assume the PsiT rows are sorted
+// block-diagonally by kpoint; it only requires that each orbital is confined to a
+// single kpoint block (a single-kpoint Bloch state). For an already-sorted
+// wavefunction, list (is,ik) is exactly the contiguous range that the previous
+// count-based implementation implied.
 template<MEMORY_SPACE MEM>
 auto nocc_per_kpoint(WALKER_TYPES type, int nkpts, nda::array<PsiT_Matrix<MEM>,2> const& PsiT)
 {
@@ -42,50 +49,77 @@ auto nocc_per_kpoint(WALKER_TYPES type, int nkpts, nda::array<PsiT_Matrix<MEM>,2
   int NMO = PsiT(0,0).extent(1)/npol;
   int nbnd = NMO/nkpts;
   utils::check(NMO%nkpts==0, "NMO%nkpts != 0");
-  utils::check(nspin_in_PsiT==1 or nspin_in_PsiT==nspin, "Shape mismatch"); 
+  utils::check(nspin_in_PsiT==1 or nspin_in_PsiT==nspin, "Shape mismatch");
 
-  // compute based on first determinant, check all others match
-  nda::array<int, 2> nocc_per_kp(nspin,nkpts);
-  nocc_per_kp() = 0;
-  // 1st det
-  {
-    for(int is=0; is<nspin; is++) {
-      auto cols = nda::to_host(PsiT(0,is%nspin_in_PsiT).columns());
-      auto row_begin = nda::to_host(PsiT(0,is%nspin_in_PsiT).row_begin());
-      auto row_end = nda::to_host(PsiT(0,is%nspin_in_PsiT).row_end());
-      int kp = 0;
-      int nel = PsiT(0,is%nspin_in_PsiT).extent(0);
-      for(int ia=0; ia<nel; ++ia) {
-        auto k0 = (cols(row_begin(ia))/nbnd)%nkpts;  
-        auto k1 = (cols(row_end(ia)-1)/nbnd)%nkpts;  
-        // check 
-        utils::check( (k0==k1) and ((k0==kp) or (k0==kp+1)), "Error: Wavefunction is not in block diagonal form in kpoint");
-        kp=k0;
-        nocc_per_kp(is,kp)++;
-      } 
-    }
-  }
-  for(int id=1; id<ndet; ++id) {
-    nda::array<int, 2> nocc(nspin,nkpts);
-    nocc() = 0;
+  // builds the per-(spin,kpoint) row-index lists for determinant id
+  auto rows_per_kp = [&](int id) {
+    nda::array<nda::array<int,1>,2> occ(nspin,nkpts);
     for(int is=0; is<nspin; is++) {
       auto cols = nda::to_host(PsiT(id,is%nspin_in_PsiT).columns());
       auto row_begin = nda::to_host(PsiT(id,is%nspin_in_PsiT).row_begin());
       auto row_end = nda::to_host(PsiT(id,is%nspin_in_PsiT).row_end());
-      int kp = 0;
       int nel = PsiT(id,is%nspin_in_PsiT).extent(0);
+      // first pass: count occupied orbitals per kpoint
+      nda::array<int,1> cnt(nkpts);
+      cnt() = 0;
+      std::vector<int> kpt(nel);
       for(int ia=0; ia<nel; ++ia) {
-        auto k0 = (cols(row_begin(ia))/nbnd)%nkpts;
-        auto k1 = (cols(row_end(ia)-1)/nbnd)%nkpts;
-        // check 
-        utils::check( (k0==k1) and ((k0==kp) or (k0==kp+1)), "Error: Wavefunction is not in block diagonal form in kpoint");
-        kp=k0;
-        nocc(is,kp)++;
+        int k0 = (cols(row_begin(ia))/nbnd)%nkpts;
+        int k1 = (cols(row_end(ia)-1)/nbnd)%nkpts;
+        utils::check( k0==k1, "Error: orbital row {} spans multiple kpoint blocks (not a single-kpoint Bloch state).",ia);
+        kpt[ia] = k0;
+        cnt(k0)++;
+      }
+      // second pass: allocate and fill, preserving increasing global-row order
+      for(int ik=0; ik<nkpts; ++ik) occ(is,ik) = nda::array<int,1>(cnt(ik));
+      nda::array<int,1> pos(nkpts);
+      pos() = 0;
+      for(int ia=0; ia<nel; ++ia) {
+        int k0 = kpt[ia];
+        occ(is,k0)(pos(k0)++) = ia;
       }
     }
-    utils::check(nda::sum(nda::abs(nocc()-nocc_per_kp())) == 0, "Error: Occupation numbers for each kpoint differ between determinants, idet:{}",id);
+    return occ;
+  };
+
+  // compute based on first determinant, check all others have matching occupations
+  auto nocc_per_kp = rows_per_kp(0);
+  for(int id=1; id<ndet; ++id) {
+    auto nocc = rows_per_kp(id);
+    for(int is=0; is<nspin; is++)
+      for(int ik=0; ik<nkpts; ++ik)
+        utils::check(nocc(is,ik).size() == nocc_per_kp(is,ik).size(),
+          "Error: Occupation numbers for each kpoint differ between determinants, idet:{}",id);
   }
   return nocc_per_kp;
+}
+
+// Total number of occupied orbitals for spin is across all kpoints.
+inline int nelec_for_spin(nda::array<nda::array<int,1>,2> const& nocc, int is)
+{
+  int n = 0;
+  for(int ik=0; ik<nocc.extent(1); ++ik) n += int(nocc(is,ik).size());
+  return n;
+}
+
+// Maximum occupation over all (spin,kpoint) blocks.
+inline int max_nocc_per_kpoint(nda::array<nda::array<int,1>,2> const& nocc)
+{
+  int n = 0;
+  for(int is=0; is<nocc.extent(0); ++is)
+    for(int ik=0; ik<nocc.extent(1); ++ik)
+      n = std::max(n, int(nocc(is,ik).size()));
+  return n;
+}
+
+// True if a row-index list is a contiguous ascending run (rows(a)==rows(0)+a).
+// This holds for an already kpoint-sorted wavefunction, enabling a single slice
+// copy; otherwise the rows must be gathered individually.
+inline bool contiguous_rows(nda::array<int,1> const& rows)
+{
+  for(int a=1; a<int(rows.size()); ++a)
+    if(rows(a) != rows(a-1)+1) return false;
+  return true;
 }
 
 } // namespace sfqmc::afqmc

--- a/src/AFQMC/Walkers/WalkerSetBase.icc
+++ b/src/AFQMC/Walkers/WalkerSetBase.icc
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include "utilities/check_shape.hpp"
 
 namespace sfqmc
 {
@@ -461,7 +462,7 @@ void WalkerSetBase<_M_>::popControl(std::vector<ComplexType>& curData, bool skip
  * Adds/removes the number of walkers in the set to match the requested value.
  * Walkers are removed from the end of the set 
  *      and buffer capacity remains unchanged in this case.
- * New walkers are initialized from the supplied matrix. 
+ * New walkers are initialized from the supplied array A. 
  * Capacity is increased if necessary.
  * Target Populations are set to n.
 */
@@ -470,7 +471,7 @@ void WalkerSetBase<_M_>::resize(int n, nda::MemoryArrayOfRank<3> auto const& A)
 { 
   auto all = nda::range::all;
   int nspin = (walkerType == COLLINEAR ? 2 : 1);
-  utils::check(A.shape() == std::array<long,3>{nspin,wlk_desc[0],wlk_desc[1]} , "Size mismatch.");
+  utils::check_shape(A, "A", nspin, wlk_desc[0], wlk_desc[1]);
   reserve(n);
   if (n > tot_num_walkers)
   { 

--- a/src/AFQMC/Walkers/WalkerSetBase.icc
+++ b/src/AFQMC/Walkers/WalkerSetBase.icc
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cstdlib>
 #include "utilities/check_shape.hpp"
+#include "utilities/parser.h"
 
 namespace sfqmc
 {
@@ -47,104 +48,31 @@ void WalkerSetBase<_M_>::parse(ptree pt_in)
   max_weight        = pt.get<double>("max_weight");
 
   if constexpr (_M_ == HOST_MEMORY)
-    app_log(1, " Walker resides in CPU memory");
+    app_log(1, "Walker resides in CPU memory");
   else
-    app_log(1, " Walker resides in GPU memory");
-  io::tolower(walker_type);
-  if (walker_type.find("closed") != std::string::npos)
-  {
-    app_log(1," Using a closed-shell (closed-shell RHF) walker. ");
-    walkerType = CLOSED;
-  }
-  else if (walker_type.find("non-collinear-ft") != std::string::npos)
-  {
-    app_log(1," Using a non-collinear (GHF) finite temperature walker. ");
-    walkerType = NONCOLLINEAR_FT;
-  }
-  else if (walker_type.find("noncollinear-ft") != std::string::npos)
-  {
-    app_log(1," Using a non-collinear (GHF) finite temperature walker. ");
-    walkerType = NONCOLLINEAR_FT;
-  }
-  else if (walker_type.find("collinear-ft") != std::string::npos)
-  {
-    app_log(1," Using a collinear (UHF/ROHF) finite temperature walker. ");
-    walkerType = COLLINEAR_FT;
-  }
-  else if (walker_type.find("non-collinear") != std::string::npos)
-  {
-    app_log(1," Using a non-collinear (GHF) walker. ");
-    walkerType = NONCOLLINEAR;
-  }
-  else if (walker_type.find("noncollinear") != std::string::npos)
-  {
-    app_log(1," Using a non-collinear (GHF) walker. ");
-    walkerType = NONCOLLINEAR;
-  }
-  else if (walker_type.find("collinear") != std::string::npos)
-  {
-    app_log(1," Using a collinear (UHF/ROHF) walker. ");
-    walkerType = COLLINEAR;
-  }
-  else if (walker_type.find("fullypolarized") != std::string::npos)
-  {
-    app_log(1," Using a fully spin-polarized (beta-sector identically 0) walker. ");
-    walkerType = FULLYPOLARIZED;
-  }
-  else if (walker_type.find("fully-polarized") != std::string::npos)
-  {
-    app_log(1," Using a fully spin-polarized (beta-sector identically 0) walker. ");
-    walkerType = FULLYPOLARIZED;
-  }
-  else
-  {
-    app_error(" Error: Unknown walker type: {} ", walker_type);
-    APP_ABORT("");
-  }
+    app_log(1, "Walker resides in GPU memory");
 
-  io::tolower(load_balance_type);
-  if (load_balance_type.find("simple") != std::string::npos)
-  {
-    app_log(1," Using blocking (1-1) swap load balancing algorithm. ");
-    load_balance = SIMPLE;
-  }
-  else if (load_balance_type.find("async") != std::string::npos)
-  {
-    app_log(1," Using asynchronous non-blocking swap load balancing algorithm. ");
-    load_balance = ASYNC;
-  }
-  else
-  {
-    app_error(" Error: Unknown load balancing algorithm: {} ", load_balance_type);
-    APP_ABORT("");
-  }
+    
+  walkerType = utils::parse_enum<WALKER_TYPES>(walker_type, {
+    {CLOSED, "closed-shell RHF", {"closed"}},
+    {NONCOLLINEAR_FT, "GHF finite-temperature", {"noncollinear-ft", "non-collinear-ft"}},
+    {COLLINEAR_FT, "UHF/ROHF finite-temperature", {"collinear-ft"}},
+    {NONCOLLINEAR, "GHF", {"non-collinear", "noncollinear"}},
+    {COLLINEAR, "UHF/ROHF", {"collinear"}},
+    {FULLYPOLARIZED, "beta sector identically 0", {"fullypolarized", "fully-polarized"}},
+  }, "walker");
 
-  io::tolower(pop_control_type);
-  if (pop_control_type.find("pair") != std::string::npos)
-  {
-    app_log(1," Using population control algorithm based on paired walker branching. ");
-    pop_control = PAIR;
-  }
-  else if (pop_control_type.find("serial_comb") != std::string::npos)
-  {
-    app_log(1," Using population control algorithm based on comb method (See Booth, Gubernatis, PRE 2009). ");
-    pop_control = SERIAL_COMB;
-  }
-  else if (pop_control_type.find("comb") != std::string::npos)
-  {
-    app_log(1," Using population control algorithm based on comb method (See Booth, Gubernatis, PRE 2009). ");
-    pop_control = COMB;
-  }
-  else if (pop_control_type.find("min") != std::string::npos)
-  {
-    app_log(1," Using population control algorithm based on minimum reconfiguration (Caffarel et al., 2000). ");
-    pop_control = MIN_BRANCH;
-  }
-  else
-  {
-    app_error(" Error: Unknown population control algorithm: {}", pop_control_type);
-    APP_ABORT("");
-  }
+  load_balance = utils::parse_enum<LOAD_BALANCE_ALGORITHM>(load_balance_type, {
+    {SIMPLE, "blocking 1-1 swap", {"simple"}},
+    {ASYNC, "nonblocking swap", {"async"}},
+  }, "load balancing algorithm");
+  
+  pop_control = utils::parse_enum<BRANCHING_ALGORITHM>(pop_control_type, {
+    {PAIR, "paired walker branching", {"pair"}},
+    {SERIAL_COMB, "comb method [Booth, Gubernatis, PRE 2009]", {"serial_comb"}},
+    {COMB, "comb method [Booth, Gubernatis, PRE 2009]", {"comb"}},
+    {MIN_BRANCH, "minimum reconfiguration [Caffarel et al., 2000]", {"min"}},
+  }, "population control algorithm");
 
   app_log(1, "");
 }

--- a/src/AFQMC/Wavefunctions/NOMSD.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.hpp
@@ -44,7 +44,7 @@ namespace afqmc
  * For particle-hole orthogonal MSD wfns, use FastMSD.
  */
 template<MEMORY_SPACE MEM, class devPsiT>
-class NOMSD : public AFQMCInfo
+class NOMSD
 {
 
 public:
@@ -53,8 +53,8 @@ public:
     utils::check(false,"Default constructor for NOMSD disabled.");
   }
 
-  NOMSD(AFQMCInfo& info,
-        ptree pt_in,
+  NOMSD(ptree pt_in,
+        int NMO_, int nup_, int ndown_,
         WALKER_TYPES wlk,
         std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> _mpi,
         HamiltonianOperations<MEM>&& hop_,
@@ -62,9 +62,9 @@ public:
         nda::array<devPsiT,2>&& orbs_,
         ComplexType nce,
         [[maybe_unused]] int targetNW = 1)
-      : AFQMCInfo(info),
-        mpi(_mpi),
+      : mpi(_mpi),
         walker_type(wlk),
+        NMO{NMO_}, nup{nup_}, ndown{ndown_},
         HamOp(std::move(hop_)),
         ci(std::move(ci_)),
         OrbMats(std::move(orbs_)),
@@ -103,13 +103,6 @@ public:
     io::compare_known_keys("Non-orthogonal multi-Slater det. (NOMSD) Wavefunction",pt1, pt0,pass_through_keys);
     return pt1;
   }
-
-  ~NOMSD() = default; 
-
-  NOMSD(NOMSD const& other) = delete;
-  NOMSD& operator=(NOMSD const& other) = delete;
-  NOMSD(NOMSD&& other)                 = default;
-  NOMSD& operator=(NOMSD&& other) = delete;
 
   int number_of_cholesky_vectors() const { return HamOp.number_of_cholesky_vectors(); }
 
@@ -359,6 +352,10 @@ protected:
 
   // type of walker/wfn
   WALKER_TYPES walker_type;
+
+  int NMO{};
+  int nup{};
+  int ndown{};
 
   HamiltonianOperations<MEM> HamOp;
 

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -112,13 +112,15 @@ void NOMSD<MEM,devPsiT>::DensityMatrix(const WlkSet& wset, RVec&& Ref, MatG&& G,
   utils::check(Ov.size() == nw, "Size mismatch");
   utils::check(Ref.size() == nspin,"Size mismatch");
   if(herm) {
-    utils::check(Ref(0).shape() == std::array<long,2>{nup,npol*NMO}, "Size mismatch");
-    if(nspin>1)
-      utils::check(Ref(1).shape() == std::array<long,2>{ndown,npol*NMO}, "Size mismatch");
+    utils::check_shape(Ref(0), "Ref(0)", nup,npol*NMO);
+    if(nspin>1) {
+      utils::check_shape(Ref(1), "Ref(1)", ndown,npol*NMO);
+    }
   } else {
-    utils::check(Ref(0).shape() == std::array<long,2>{npol*NMO,nup}, "Size mismatch");
-    if(nspin>1)
-      utils::check(Ref(1).shape() == std::array<long,2>{npol*NMO,ndown}, "Size mismatch");
+    utils::check_shape(Ref(0), "Ref(0)", npol*NMO, nup);
+    if(nspin>1) {
+      utils::check_shape(Ref(1), "Ref(1)", npol*NMO, ndown);
+    }
   }
   G() = ComplexType(0.0);
   Ov() = ComplexType(0.0);

--- a/src/AFQMC/Wavefunctions/NOMSD_FT.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD_FT.hpp
@@ -44,7 +44,7 @@ namespace afqmc
  * For particle-hole orthogonal MSD wfns, use FastMSD.
  */
 template<MEMORY_SPACE MEM, class devPsiT>
-class NOMSD_FT : public AFQMCInfo
+class NOMSD_FT
 {
 
 public:
@@ -53,18 +53,18 @@ public:
     utils::check(false,"Default constructor for NOMSD disabled.");
   }
 
-  NOMSD_FT(AFQMCInfo& info,
-        ptree pt_in,
+  NOMSD_FT(ptree pt_in,
+        int NMO_, int ntau_,
         WALKER_TYPES wlk,
-        std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> _mpi,
+        std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> mpi_,
         HamiltonianOperations<MEM>&& hop_,
         nda::array<ComplexType,1>&& ci_,
         nda::array<devPsiT,3>&& orbs_,
         ComplexType nce,
         [[maybe_unused]] int targetNW = 1)
-      : AFQMCInfo(info),
-        mpi(_mpi),
+      : mpi(mpi_),
         walker_type(wlk),
+        NMO{NMO_}, ntau{ntau_},
         HamOp(std::move(hop_)),
         ci(std::move(ci_)),
         OrbMats(std::move(orbs_)),
@@ -132,9 +132,8 @@ public:
   void runtime_optimization(WlkSet& wset)
   {
     const int nw   = wset.size();
-    const int nel = (walker_type==COLLINEAR_FT ? nup+ndown : nup );
     const int npol = (walker_type==NONCOLLINEAR_FT ? 2 : 1 );
-    memory::array<MEM,ComplexType,2> G(nw,nel*npol*NMO);
+    memory::array<MEM,ComplexType,2> G(nw,npol*NMO*npol*NMO);
     // don't use buffered_array!!!
     HamOp.runtime_optimization(G);
   }
@@ -356,6 +355,8 @@ protected:
 
   // type of walker/wfn
   WALKER_TYPES walker_type;
+  int NMO{};
+  int ntau{};
 
   HamiltonianOperations<MEM> HamOp;
 

--- a/src/AFQMC/Wavefunctions/NOMSD_FT.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD_FT.icc
@@ -365,20 +365,17 @@ void NOMSD_FT<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Me
   auto all = range::all;
   const int ndet   = ci.size();
   const int nw     = wset.size();
-  const int neltot = (walker_type==COLLINEAR ? nup+ndown : nup );
   const int nspin  = (walker_type==COLLINEAR ? 2 : 1 );
   const int npol   = (walker_type==NONCOLLINEAR ? 2 : 1 );
 
   // this is wrong without importanceSampling!!!
   utils::check(importanceSampling, "Finish");
 
-  memory::buffered_array<MEM,ComplexType,2> Gc(nw,neltot*npol*NMO); 
+  memory::buffered_array<MEM,ComplexType,2> Gc(nw,npol*NMO*npol*NMO); 
   //auto Gc3d = nda::reshape(Gc,std::array<long,3>{nw,neltot,npol*NMO});
   
   if(ndet == 1) {
 
-    // for finite-T, nup = ndn = NMO
-    utils::check(neltot == npol*NMO, "size mismatch");
     auto Gfull = nda::reshape(Gc,std::array<long,4>{nw,nspin,npol*NMO,npol*NMO});
     //memory::buffered_array<MEM,ComplexType,4> Gfull(nw,nspin,npol*NMO,npol*NMO); 
     memory::buffered_array<MEM,ComplexType,1> LogOv(nw); 

--- a/src/AFQMC/Wavefunctions/PHMSD.hpp
+++ b/src/AFQMC/Wavefunctions/PHMSD.hpp
@@ -43,36 +43,36 @@ namespace afqmc
  * by a list of single particle excitations.
  */
 template<MEMORY_SPACE MEM>
-class PHMSD : public AFQMCInfo
+class PHMSD
 {
 
 public:
   // temporary
-  PHMSD(AFQMCInfo& info,
-        ptree pt_in,
+  PHMSD(ptree pt_in,
         WALKER_TYPES wlk,
-        std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> _mpi,
+        int NMO_, int nup_, int ndown_,
+        std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> mpi_,
         HamiltonianOperations<MEM>&& hop_)
-      : AFQMCInfo(info),
-        mpi(_mpi),
+      : mpi(mpi_),
         walker_type(wlk),
+        NMO{NMO_}, nup{nup_}, ndown{ndown_},
         HamOp(std::move(hop_))
   {}
 
   template<class csrM>
-  PHMSD(AFQMCInfo& info,
-        ptree pt_in,
+  PHMSD(ptree pt_in,
         WALKER_TYPES wlk,
-        std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> _mpi,
+        int NMO_, int nup_, int ndown_,
+        std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> mpi_,
         HamiltonianOperations<MEM>&& hop_,
         ph_excitations<int, ComplexType, MEM>&& abij_,
         nda::array<csrM,1>&& op_spin_det_coupling_,
         nda::array<csrM,1>&& orbs_,
         ComplexType nce,
         [[maybe_unused]] int targetNW = 1)
-      : AFQMCInfo(info),
-        mpi(_mpi),
+      : mpi(mpi_),
         walker_type(wlk),
+        NMO{NMO_}, nup{nup_}, ndown{ndown_},
         HamOp(std::move(hop_)),
         abij(std::move(abij_)),
         OpSpinDetCouplings(std::move(op_spin_det_coupling_)),
@@ -152,13 +152,6 @@ public:
     io::compare_known_keys("particle-hole multi-Slater det. (PHMSD) Wavefunction", pt1, pt0,pass_through_keys);
     return pt1;
   }
-
-  ~PHMSD() = default; 
-
-  PHMSD(PHMSD const& other) = default;
-  PHMSD& operator=(PHMSD const& other) = default;
-  PHMSD(PHMSD&& other)                 = default;
-  PHMSD& operator=(PHMSD&& other) = default;
 
   int number_of_cholesky_vectors() const { return HamOp.number_of_cholesky_vectors(); }
 
@@ -431,7 +424,10 @@ protected:
   std::shared_ptr<utils::mpi_context_t<mpi3::communicator>> mpi;
 
   // type of walker/wfn
-  WALKER_TYPES walker_type;  
+  WALKER_TYPES walker_type{};
+  int NMO{};
+  int nup{};
+  int ndown{};
 
   HamiltonianOperations<MEM> HamOp;
 

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
@@ -415,16 +415,25 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
     det_coupling_matrix(0) = unsorted_det_coupling[0];
     det_coupling_matrix(1) = unsorted_det_coupling[1];
 
-    // move to 2d version just for getHamiltonianOperations
-    nda::array<PsiT_Matrix<MEM>, 2> PsiT_2d(1,PsiT_MO.extent(0));
-    for(int i=0; i<PsiT_MO.extent(0); i++)
-      PsiT_2d(0,i) = std::move(PsiT_MO(i));
+    // PsiT carries n_ref reference(s): 1 for RHF/GHF (combined), 2 for UHF.
+    // The Hamiltonian expects one entry per spin channel (nspin), so for a single
+    // combined reference under COLLINEAR we duplicate it across both spins -- the
+    // same walker-type conversion every other wavefunction path performs on read.
+    int const n_ref = PsiT_MO.extent(0);
+    int const nspin = (walker_type == COLLINEAR ? 2 : 1);
+
+    // 2d version just for getHamiltonianOperations (copy, so PsiT_MO survives)
+    nda::array<PsiT_Matrix<MEM>, 2> PsiT_2d(1, nspin);
+    for(int i=0; i<nspin; i++) {
+      PsiT_2d(0,i) = PsiT_MO(i % n_ref);
+    }
     auto HOps = h.getHamiltonianOperations<MEM>(walker_type, mpi, PsiT_2d);
 
-    // move to 1-d array for PHMSD
-    nda::array<PsiT_Matrix<MEM>, 1> PsiT_1d(PsiT_2d.extent(1));
-    for(int i=0; i<PsiT_2d.extent(1); i++)
-      PsiT_1d(i) = std::move(PsiT_2d(0,i));
+    // 1-d array for PHMSD keeps the original reference count (1 or 2)
+    nda::array<PsiT_Matrix<MEM>, 1> PsiT_1d(n_ref);
+    for(int i=0; i<n_ref; i++) {
+      PsiT_1d(i) = std::move(PsiT_MO(i));
+    }
 
     return Wavefunction<MEM>(PHMSD<MEM>(AFinfo, pt, walker_type, mpi, std::move(HOps),
                     std::move(abij), std::move(det_coupling_matrix),

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
@@ -17,6 +17,7 @@
 #include <random>
 #include <boost/optional.hpp>
 #include "utilities/h5_utils.hpp"
+#include "AFQMC/Hamiltonians/hdf5_helpers.hpp"
 
 #include "AFQMC/Utilities/readWfn.h"
 #include "WavefunctionFactory.h"
@@ -28,6 +29,31 @@ namespace sfqmc
 namespace afqmc
 {
 
+namespace {
+
+// Convert an array of numbers of electrons per flavor ({nup, ndown}) from one walker type to another.
+// Most of the time, this is is an identity. However, in the noncollinear case, only
+// the first component contains all electrons and the rest is supposed to be zero.
+template<std::size_t N = 2>
+auto broadcast_number_of_electrons(const std::array<int, N> &nel, WALKER_TYPES from, WALKER_TYPES to) {
+  static_assert(N > 0, "Cannot have no electron flavors");
+  utils::check(walkerTypeIsConvertible(from, to), "Cannot convert {} wavefunction to {} walker type", walkerTypeToString(from), walkerTypeToString(to));
+  if(from == CLOSED) {
+    utils::check(
+      !nel.empty() && std::all_of(nel.begin(), nel.end(), [&](auto n) { return n == nel.front(); }),
+      "Closed wavefunction does not have uniform number of electrons: {}", nel);
+  }
+  
+  if(to == NONCOLLINEAR) {
+    std::array<int, N> result{};
+    result[0] = std::accumulate(nel.begin(), nel.end(), 0);
+    return result;
+  }    
+  return nel;
+}
+
+}
+
 template<MEMORY_SPACE MEM>
 Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
                                            ptree pt_in,
@@ -36,10 +62,6 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
                                            int targetNW)
 {
   ptree pt = interpret_inputs(pt_in);
-
-  std::string info = pt.get<std::string>("system");
-  if (InfoMap.find(info) == InfoMap.end())
-    utils::check(false,"ERROR: Undefined system in WavefunctionFactory. ");
 
   bool dense_trial;
   std::string name          = pt.get<std::string>("name");
@@ -50,18 +72,12 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
   if( auto node = pt.get_child_optional("dense_trial") )
     dense_trial_opt = node->get_value_optional<bool>(); 
 
-  AFQMCInfo& AFinfo = InfoMap[info];
   ComplexType NCE     = 0.0;
 
-  int NMO  = AFinfo.NMO;
-  int nup = AFinfo.nup;
-  int ndown = AFinfo.ndown;
-  int ntau = AFinfo.ntau;
+  const auto [NMO, nup_in_wfn, ndown_in_wfn] = read_info_from_wfn(filename,"any");
+
   int nspin = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
   int npol = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
-  // FIX : add check for finite-T
-  utils::check((walker_type != NONCOLLINEAR) or (ndown == 0),
-    " Error in Wavefunctions/WavefunctionFactory::fromHDF5: noncollinear && ndown!=0. ndown: {}\n\n\n ", ndown);
 
   WAVEFUNCTION_TYPES wfn_type; 
   if(mpi->comm.root()) { 
@@ -82,19 +98,20 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
   
   if (wfn_type == NOMSD_WFN)
   {
-    if (walker_type != COLLINEAR_FT and walker_type != NONCOLLINEAR_FT){
-      app_log(1," Wavefunction type: NOMSD");
-      h5::group ngrp = wgrp.open_group("NOMSD");
-      nda::array<ComplexType,1> ci;
+    app_log(1," Wavefunction type: NOMSD");
+    nda::array<ComplexType,1> ci;
+    h5::group ngrp = wgrp.open_group("NOMSD");
+    // Read common trial wavefunction input options.
+    WALKER_TYPES input_wtype{};
+    getCommonInput(ngrp, ndets_to_read, ci, input_wtype);
 
-      // Read common trial wavefunction input options.
-      WALKER_TYPES input_wtype;
-      getCommonInput(ngrp, NMO, nup, ndown, ndets_to_read, ci, input_wtype);
-      
+    if (walker_type != COLLINEAR_FT and walker_type != NONCOLLINEAR_FT) {      
       // validation blocks
       utils::check(input_wtype != NONCOLLINEAR or walker_type == NONCOLLINEAR,
           "Error: Trial wavefunction is NONCOLLINEAR and requires NONCOLLINEAR walkers. walker_type: {}", walkerTypeToString(walker_type));
       
+      auto [nup, ndown] = broadcast_number_of_electrons({nup_in_wfn, ndown_in_wfn}, input_wtype, walker_type);
+    
       NCE = h.getNuclearCoulombEnergy();
 
       //mpi->comm.broadcast_n(ci.data(), ci.size());
@@ -104,7 +121,7 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
       auto PsiT = read_nomsd_wavefunction<MEM>(ngrp,ndets_to_read,walker_type,NMO,nup,ndown);
 
       // Set initial walker's Slater matrix.
-      getInitialGuess(ngrp, mpi, name, NMO, nup, ndown, walker_type);
+      getInitialGuess(ngrp, *mpi, name, NMO, nup, ndown, walker_type);
 
       // if not set, get default based on HamTYpe
       // use sparse trial only on KP runs
@@ -130,30 +147,23 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
             });
           }
         }
-        return Wavefunction(NOMSD<MEM,MType>(AFinfo, pt, walker_type, mpi, std::move(HOps), 
+        return Wavefunction(NOMSD<MEM,MType>(pt, NMO, nup, ndown, walker_type, mpi, std::move(HOps), 
                                       std::move(ci), std::move(PsiT_dense),NCE,targetNW)); 
       }
       else
       {
-        return Wavefunction(NOMSD<MEM,PsiT_Matrix<MEM>>(AFinfo, pt, walker_type, mpi, std::move(HOps), 
+        return Wavefunction(NOMSD<MEM,PsiT_Matrix<MEM>>(pt, NMO, nup, ndown, walker_type, mpi, std::move(HOps), 
                                       std::move(ci), std::move(PsiT),NCE,targetNW)); 
       }
     }
     else
-    {     
-      app_log(1," Wavefunction type: NOMSD");
-      h5::group ngrp = wgrp.open_group("NOMSD");
-      nda::array<ComplexType,1> ci;
-
-      // Read common trial wavefunction input options.
-      WALKER_TYPES input_wtype;
-      //ndown not used for finite-T
-      getCommonInput(ngrp, NMO, ntau, 0, ndets_to_read, ci, input_wtype);
-      
+    {           
       // validation blocks
       utils::check(input_wtype != NONCOLLINEAR_FT or walker_type == NONCOLLINEAR_FT,
           "Error: Trial wavefunction is NONCOLLINEAR and requires NONCOLLINEAR walkers. walker_type: {}", walkerTypeToString(walker_type));
       
+      int ntau = nup_in_wfn;
+      utils::check(ndown_in_wfn == 0, "expected ndown dimension to be 0 at finite temperature");
       NCE = h.getNuclearCoulombEnergy();
 
       //mpi->comm.broadcast_n(ci.data(), ci.size());
@@ -163,7 +173,7 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
       auto PsiT = read_nomsd_wavefunction<MEM>(ngrp,ndets_to_read,walker_type,NMO,ntau);
 
       // Set initial walker's Slater matrix.
-      getInitialGuess(ngrp, mpi, name, NMO, nup, ndown, walker_type);
+      getInitialGuess_ft(ngrp, *mpi, name, NMO, walker_type);
 
       // if not set, get default based on HamTYpe
       // use sparse trial only on KP runs
@@ -198,12 +208,12 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
             }
           }
         }
-        return Wavefunction(NOMSD_FT<MEM,MType>(AFinfo, pt, walker_type, mpi, std::move(HOps), 
+        return Wavefunction(NOMSD_FT<MEM,MType>(pt, NMO, ntau, walker_type, mpi, std::move(HOps), 
                                       std::move(ci), std::move(PsiT_dense),NCE,targetNW)); 
       }
       else
       {
-        return Wavefunction(NOMSD_FT<MEM,PsiT_Matrix<MEM>>(AFinfo, pt, walker_type, mpi, std::move(HOps), 
+        return Wavefunction(NOMSD_FT<MEM,PsiT_Matrix<MEM>>(pt, NMO, ntau, walker_type, mpi, std::move(HOps), 
                                       std::move(ci), std::move(PsiT),NCE,targetNW));
       }
 
@@ -224,6 +234,10 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
     //
 
     nda::array<PsiT_Matrix<HOST_MEMORY>, 1> PsiT_MO;
+    
+    // phmsd does not support conversion to noncollinear
+    int nup = nup_in_wfn;
+    int ndown = ndown_in_wfn;
 
     std::string orb_type;
     h5::group ngrp = wgrp.open_group("PHMSD");
@@ -376,7 +390,7 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
       }
     }
 
-    getInitialGuess(ngrp, mpi, name, NMO, nup, ndown, walker_type);
+    getInitialGuess(ngrp, *mpi, name, NMO, nup, ndown, walker_type);
 
     auto n_unique(abij.number_of_unique_excitations());
     app_log(1," Number of unique determinants per spin channel: {} {} ",
@@ -435,7 +449,7 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
       PsiT_1d(i) = std::move(PsiT_MO(i));
     }
 
-    return Wavefunction<MEM>(PHMSD<MEM>(AFinfo, pt, walker_type, mpi, std::move(HOps),
+    return Wavefunction<MEM>(PHMSD<MEM>(pt, walker_type, NMO, nup, ndown, mpi, std::move(HOps),
                     std::move(abij), std::move(det_coupling_matrix),
                     std::move(PsiT_1d), NCE, targetNW));
   }
@@ -451,14 +465,68 @@ Wavefunction<MEM> WavefunctionFactory<MEM>::fromHDF5(std::shared_ptr<utils::mpi_
  * Read Initial walker from file. Needs all mpi tasks, since it allocates on shared memory.
 */
 template<MEMORY_SPACE MEM>
+void WavefunctionFactory<MEM>::getInitialGuess_ft(h5::group grp,
+         utils::mpi_context_t<boost::mpi3::communicator>& mpi,
+         const std::string& name, int NMO, WALKER_TYPES walker_type)
+{
+  using nda::range;
+  int nspin = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
+  int npol = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
+  nda::array<int,1> dims(5);
+  nda::h5_read(grp,"dims",dims);
+  
+  WALKER_TYPES wtype(initWALKER_TYPES(dims[3]));
+  utils::check(walkerTypeIsConvertible(wtype, walker_type), "Initial guess ({}) not convertible to walker_type {}", walkerTypeToString(wtype), walkerTypeToString(walker_type));
+  
+  auto guess = initial_guess_ft.find(name);
+  utils::check(guess == initial_guess_ft.end(), 
+             "Error: Problems adding new initial guess, already exists.");
+  auto newg = initial_guess_ft.insert(std::make_pair(name, memory::share_from_root(mpi, [&] {
+    nda::array<ComplexType,4> M(3, nspin, npol * NMO, NMO);
+    M() = ComplexType(0.0, 0.0);
+    auto URup = M(0,0,nda::ellipsis{});
+    utils::h5_read(grp,"UR_alpha",URup);
+    auto DRup = M(1,0,nda::ellipsis{});
+    utils::h5_read(grp,"DR_alpha",DRup);
+    auto VRup = M(2,0,nda::ellipsis{});
+    utils::h5_read(grp,"VR_alpha",VRup);
+    if (walker_type == COLLINEAR_FT)
+    {
+      if (wtype == COLLINEAR_FT)
+      {
+        auto URdn = M(0,1,nda::range::all,nda::range(NMO));
+        utils::h5_read(grp,"UR_beta",URdn);
+        auto DRdn = M(1,1,nda::range::all,nda::range(NMO));
+        utils::h5_read(grp,"DR_beta",DRdn);
+        auto VRdn = M(2,1,nda::range::all,nda::range(NMO));
+        utils::h5_read(grp,"VR_beta",VRdn);
+      }
+      else if (wtype == CLOSED)
+      {
+        //utils::check(nup == ndown, "Error: wfn_type:Closed with nup != ndown.");
+        M(0,1,nda::ellipsis{}) = URup();
+        M(1,1,nda::ellipsis{}) = DRup();
+        M(2,1,nda::ellipsis{}) = VRup();
+      }
+      else
+        utils::check(false," Error: Unknown wtype. ");
+    }
+    return M;
+  })));
+  utils::check(newg.second, " Error: Problems adding new initial guess. ");
+}
+
+/*
+ * Read Initial walker from file. Needs all mpi tasks, since it allocates on shared memory.
+*/
+template<MEMORY_SPACE MEM>
 void WavefunctionFactory<MEM>::getInitialGuess(h5::group grp,
-         std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
-         std::string& name, int NMO, int nup, int ndown, WALKER_TYPES walker_type)
+         utils::mpi_context_t<boost::mpi3::communicator>& mpi,
+         const std::string& name, int NMO, int nup, int ndown, WALKER_TYPES walker_type)
 {
   using nda::range;
   auto all = range::all;
-  int nspin = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
-  int npol = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
+
   nda::array<int,1> dims(5);
   nda::h5_read(grp,"dims",dims);
   
@@ -466,86 +534,47 @@ void WavefunctionFactory<MEM>::getInitialGuess(h5::group grp,
 
   WALKER_TYPES wtype(initWALKER_TYPES(dims[3]));
   utils::check(walkerTypeIsConvertible(wtype, walker_type), "Initial guess ({}) not convertible to walker_type {}", walkerTypeToString(wtype), walkerTypeToString(walker_type));
-  if(walker_type != COLLINEAR_FT and walker_type != NONCOLLINEAR_FT){
-    auto guess = initial_guess.find(name);
-    utils::check(guess == initial_guess.end(), 
-               "Error: Problems adding new initial guess, already exists.");
-    auto newg = initial_guess.insert(std::make_pair(name, memory::share_from_root(*mpi, [&] {
-      auto [nspin_in_guess, npol_in_guess] = walkerTypeToDims(wtype);
-      nda::array<ComplexType,3> M(nspin_in_guess, npol_in_guess * NMO, nup);
-      M() = 0;
+  utils::check(walker_type != COLLINEAR_FT and walker_type != NONCOLLINEAR_FT, "called ground state function on finite temperature");
+  auto guess = initial_guess.find(name);
+  utils::check(guess == initial_guess.end(), 
+             "Error: Problems adding new initial guess, already exists.");
+  auto newg = initial_guess.insert(std::make_pair(name, memory::share_from_root(mpi, [&] {
+    auto [nspin_in_guess, npol_in_guess] = walkerTypeToDims(wtype);
+    nda::array<ComplexType,3> M(nspin_in_guess, npol_in_guess * NMO, *std::ranges::max_element(nel_in_guess));
+    M() = 0;
 
-      std::array<std::string,2> dataset_names{{"Psi0_alpha", "Psi0_beta"}};
+    std::array<std::string,2> dataset_names{{"Psi0_alpha", "Psi0_beta"}};
 
-      for(int is = 0; is < nspin_in_guess; is++) {
-        auto Mspin = M(is, all, range(nel_in_guess[is]));
-        utils::h5_read(grp, dataset_names[is], Mspin);
-      }
+    for(int is = 0; is < nspin_in_guess; is++) {
+      utils::check(nup >= nel_in_guess[is], "initial guess contains more electrons of spin {} than walker nup ({})", nel_in_guess[is], nup);
+      auto Mspin = M(is, all, range(nel_in_guess[is]));
+      utils::h5_read(grp, dataset_names[is], Mspin);
+    }
+    auto [nspin, npol] = walkerTypeToDims(walker_type);
 
-      if(walker_type == wtype) {
-        return M;
-      } else if(walker_type == NONCOLLINEAR) {
-        nda::array<ComplexType,3> Mfull(nspin, npol * NMO, std::accumulate(nel_in_guess.begin(), nel_in_guess.end(), 0));
-        Mfull() = 0;
-        auto Mfull4d = reshape(Mfull, nspin, npol, NMO, Mfull.extent(2));
-        int offset = 0;
-        for(int ip = 0; ip < npol; ip++) {
-          Mfull4d(0, ip, all, range(offset, offset + nel_in_guess[ip])) = M(ip % nspin_in_guess, all, all); 
-          offset += nel_in_guess[ip];
-        }
-        return Mfull;
-      } else { // CLOSED -> COLLINEAR
-        nda::array<ComplexType,3> Mfull(nspin, npol * NMO, *std::ranges::max_element(nel_in_guess));
-        Mfull() = 0;
-        for(int is = 0; is < nspin; is++) {
-          Mfull(is, all, all) = M(is % nspin_in_guess, all, all); 
-        }
-        return Mfull;
-      }
-    })));
-    utils::check(newg.second, " Error: Problems adding new initial guess. ");
-  }
-  else
-  {
-    auto guess = initial_guess_ft.find(name);
-    utils::check(guess == initial_guess_ft.end(), 
-               "Error: Problems adding new initial guess, already exists.");
-    auto newg = initial_guess_ft.insert(std::make_pair(name, memory::share_from_root(*mpi, [&] {
-      nda::array<ComplexType,4> M(3, nspin, npol * NMO, NMO);
-      M() = ComplexType(0.0, 0.0);
-      auto URup = M(0,0,nda::ellipsis{});
-      utils::h5_read(grp,"UR_alpha",URup);
-      auto DRup = M(1,0,nda::ellipsis{});
-      utils::h5_read(grp,"DR_alpha",DRup);
-      auto VRup = M(2,0,nda::ellipsis{});
-      utils::h5_read(grp,"VR_alpha",VRup);
-      if (walker_type == COLLINEAR_FT)
-      {
-        if (wtype == COLLINEAR_FT)
-        {
-          auto URdn = M(0,1,nda::range::all,nda::range(NMO));
-          utils::h5_read(grp,"UR_beta",URdn);
-          auto DRdn = M(1,1,nda::range::all,nda::range(NMO));
-          utils::h5_read(grp,"DR_beta",DRdn);
-          auto VRdn = M(2,1,nda::range::all,nda::range(NMO));
-          utils::h5_read(grp,"VR_beta",VRdn);
-        }
-        else if (wtype == CLOSED)
-        {
-          //utils::check(nup == ndown, "Error: wfn_type:Closed with nup != ndown.");
-          M(0,1,nda::ellipsis{}) = URup();
-          M(1,1,nda::ellipsis{}) = DRup();
-          M(2,1,nda::ellipsis{}) = VRup();
-        }
-        else
-          utils::check(false," Error: Unknown wtype. ");
-      }
+    if(walker_type == wtype) {
       return M;
-    })));
-    utils::check(newg.second, " Error: Problems adding new initial guess. ");
-  }
+    } else if(walker_type == NONCOLLINEAR) {
+      nda::array<ComplexType,3> Mfull(nspin, npol * NMO, nup);
+      Mfull() = 0;
+      auto Mfull4d = reshape(Mfull, nspin, npol, NMO, Mfull.extent(2));
+      int offset = 0;
+      for(int ip = 0; ip < npol; ip++) {
+        Mfull4d(0, ip, all, range(offset, offset + nel_in_guess[ip])) = M(ip % nspin_in_guess, all, range(nel_in_guess[ip])); 
+        offset += nel_in_guess[ip];
+      }
+      return Mfull;
+    } else { // CLOSED -> COLLINEAR
+      nda::array<ComplexType,3> Mfull(nspin, npol * NMO, std::max(nup,ndown));
+      Mfull() = 0;
+      for(int is = 0; is < nspin; is++) {
+        Mfull(is, all, all) = M(is % nspin_in_guess, all, all); 
+      }
+      return Mfull;
+    }
+  })));
+  utils::check(newg.second, " Error: Problems adding new initial guess. ");
 }
-
 
 /*
 void WavefunctionFactory::computeVariationalEnergyPHMSD(TaskGroup_& TG,

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
@@ -446,36 +446,53 @@ void WavefunctionFactory<MEM>::getInitialGuess(h5::group grp,
          std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
          std::string& name, int NMO, int nup, int ndown, WALKER_TYPES walker_type)
 {
+  using nda::range;
+  auto all = range::all;
   int nspin = (walker_type == COLLINEAR or walker_type == COLLINEAR_FT) ? 2 : 1;
   int npol = (walker_type == NONCOLLINEAR or walker_type == NONCOLLINEAR_FT) ? 2 : 1;
   nda::array<int,1> dims(5);
   nda::h5_read(grp,"dims",dims);
+  
+  auto nel_in_guess = std::to_array({dims[1],dims[2]});
+
   WALKER_TYPES wtype(initWALKER_TYPES(dims[3]));
+  utils::check(walkerTypeIsConvertible(wtype, walker_type), "Initial guess ({}) not convertible to walker_type {}", walkerTypeToString(wtype), walkerTypeToString(walker_type));
   if(walker_type != COLLINEAR_FT and walker_type != NONCOLLINEAR_FT){
     auto guess = initial_guess.find(name);
     utils::check(guess == initial_guess.end(), 
                "Error: Problems adding new initial guess, already exists.");
     auto newg = initial_guess.insert(std::make_pair(name, memory::share_from_root(*mpi, [&] {
-      nda::array<ComplexType,3> M(nspin, npol * NMO, nup);
-      M() = ComplexType(0.0, 0.0);
-      auto Mup = M(0,nda::ellipsis{});
-      utils::h5_read(grp,"Psi0_alpha",Mup);
-      if (walker_type == COLLINEAR)
-      {
-        if (wtype == COLLINEAR)
-        {
-          auto Mdn = M(1,nda::range::all,nda::range(ndown));
-          utils::h5_read(grp,"Psi0_beta",Mdn);
-        }
-        else if (wtype == CLOSED)
-        {
-          utils::check(nup == ndown, "Error: wfn_type:Closed with nup != ndown.");
-          M(1,nda::ellipsis{}) = Mup();
-        }
-        else
-          utils::check(false," Error: Unknown wtype. ");
+      auto [nspin_in_guess, npol_in_guess] = walkerTypeToDims(wtype);
+      nda::array<ComplexType,3> M(nspin_in_guess, npol_in_guess * NMO, nup);
+      M() = 0;
+
+      std::array<std::string,2> dataset_names{{"Psi0_alpha", "Psi0_beta"}};
+
+      for(int is = 0; is < nspin_in_guess; is++) {
+        auto Mspin = M(is, all, range(nel_in_guess[is]));
+        utils::h5_read(grp, dataset_names[is], Mspin);
       }
-      return M;
+
+      if(walker_type == wtype) {
+        return M;
+      } else if(walker_type == NONCOLLINEAR) {
+        nda::array<ComplexType,3> Mfull(nspin, npol * NMO, std::accumulate(nel_in_guess.begin(), nel_in_guess.end(), 0));
+        Mfull() = 0;
+        auto Mfull4d = reshape(Mfull, nspin, npol, NMO, Mfull.extent(2));
+        int offset = 0;
+        for(int ip = 0; ip < npol; ip++) {
+          Mfull4d(0, ip, all, range(offset, offset + nel_in_guess[ip])) = M(ip % nspin_in_guess, all, all); 
+          offset += nel_in_guess[ip];
+        }
+        return Mfull;
+      } else { // CLOSED -> COLLINEAR
+        nda::array<ComplexType,3> Mfull(nspin, npol * NMO, *std::ranges::max_element(nel_in_guess));
+        Mfull() = 0;
+        for(int is = 0; is < nspin; is++) {
+          Mfull(is, all, all) = M(is % nspin_in_guess, all, all); 
+        }
+        return Mfull;
+      }
     })));
     utils::check(newg.second, " Error: Problems adding new initial guess. ");
   }

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.h
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.h
@@ -36,7 +36,7 @@ template<MEMORY_SPACE MEM>
 class WavefunctionFactory
 {
 public:
-  WavefunctionFactory(std::map<std::string, AFQMCInfo>& info) : InfoMap(info) 
+  WavefunctionFactory() 
   {
     // initialize in fromHDF5
   }
@@ -78,8 +78,6 @@ public:
     io::compare_known_keys("Wavefunction Factory",pt1, pt0,pass_through_keys);
     return pt1;
   }
-
-  ~WavefunctionFactory() {}
 
   bool is_constructed(const std::string& ID)
   {
@@ -203,9 +201,6 @@ public:
   }
 
 protected:
-  // reference to container of AFQMCInfo objects
-  std::map<std::string, AFQMCInfo>& InfoMap;
-
   // generates a new Wavefunction and returns the pointer to the base class
   Wavefunction<MEM> buildWavefunction(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
                                  ptree pt,
@@ -226,7 +221,8 @@ protected:
                         Hamiltonian& h,
                         int targetNW);
 
-  void getInitialGuess(h5::group grp, std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi, std::string& name, int NMO, int nup, int ndown, WALKER_TYPES walker_type);
+  void getInitialGuess(h5::group grp, utils::mpi_context_t<boost::mpi3::communicator>& mpi, const std::string& name, int NMO, int nup, int ndown, WALKER_TYPES walker_type);
+  void getInitialGuess_ft(h5::group grp, utils::mpi_context_t<boost::mpi3::communicator>& mpi, const std::string& name, int NMO, WALKER_TYPES walker_type);
 /*
   int getExcitation(nda::MemoryVector& deti,
                     nda::MemoryVector& detj,

--- a/src/AFQMC/config.h
+++ b/src/AFQMC/config.h
@@ -98,6 +98,9 @@ inline WALKER_TYPES walkerTypeFromDims(int nspin, int npol) {
 }
 
 inline bool walkerTypeIsConvertible(WALKER_TYPES from, WALKER_TYPES to) {
+  if(from == to) {
+    return true;
+  }
   if(from < CLOSED || from > NONCOLLINEAR || to < CLOSED || to > NONCOLLINEAR) {
     // hopefully we can get rid of FULLYPOLARIZED and use a smarter scheme to work with FT
     return false;

--- a/src/numerics/sparse/csr_utils.hpp
+++ b/src/numerics/sparse/csr_utils.hpp
@@ -231,6 +231,48 @@ auto to_array(csr_matrix<ValType,MEM,IndxType,IntType> const& csr)
   return to_array<op>(csr,nda::range(csr.extent(0)),nda::range(csr.extent(1)));
 }
 
+// Gathers an arbitrary (not necessarily contiguous) set of rows from a CSR matrix
+// into a dense array. Output row r corresponds to source row rows(r). This does a host copy for now. Optimize if needed.
+template<char op, typename ValType, MEMORY_SPACE MEM = HOST_MEMORY, typename IndxType = int, typename IntType = long>
+requires( (op == 'N' or op == 'T' or op == 'H') )
+auto to_array(csr_matrix<ValType,MEM,IndxType,IntType> const& csr, nda::array<int,1> const& rows, nda::range col_range)
+{
+  sfqmc::utils::check(col_range.first() >= 0 and col_range.first() <= csr.extent(1) and
+                      col_range.last() >= col_range.first() and col_range.last() <= csr.extent(1),
+                      "to_array: col_range out of bounds.");
+  auto vals = ::nda::to_host(csr.values());
+  auto cols = ::nda::to_host(csr.columns());
+  auto row_begin = ::nda::to_host(csr.row_begin());
+  auto row_end = ::nda::to_host(csr.row_end());
+
+  long nr = rows.size();
+  long nc = col_range.size();
+  long i0 = row_begin(0);
+  long c0 = col_range.first();
+  long c1 = col_range.last();
+
+  long nr_out = op == 'N' ? nr : nc;
+  long nc_out = op == 'N' ? nc : nr;
+  
+  auto A = nda::array<ValType, 2>::zeros({nr_out,nc_out});
+  for(long ridx=0; ridx<nr; ++ridx) {
+    long r = rows(ridx);
+    sfqmc::utils::check(r >= 0 and r < csr.extent(0), "to_array: row index out of bounds.");
+    for(long i=row_begin(r); i<row_end(r); ++i) {
+      if( cols(i-i0) >= c0 and cols(i-i0) < c1 ) {
+        if constexpr (op=='T') {
+          A(cols(i-i0)-c0,ridx) = ValType(vals(i-i0));
+        } else if constexpr (op=='H') {
+          A(cols(i-i0)-c0,ridx) = std::conj(ValType(vals(i-i0)));
+        } else {
+          A(ridx,cols(i-i0)-c0) = ValType(vals(i-i0));
+        }
+      }
+    }
+  }
+  return memory::to_memory_space<MEM>(std::move(A));
+}
+
 // On host returns a view, on device returns an array
 template<char op, typename... Args>
 requires( (op == 'N' or op == 'T' or op == 'H' or op == 'C') )

--- a/src/utilities/memory_utils.hpp
+++ b/src/utilities/memory_utils.hpp
@@ -17,6 +17,18 @@
 #include "utilities/check.hpp"
 
 namespace sfqmc::utils {
+inline std::string format_bytes(double bytes) {
+  constexpr std::array units = {
+    "B  ", "KiB", "MiB", "GiB", "TiB",
+  };
+
+  int unit = 0;
+  for(; unit + 1 < units.size() && bytes > 1024; unit++) {
+    bytes /= 1024;
+  }
+
+  return std::format("{:6.1f} {}", bytes, units[unit]);
+}
 
 inline void resize_nda_static_allocator(double x = 0.05)
 {
@@ -26,10 +38,9 @@ inline void resize_nda_static_allocator(double x = 0.05)
     size_t oldsz = static_alloc_host.get_primary()->size(); 
     size_t maxm  = static_alloc_host.get_primary()->maximum_memory();
     if(maxm > oldsz) {
-      double gb = 1.0 / (1024.0*1024.0*1024.0);
-      size_t newsz = size_t( double(maxm) * (1.0+x) ); 
-      app_log(2, "Increasing host buffer size, old:{} GB new:{} GB",
-        double(oldsz)*gb, double(newsz)*gb);
+      size_t newsz = static_cast<size_t>(maxm * (1.0+x)); 
+      app_log(2, "Increasing host buffer size: {} -> {}",
+        format_bytes(oldsz), format_bytes(newsz));
       static_alloc_host.get_primary()->resize(newsz);
     }
   } 
@@ -39,10 +50,9 @@ inline void resize_nda_static_allocator(double x = 0.05)
     size_t oldsz = static_alloc_dev.get_primary()->size();
     size_t maxm  = static_alloc_dev.get_primary()->maximum_memory();
     if(maxm > oldsz) {
-      double gb = 1.0 / (1024.0*1024.0*1024.0);
       size_t newsz = size_t( double(maxm) * (1.0+x) ); 
-      app_log(2, "Increasing device buffer size, old:{} GB new:{} GB",
-        double(oldsz)*gb, double(newsz)*gb);
+      app_log(2, "Increasing device buffer size: {} -> {}",
+        format_bytes(oldsz), format_bytes(newsz));
       static_alloc_dev.get_primary()->resize(newsz);
     }
   }

--- a/src/utilities/parser.h
+++ b/src/utilities/parser.h
@@ -13,16 +13,56 @@
 
 #pragma once
 
+#include <algorithm>
 #include <string>
-#include <iostream>
-#include <fstream>
 #include <vector>
+#include <format>
+#include "utilities/check.hpp"
 
 namespace sfqmc {
 namespace utils
 {
 
 std::vector<std::string> split(std::string const&, std::string const&);
+
+
+template<typename T>
+struct EnumInputSpec {
+  T type{};
+  std::string_view explanation{};
+  std::vector<std::string> names{};
+};
+  
+// consider unifying this together with the other walker functions into a separate file
+template<typename T>
+T parse_enum(std::string_view input, std::initializer_list<EnumInputSpec<T>> specs, std::string_view enum_name) {
+  std::string lower_input{input};
+  std::ranges::transform(lower_input, lower_input.begin(),
+                         [](unsigned char c) { return std::tolower(c); });
+
+  for(const auto& spec : specs) {
+    for(const auto &name: spec.names) {
+      if(lower_input == name) {
+        std::string explanation{};
+        if(!spec.explanation.empty()) {
+          explanation = std::format(" ({})", spec.explanation);
+        }
+        app_log(1,"Using {}{} {}.", spec.names.front(), explanation, enum_name); 
+        return spec.type;
+      }
+    }
+  }
+  std::string allowed;
+  for(const auto& spec : specs) {
+    if(!allowed.empty()) {
+      allowed += ", ";
+    }
+    allowed += std::format("\"{}\"", spec.names.front());
+  }
+    
+  check(false, "Unknown {} type \"{}\" has to be one of {{{}}}.", enum_name, lower_input, allowed);
+  return T{};
+}
 
 }
 }

--- a/tests/hubbard_factorizations.hpp
+++ b/tests/hubbard_factorizations.hpp
@@ -591,8 +591,8 @@ HamiltonianOperations<MEM> build_kpthc(
 /// counterterm lands in H1, matching the Real3 / THC / KP* convention.
 class HubbardModelHamOpsAccess : public ModelHamOpsGenerator {
 public:
-  explicit HubbardModelHamOpsAccess(AFQMCInfo const& info)
-      : ModelHamOpsGenerator(info, dummy_pt(), ComplexType(0), ComplexType(0)) {}
+  explicit HubbardModelHamOpsAccess()
+      : ModelHamOpsGenerator(dummy_pt(), ComplexType(0), ComplexType(0)) {}
 
   using ModelHamOpsGenerator::addComponent;
   using ModelHamOpsGenerator::find_occupied_pairs;
@@ -705,8 +705,7 @@ HamiltonianOperations<MEM> build_modelhamops(
     Jvec.emplace_back(csrM({long(NMO), long(NMO)}, 0));
   }
 
-  AFQMCInfo info{"hubbard_test", int(NMO), s.nup, s.ndown};
-  HubbardModelHamOpsAccess gen(info);
+  HubbardModelHamOpsAccess gen;
 
   nda::array<long, 1> n2IJ =
       gen.find_occupied_pairs<RealType>(s.walker_type, Uvec, Jvec);

--- a/tests/test_driver_factory.cpp
+++ b/tests/test_driver_factory.cpp
@@ -58,7 +58,7 @@ void driver_factory_build(std::shared_ptr<utils::mpi_context_t<boost::mpi3::comm
   std::map<std::string, AFQMCInfo> InfoMap;
   HamiltonianFactory HamFac(InfoMap);
   WalkerSetFactory<MEM> WSetFac(InfoMap);
-  WavefunctionFactory<MEM> WfnFac(InfoMap);
+  WavefunctionFactory<MEM> WfnFac{};
   PropagatorFactory<MEM> PropFac(InfoMap);
   DriverFactory<MEM> DriverFac(mpi, InfoMap, WSetFac, PropFac, WfnFac, HamFac);
 

--- a/tests/test_estimator_handler.cpp
+++ b/tests/test_estimator_handler.cpp
@@ -93,7 +93,7 @@ void estimator_handler_measure_schedule(std::shared_ptr<utils::mpi_context_t<boo
   wfn_pt.put("dense_trial",true);
 
   int nwalk = 11;
-  WavefunctionFactory<MEM> WfnFac(InfoMap);
+  WavefunctionFactory<MEM> WfnFac{};
   WfnFac.push("wfn0", wfn_pt);
   auto& wfn = WfnFac.getWavefunction(mpi, "wfn0", type, &ham, nwalk);
 

--- a/tests/test_estimators.cpp
+++ b/tests/test_estimators.cpp
@@ -148,7 +148,7 @@ void estimators_reduced_density_matrix(std::shared_ptr<utils::mpi_context_t<boos
   wfn_pt.put("filename",wfn_file);
 
   int nwalk = 2;
-  WavefunctionFactory<MEM> WfnFac(InfoMap);
+  WavefunctionFactory<MEM> WfnFac{};
   WfnFac.push("wfn0", wfn_pt);
   auto& wfn = WfnFac.getWavefunction(mpi, "wfn0", type, &ham, nwalk);
 

--- a/tests/test_phmsd.cpp
+++ b/tests/test_phmsd.cpp
@@ -178,7 +178,7 @@ void phmsd_compute(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicato
   wfn_pt.put("ndets_to_read",-1);
   wfn_pt.put("algorithm",0);
 
-  WavefunctionFactory<MEM> WfnFac(InfoMap);
+  WavefunctionFactory<MEM> WfnFac{};
   WfnFac.push("wfn0", wfn_pt);
   auto& wfn = WfnFac.getWavefunction(mpi, "wfn0", type, &ham, nwalk);
 

--- a/tests/test_propagator_factory.cpp
+++ b/tests/test_propagator_factory.cpp
@@ -107,7 +107,7 @@ void propagator_factory_build(std::shared_ptr<utils::mpi_context_t<boost::mpi3::
   wfn_pt.put("filename",wfn_file);
   wfn_pt.put("dense_trial",dense_trial);
 
-  WavefunctionFactory<MEM> WfnFac(InfoMap);
+  WavefunctionFactory<MEM> WfnFac{};
   WfnFac.push("wfn0", wfn_pt);
   auto& wfn = WfnFac.getWavefunction(mpi, "wfn0", type, &ham, nwalk);
 

--- a/tests/test_wfn_factory.cpp
+++ b/tests/test_wfn_factory.cpp
@@ -61,7 +61,8 @@ using namespace afqmc;
 
 template<MEMORY_SPACE MEM>
 void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicator>> mpi,
-             std::string hamil_file, std::string wfn_file, bool dense_trial, bool write_reference)
+             std::string hamil_file, std::string wfn_file, WALKER_TYPES type,
+             bool dense_trial, bool write_reference)
 {
   using nda::range;
   auto all = range::all;
@@ -114,7 +115,7 @@ void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
   wfn_pt.put("filename",wfn_file);
   wfn_pt.put("dense_trial",dense_trial);
 
-  WavefunctionFactory<MEM> WfnFac(InfoMap);
+  WavefunctionFactory<MEM> WfnFac{};
   WfnFac.push("wfn0", wfn_pt);
   auto& wfn = WfnFac.getWavefunction(mpi, "wfn0", type, &ham, nwalk);
 

--- a/tests/test_wfn_factory.cpp
+++ b/tests/test_wfn_factory.cpp
@@ -77,11 +77,28 @@ void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
   auto [NMO,nup,ndown] = read_info_from_wfn(wfn_file, "any");
   utils::check(NMO == reference_data.NMO, "Incompatible NMO.");
 
-  WALKER_TYPES type    = afqmc::getWalkerType(wfn_file, "any");
+  // 'type' is the *target* walker type. The wavefunction file has its own native type,
+  // which the factory may convert to any compatible target.
+  WALKER_TYPES from    = afqmc::getWalkerType(wfn_file, "any");
+  bool native          = (type == from);
+  // For now, only do reference testing on the native-type run. Refine to full combinations later.
+  write_reference      = write_reference && native;
+  bool compare         = native && reference_data.available && !write_reference;
+
+  // Broadcast the electron counts from the native type to the target walker type,
+  // mirroring broadcast_number_of_electrons() in the WavefunctionFactory.
+  if(type == NONCOLLINEAR) {
+    nup   = nup + ndown;
+    ndown = 0;
+  }
+
   int nspin            = (type == COLLINEAR or type == COLLINEAR_FT) ? 2 : 1;
   int npol             = (type == NONCOLLINEAR or type == NONCOLLINEAR_FT) ? 2 : 1;
-  int nel              = (type == COLLINEAR or type == COLLINEAR_FT) ? nup+ndown : nup;  
+  int nel              = (type == COLLINEAR or type == COLLINEAR_FT) ? nup+ndown : nup;
   double dt(0.01);
+
+  app_log(1, "wfn_factory_sdet: native type {} -> walker type {} (dense_trial={})",
+          walkerTypeToString(from), walkerTypeToString(type), dense_trial);
 
   int ntau(0);
   if(type == COLLINEAR_FT or type == NONCOLLINEAR_FT){
@@ -183,12 +200,12 @@ void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
 
   if (!write_reference)
   {
-    if(reference_data.available) {
+    if(compare) {
       CHECK_THAT(e1_w, utils::Approx(reference_data.E1));
       CHECK_THAT(ej_w, utils::Approx(reference_data.EJ));
       CHECK_THAT(exx_w, utils::Approx(reference_data.EXX));
     }
-  } 
+  }
   else
   {
     reference_data.E1 = e1_w;
@@ -242,7 +259,7 @@ void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
   {
     auto X_h = nda::to_host(X);
     if (!write_reference) {
-      if(reference_data.available) {
+      if(compare) {
         CHECK_THAT(X_h, utils::Approx(reference_data.vbias));
       }
     } else {
@@ -267,7 +284,7 @@ void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
 
     if (!write_reference)
     {
-      if(reference_data.available) {
+      if(compare) {
         CHECK_THAT(vHS_h, utils::Approx(reference_data.VHS));
       }
     }
@@ -285,7 +302,7 @@ void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
     utils::check((vHS_sp(0).shape() == std::array<long,2>{nwalk*npol*NMO,nwalk*npol*NMO}) and
                  (vHS_sp(nspin-1).shape() == std::array<long,2>{nwalk*npol*NMO,nwalk*npol*NMO}),
                  "Size mismatch");
-    if (!write_reference && reference_data.available) {
+    if (compare) {
       auto vHS_sp_dense = math::sparse::to_array<'N'>(vHS_sp(0));
       auto[vHS_nspin, vHS_npol] = wfn.vHS_dims();
       CHECK_THAT(vHS_sp_dense(range(vHS_npol*NMO), range(NMO)), utils::Approx(reference_data.VHS(0,0,nda::ellipsis{})));
@@ -308,8 +325,13 @@ TEST_CASE("wfn_factory: sdet", "[wfn_factory]")
   bool write_reference = WRITE_REFERENCE;
 
   run_test_with_files([&]<auto MEM>(std::string hamil_file, std::string wfn_file, WALKER_TYPES) {
-    wfn_factory_sdet<MEM>(mpi, hamil_file, wfn_file, true, write_reference && MEM == HOST_MEMORY);
-    wfn_factory_sdet<MEM>(mpi, hamil_file, wfn_file, false, false);
+    WALKER_TYPES from = afqmc::getWalkerType(wfn_file, "any");
+    // Test the wfn's native walker type plus every walker type it can be converted to.
+    for(auto to : {CLOSED, COLLINEAR, NONCOLLINEAR, FULLYPOLARIZED, COLLINEAR_FT, NONCOLLINEAR_FT}) {
+      if(!walkerTypeIsConvertible(from, to)) continue;
+      wfn_factory_sdet<MEM>(mpi, hamil_file, wfn_file, to, true,  write_reference && MEM == HOST_MEMORY);
+      wfn_factory_sdet<MEM>(mpi, hamil_file, wfn_file, to, false, false);
+    }
   }, UTEST_HAMIL, UTEST_WFN, TestFiles::RHF | TestFiles::UHF | TestFiles::GHF | TestFiles::NOMSD | TestFiles::FINITE_T | TestFiles::ALL_SYSTEMS);
   
 }


### PR DESCRIPTION
A previous PR addressed walker-type promotions of the Hamiltonian, which were previously incompletely implemented.
This PR completes the walker-type promotion fixes by addressing the wavefunction and its associated half-rotated quantities.
It also contains some ancillary bugfixes and improvements.

## Notable changes

- AFQMCInfo is read at a time when walker_type is not yet known. Therefore it contains nup, ndown that are not promoted to the walker type. Because of the way it is passed through the code, updating nup, ndown after walker_type is known is very tricky. As an alternative, this PR removes AFQMCInfo from the Hamiltonians and Wavefunctions. These parts of the code already know the correct nup, ndown and the walker_type from their input anyway and will organically propagate the correctly broadcasted values. In the future, AFQMCInfo may be removed entirely.
- For kpoint symmetry, we no longer assume than the nel axis of the trial wavefunction is sorted in k points. This is important for the collinear -> noncollinear promition.
- Walker type conversions are now covered in the test_wavefunction test.

