### PR TITLE
Lattice model fixes

### DIFF
--- a/src/AFQMC/Drivers/AFQMCDriver.cpp
+++ b/src/AFQMC/Drivers/AFQMCDriver.cpp
@@ -132,8 +132,12 @@ bool AFQMCDriver<MEM>::run(WalkerSet<MEM>& wset)
     checkpoint(wset, iBlock, step_tot);
 
   // print timers
-  if(mpi->comm.root()) AFQMCTimer.print_all();
-  
+  if(mpi->comm.root())
+  { 
+    prop0.printBoundStatistics();
+    AFQMCTimer.print_all();
+  }
+
   app_log(1,"****************************************************");
   app_log(1,"               Finished AFQMC calculation           ");
   app_log(1,"****************************************************");

--- a/src/AFQMC/Drivers/AFQMCDriver.cpp
+++ b/src/AFQMC/Drivers/AFQMCDriver.cpp
@@ -131,12 +131,9 @@ bool AFQMCDriver<MEM>::run(WalkerSet<MEM>& wset)
   if (nCheckpoint > 0)
     checkpoint(wset, iBlock, step_tot);
 
+  prop0.printBoundStatistics();
   // print timers
-  if(mpi->comm.root())
-  { 
-    prop0.printBoundStatistics();
-    AFQMCTimer.print_all();
-  }
+  if(mpi->comm.root()) AFQMCTimer.print_all();
 
   app_log(1,"****************************************************");
   app_log(1,"               Finished AFQMC calculation           ");

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -302,6 +302,40 @@ public:
 
   void set_rng_block_size(int sz) { rng_block_size = sz; }
 
+  // Report, at the end of the calculation, how often the propagation bounding boxes were
+  // triggered: the force-bias (vbias) clamp and the local-energy (eloc) clamp. Counters are
+  // aggregated across all ranks; only the root prints.
+  void printBoundStatistics()
+  {
+    long buf[6] = {vbias_bound_stats.total, vbias_bound_stats.upper, vbias_bound_stats.lower,
+                   eloc_bound_stats.total,  eloc_bound_stats.upper,  eloc_bound_stats.lower};
+    mpi->comm.all_reduce_in_place_n(&buf[0], 6, std::plus<>());
+    if (not mpi->comm.root()) return;
+    long vb_tot = buf[0], vb_up = buf[1];
+    long el_tot = buf[3], el_up = buf[4], el_lo = buf[5];
+    auto pct = [](long h, long t) { return t > 0 ? 100.0 * double(h) / double(t) : 0.0; };
+
+    app_log(1, "\n****************************************************");
+    app_log(1,   "          Bounding-box trigger statistics           ");
+    app_log(1,   "****************************************************");
+
+    app_log(1, " Force-bias (vbias) clamp  [|vbias| > vbias_bound*sqrt(dt)], per (walker,field):");
+    if (vb_tot == 0)
+      app_log(1, "   not measured (host-side counting only).");
+    else
+      app_log(1, "   operations: {}   hits: {} ({:.4f}%)  [upper/magnitude: {} ({:.4f}%)]",
+              vb_tot, vb_up, pct(vb_up, vb_tot), vb_up, pct(vb_up, vb_tot));
+
+    app_log(1, " Local-energy (eloc) clamp  [eloc outside Eshift +/- cutoff_scale*sqrt(2/dt)], per walker:");
+    if (el_tot == 0)
+      app_log(1, "   not triggered (0 operations counted).");
+    else
+      app_log(1, "   operations: {}   hits: {} ({:.4f}%)  [upper: {} ({:.4f}%), lower: {} ({:.4f}%)]",
+              el_tot, el_up + el_lo, pct(el_up + el_lo, el_tot),
+              el_up, pct(el_up, el_tot), el_lo, pct(el_lo, el_tot));
+    app_log(1,   "****************************************************\n");
+  }
+
 
 protected:
   // mpi_context
@@ -367,6 +401,10 @@ protected:
   int npol_in_vHS   = 1;
 
   bool debug_verbosity = false;
+
+  // Diagnostic counters: how often the propagation bounding boxes are triggered over the run.
+  BoundStats vbias_bound_stats;  // force-bias (vbias) clamp, counted per (walker,field)
+  BoundStats eloc_bound_stats;   // local-energy (eloc) clamp, counted per walker
 
   // excited state propagator
   bool excitedState = false;

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -70,15 +70,13 @@ public:
     app_log(1," vHS dimensions: nspins = {}, npol = {}", nspins_in_vHS, npol_in_vHS);
     // convert user input to verbose input
     ptree pt = interpret_inputs(pt_in);
-    // Several defaults are Hamiltonian-type dependent, matching develop: its dedicated
-    // model/lattice propagator defaulted upper/lower_cutoff_scale to 50/50 and vbias_bound to
-    // 100 while the molecular base propagator used 10/1 and 50. Overhaul folded both into this
-    // class, so apply the model defaults here -- but only when the user did not set the values
-    // explicitly in the input.
+    // set model hamiltonian defaults to legacy values if not specified by user
     if (wfn->getHamType() == ModelHamiltonian) {
       if (not pt_in.get_optional<double>("upper_cutoff_scale")) pt.put("upper_cutoff_scale", 50.0);
       if (not pt_in.get_optional<double>("lower_cutoff_scale")) pt.put("lower_cutoff_scale", 50.0);
       if (not pt_in.get_optional<double>("vbias_bound"))        pt.put("vbias_bound", 100.0);
+      if (not pt_in.get_optional<bool>("denseP2"))                pt.put("denseP2", false);
+      if (not pt_in.get_optional<bool>("symmetric_split"))        pt.put("symmetric_split", false);
     }
     app_log(2,"\nBasePropagator input:\n\n{}\n",io::to_string(pt));
     // initialize using verbose input

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -232,7 +232,7 @@ public:
     bool denseP2                = pt0.get<bool>("denseP2", true);
     bool debug_verbosity        = pt0.get<bool>("debug_verbosity", false);
     auto natural_shift          = pt0.get<bool>("natural_shift",true);
-    auto symmetric_split        = pt0.get<bool>("symmetric_split",false);
+    auto symmetric_split        = pt0.get<bool>("symmetric_split",true);
     auto use_cp_constraint      = pt0.get<bool>("use_cp_constraint", false);
     auto use_real_vbias         = pt0.get<bool>("use_real_vbias", false);
     std::string external_field  = pt0.get<std::string>("external_field", "");
@@ -405,7 +405,7 @@ protected:
   double upper_cutoff_scale = 10.0;
   double lower_cutoff_scale = 1.0;
   bool natural_shift = true;
-  bool symmetric_split = false;
+  bool symmetric_split = true;
   bool use_cp_constraint = false;
   bool use_real_vbias = false;
 

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -109,7 +109,8 @@ public:
 
     app_log(1,"\n\n --------------- Constructing Propagator ------------------ \n");
 
-    app_log(1," vbias_bound: {}", vbias_bound); 
+    app_log(1," vbias_bound: {}", vbias_bound);
+    app_log(1," cutoff scales (upper/lower): {} / {}", upper_cutoff_scale, lower_cutoff_scale);
     if(denseP1)
       app_log(1," Using dense 1-body propagator");
     else

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -30,6 +30,7 @@
 #include "numerics/shared_array/const_shared_array.hpp"
 #include "AFQMC/Wavefunctions/Wavefunction.hpp"
 #include "AFQMC/SlaterDeterminantOperations/propagate.hpp"
+#include "AFQMC/Propagators/WalkerSetUpdate.hpp"
 
 namespace sfqmc
 {
@@ -69,6 +70,16 @@ public:
     app_log(1," vHS dimensions: nspins = {}, npol = {}", nspins_in_vHS, npol_in_vHS);
     // convert user input to verbose input
     ptree pt = interpret_inputs(pt_in);
+    // Several defaults are Hamiltonian-type dependent, matching develop: its dedicated
+    // model/lattice propagator defaulted upper/lower_cutoff_scale to 50/50 and vbias_bound to
+    // 100 while the molecular base propagator used 10/1 and 50. Overhaul folded both into this
+    // class, so apply the model defaults here -- but only when the user did not set the values
+    // explicitly in the input.
+    if (wfn->getHamType() == ModelHamiltonian) {
+      if (not pt_in.get_optional<double>("upper_cutoff_scale")) pt.put("upper_cutoff_scale", 50.0);
+      if (not pt_in.get_optional<double>("lower_cutoff_scale")) pt.put("lower_cutoff_scale", 50.0);
+      if (not pt_in.get_optional<double>("vbias_bound"))        pt.put("vbias_bound", 100.0);
+    }
     app_log(2,"\nBasePropagator input:\n\n{}\n",io::to_string(pt));
     // initialize using verbose input
     std::string external_field;

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -584,6 +584,19 @@ void AFQMCBasePropagator<MEM>::assemble_X(RealType sqrtdt,
   // remember to call vbi = apply_bound_vbias(*vb);
 
   auto [nwalk,nCV] = X.shape();
+
+  // Count force-bias (vbias) clamp hits for the end-of-run report. On entry X(iw,m) still holds
+  // the raw vbias, so re-evaluate the exact magnitude condition construct_X uses to clamp it.
+  // Host-only (X is on device for DEVICE_MEMORY); device counting is not supported.
+  if constexpr (MEM == HOST_MEMORY) {
+    RealType bnd = vbias_bound * sqrtdt;
+    auto Xv = X();
+    for (long iw = 0; iw < nwalk; ++iw)
+      for (long m = 0; m < nCV; ++m) {
+        ++vbias_bound_stats.total;
+        if (std::abs(Xv(iw, m)) > bnd) ++vbias_bound_stats.upper;
+      }
+  }
   // generate random numbers
   utils::check( rng_block_size >= nCV, "Error in assemble_X: rng_block_size < nCV.");
   memory::buffered_array<MEM,RealType,2> RNGbuff(nwalk,rng_block_size);

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -147,12 +147,13 @@ void AFQMCBasePropagator<MEM>::Propagate(WlkSet& wset, RealType Eshift, RealType
   {
     if(nt==1) step0 = true; 
     hybrid_walker_update(wset, dt, apply_constrain, importance_sampling, Eshift, new_overlaps, MFfactor,
-                         hybrid_weight, lower_cutoff_scale, upper_cutoff_scale, true, debug_verbosity, step0);
+                         hybrid_weight, lower_cutoff_scale, upper_cutoff_scale, symmetric_split, step0,
+                         debug_verbosity, use_cp_constraint, eloc_bound_stats);
   }
   else
   {
     local_energy_walker_update(wset, dt, apply_constrain, Eshift, new_overlaps, new_energies, MFfactor,
-                               lower_cutoff_scale, upper_cutoff_scale);
+                               lower_cutoff_scale, upper_cutoff_scale, eloc_bound_stats);
   }
   if (wset.getBPPos() >= 0) {
     if(wset.getBPPos() < wset.NumBackProp()) wset.advanceBPPos();

--- a/src/AFQMC/Propagators/Propagator.hpp
+++ b/src/AFQMC/Propagators/Propagator.hpp
@@ -95,6 +95,11 @@ public:
     std::visit([&](auto&& a) { a.set_rng_block_size(std::forward<Args>(args)...); }, var);
   }
 
+  void printBoundStatistics()
+  {
+    std::visit([&](auto&& a) { a.printBoundStatistics(); }, var);
+  }
+
   private:
 
   std::variant<AFQMCBasePropagator<MEM>> var;

--- a/src/AFQMC/Propagators/WalkerSetUpdate.hpp
+++ b/src/AFQMC/Propagators/WalkerSetUpdate.hpp
@@ -218,10 +218,11 @@ void hybrid_walker_update(Wlk &w, RealType dt, bool apply_constrain,
           ComplexType(scale * std::exp(-dt * (eloc.real() - Eshift)), 0.0);
     pseudo_eloc(i) = eloc;
     ovlp(i) = new_ovlp(i);
-    if (scale != 0)
+    if (std::abs(scale) > std::numeric_limits<RealType>::min()) {
       weight_factor(i) = std::exp(-ComplexType(0.0, dt) *
                                   (0.5 * (eloc.imag() + old_eloc.imag()))) /
                          scale;
+    }
     else
       weight_factor(i) = 0.0;
     phase1(i) *= weight_factor(i);
@@ -323,9 +324,13 @@ void local_energy_walker_update(Wlk &w, RealType dt, bool apply_constrain,
         scale *
             std::exp(-dt * (0.5 * (eloc.real() + old_eloc.real()) - Eshift)),
         0.0);
-    weight_factor(i) = std::exp(-ComplexType(0.0, dt) *
+    if (std::abs(scale) > std::numeric_limits<RealType>::min()) {
+      weight_factor(i) = std::exp(-ComplexType(0.0, dt) *
                                 (0.5 * (eloc.imag() + old_eloc.imag()))) /
                        scale;
+    } else {
+      weight_factor(i) = 0.0;
+    }
     phase(i) *= weight_factor(i);
     pseudo_eloc(i) = eloc;
     ovlp(i) = new_ovlp(i);

--- a/src/AFQMC/Propagators/WalkerSetUpdate.hpp
+++ b/src/AFQMC/Propagators/WalkerSetUpdate.hpp
@@ -170,8 +170,7 @@ void hybrid_walker_update(Wlk &w, RealType dt, bool apply_constrain,
     }
     ComplexType eloc_ = eloc;
 
-    if ((!std::isfinite(eloc.real())) ||
-        (std::abs(eloc.real()) < std::numeric_limits<RealType>::min())) {
+    if (!std::isfinite(eloc.real())) {
       scale = 0.0;
       eloc = old_eloc;
     } else {
@@ -306,8 +305,7 @@ void local_energy_walker_update(Wlk &w, RealType dt, bool apply_constrain,
                                                      mf_factor(i).imag())))
                            : 1.0);
     }
-    if ((!std::isfinite(eloc.real())) ||
-        (std::abs(eloc.real()) < std::numeric_limits<RealType>::min())) {
+    if (!std::isfinite(eloc.real())) {
       scale = 0.0;
       eloc = old_eloc;
     } else {

--- a/src/AFQMC/Propagators/WalkerSetUpdate.hpp
+++ b/src/AFQMC/Propagators/WalkerSetUpdate.hpp
@@ -25,6 +25,19 @@
 
 namespace sfqmc {
 namespace afqmc {
+
+struct BoundStats {
+  long total = 0;
+  long upper = 0;
+  long lower = 0;
+  BoundStats &operator+=(BoundStats const &o) {
+    total += o.total;
+    upper += o.upper;
+    lower += o.lower;
+    return *this;
+  }
+};
+
 template <class Wlk>
 void free_projection_walker_update(Wlk &w, RealType dt,
                                    nda::MemoryVector auto &&overlap,
@@ -93,8 +106,9 @@ void hybrid_walker_update(Wlk &w, RealType dt, bool apply_constrain,
                           nda::MemoryVector auto &&MFfactor,
                           nda::MemoryVector auto &&hybrid_weight,
                           double lower_cutoff_scale, double upper_cutoff_scale,
-                          bool symmetric_split, bool debug_verbosity = false,
-                          bool step0 = false, bool use_cp_constraint = false) {
+                          bool symmetric_split, bool debug_verbosity,
+                          bool step0, bool use_cp_constraint,
+                          BoundStats &eloc_stats) {
   auto all = nda::range::all;
   int nwalk = w.size();
   bool BackProp = (w.getBPPos() >= 0 && w.getBPPos() < w.NumBackProp());
@@ -160,11 +174,14 @@ void hybrid_walker_update(Wlk &w, RealType dt, bool apply_constrain,
       scale = 0.0;
       eloc = old_eloc;
     } else {
-      eloc = ComplexType(
-          std::max(std::min(eloc.real(),
-                            Eshift + upper_cutoff_scale * std::sqrt(2.0 / dt)),
-                   Eshift - lower_cutoff_scale * std::sqrt(2.0 / dt)),
-          eloc.imag());
+      RealType hi = Eshift + upper_cutoff_scale * std::sqrt(2.0 / dt);
+      RealType lo = Eshift - lower_cutoff_scale * std::sqrt(2.0 / dt);
+      ++eloc_stats.total;
+      if (eloc.real() > hi)
+        ++eloc_stats.upper;
+      else if (eloc.real() < lo)
+        ++eloc_stats.lower;
+      eloc = ComplexType(std::max(std::min(eloc.real(), hi), lo), eloc.imag());
     }
 
     if (debug_verbosity) {
@@ -236,7 +253,8 @@ void local_energy_walker_update(Wlk &w, RealType dt, bool apply_constrain,
                                 nda::MemoryMatrix auto &&energies,
                                 nda::MemoryVector auto &&MFfactor,
                                 double lower_cutoff_scale,
-                                double upper_cutoff_scale) {
+                                double upper_cutoff_scale,
+                                BoundStats &eloc_stats) {
   auto all = nda::range::all;
   int nwalk = w.size();
   bool BackProp = (w.getBPPos() >= 0 && w.getBPPos() < w.NumBackProp());
@@ -292,11 +310,14 @@ void local_energy_walker_update(Wlk &w, RealType dt, bool apply_constrain,
       scale = 0.0;
       eloc = old_eloc;
     } else {
-      eloc = ComplexType(
-          std::max(std::min(eloc.real(),
-                            Eshift + upper_cutoff_scale * std::sqrt(2.0 / dt)),
-                   Eshift - lower_cutoff_scale * std::sqrt(2.0 / dt)),
-          eloc.imag());
+      RealType hi = Eshift + upper_cutoff_scale * std::sqrt(2.0 / dt);
+      RealType lo = Eshift - lower_cutoff_scale * std::sqrt(2.0 / dt);
+      ++eloc_stats.total;
+      if (eloc.real() > hi)
+        ++eloc_stats.upper;
+      else if (eloc.real() < lo)
+        ++eloc_stats.lower;
+      eloc = ComplexType(std::max(std::min(eloc.real(), hi), lo), eloc.imag());
     }
 
     weight(i) *= ComplexType(

--- a/src/AFQMC/Propagators/WalkerSetUpdate.hpp
+++ b/src/AFQMC/Propagators/WalkerSetUpdate.hpp
@@ -106,8 +106,9 @@ void hybrid_walker_update(Wlk &w, RealType dt, bool apply_constrain,
                           nda::MemoryVector auto &&MFfactor,
                           nda::MemoryVector auto &&hybrid_weight,
                           double lower_cutoff_scale, double upper_cutoff_scale,
-                          bool symmetric_split, bool debug_verbosity,
-                          bool step0, bool use_cp_constraint,
+                          bool symmetric_split,
+                          bool step0, bool debug_verbosity,
+                          bool use_cp_constraint,
                           BoundStats &eloc_stats) {
   auto all = nda::range::all;
   int nwalk = w.size();

--- a/src/AFQMC/SlaterDeterminantOperations/propagate.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/propagate.hpp
@@ -287,7 +287,12 @@ void Propagate(WALKER_TYPES walker_type, int npol, nda::MemoryArrayOfRank<3> aut
 {
   auto all = nda::range::all;
   int nwalk        = SMA.extent(0);
-  utils::check(V.extent(1) == nwalk, "Size mismatch");
+  if constexpr ( nda::MemoryArrayOfRank<V_t,4> ) {  // dense: V is [nspin][nwalk][...][...]
+    utils::check(V.extent(1) == nwalk, "Size mismatch");
+  } else {                                           // sparse: V is [nspin] of csr [nwalk*M, nwalk*M]
+    auto sh = V(0).shape();
+    utils::check(sh[0] == sh[1] and sh[0] % nwalk == 0, "Size mismatch (csr vHS)");
+  }
   utils::check(walker_type != COLLINEAR, "Walker type mismatch: walker_type must not be COLLINEAR");
 
 // MAM: wrong if npol_in_file == 1 in NONCOLLINEAR, fix fix fix!!!
@@ -316,7 +321,12 @@ void Propagate(WALKER_TYPES walker_type, int npol, nda::MemoryArrayOfRank<3> aut
 {
   auto all = nda::range::all;
   int nwalk        = SMA.extent(0); 
-  utils::check(V.extent(1) == nwalk, "Size mismatch");
+  if constexpr ( nda::MemoryArrayOfRank<V_t,4> ) {   // dense: V is [nspin][nwalk][...][...]
+    utils::check(V.extent(1) == nwalk, "Size mismatch");
+  } else {                                           // sparse: V is [nspin] of csr [nwalk*M, nwalk*M]
+    auto sh = V(0).shape();
+    utils::check(sh[0] == sh[1] and sh[0] % nwalk == 0, "Size mismatch (csr vHS)");
+  }
   long nspin_P1 = P1.extent(0);
   utils::check((walker_type == COLLINEAR) and (npol==1), "Walker type mismatch: walker_type must be COLLINEAR and npol==1, got walker_type: {}, npol: {}", walkerTypeToString(walker_type), npol);
   


### PR DESCRIPTION
This is work in progress, changes so far include:

- temporary hack to force lattice defaults to be different in the propagator : we should discuss the best place to do this
- re-implement the legacy RNG for testing purposes
- re-connects several flags that got disconnect in the nda rewrite
- adds a counter for how often the local energy and the force bias bounding boxes get hit (Host memory only for now)