### PR TITLE
port to nda/unstable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,8 +158,8 @@ block()
   set(PythonSupport OFF)
   FetchContent_Declare(
           nda
-          GIT_REPOSITORY "https://github.com/triqs/nda.git"
-          GIT_TAG        tensor
+          GIT_REPOSITORY "https://github.com/lukas-weber/nda.git"
+          GIT_TAG        safire-adjustments
           SYSTEM
   )
   FetchContent_MakeAvailable(nda)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 ######################################################################
 # set options
 ######################################################################
-option(ENABLE_ROCM " Build device code with ROCM backend" OFF)
 option(HAVE_MKL "Assume MKL BLAS/LAPACK library." OFF)
 option(BUILD_UNIT_TESTS "Build unit tests" ON)
 option(BUILD_STATIC "Link to static libraries" OFF)
@@ -127,35 +126,6 @@ if(ENABLE_CUDA)
   string(APPEND CMAKE_CUDA_FLAGS " -std=c++20 --expt-relaxed-constexpr --extended-lambda -Xcudafe \"--diag_suppress=implicit_return_from_non_void_function\" -Wdeprecated-declarations -w") 
   message( STATUS " CMAKE_CUDA_FLAGS: " ${CMAKE_CUDA_FLAGS})
 endif()
-
-######################################################################
-# ROCM 
-######################################################################
-if(ENABLE_ROCM)
-  message(STATUS "ROCM_ROOT: ${ROCM_ROOT}")
-  add_library(ROCM::libraries INTERFACE IMPORTED)
-  # temporarily put rocsolver rocrand here for convenience, should be moved to Platforms.
-  set_target_properties(ROCM::libraries PROPERTIES INTERFACE_INCLUDE_DIRECTORIES  "${ROCM_ROOT}/include"
-                                                   INTERFACE_LINK_LIBRARIES "-L${ROCM_ROOT}/lib;-lrocsolver;-lrocrand")
-endif(ENABLE_ROCM)
-
-######################################################################
-#  HIP 
-######################################################################
-if(ENABLE_HIP)
-  if(NOT ENABLE_ROCM)
-    message(FATAL_ERROR "ROCM is required to use HIP. Please set ENABLE_ROCM=ON.")
-  endif()
-  set(CMAKE_MODULE_PATH "${ROCM_ROOT}/hip/cmake" ${CMAKE_MODULE_PATH})
-  find_package(HIP REQUIRED)
-
-  add_library(HIP::HIP INTERFACE IMPORTED)
-  # temporarily put hipsparse hipblas here for convenience, should be moved to Platforms.
-  set_target_properties(HIP::HIP PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ROCM_ROOT}/include"
-                                            INTERFACE_COMPILE_DEFINITIONS "ENABLE_HIP"
-                                            INTERFACE_LINK_LIBRARIES "-L${ROCM_ROOT}/lib;-lhipsparse;-lhipblas;-lamdhip64")
-endif(ENABLE_HIP)
-
 
 ######################################################################
 # MPI

--- a/src/AFQMC/Estimators/BPWithTimeEvolvedOperators.hpp
+++ b/src/AFQMC/Estimators/BPWithTimeEvolvedOperators.hpp
@@ -196,10 +196,10 @@ public:
     // 3. Calculate observables if needed
     // 3.a add walker weights at current time
     // accumulate expects Yc = conj(Y)
-    nda::tensor::scale(ComplexType(1.0),Y,nda::tensor::op::CONJ); 
+    nda::tensor::scale(1.0,Y,nda::tensor::unary_op::CONJ);
     observ0.accumulate(iav, wset, wgt, X, Y, M, importanceSampling);
     // conjugate Y back!
-    nda::tensor::scale(ComplexType(1.0),Y,nda::tensor::op::CONJ); 
+    nda::tensor::scale(1.0,Y,nda::tensor::unary_op::CONJ);
     average_has_run[iav] = true;
 
     if (bp_step == max_nback_prop) {

--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -59,20 +59,21 @@ public:
     {
       apply_rotation = true;
 
+      nda::array<ComplexType,2> R;
       if (mpi->node_comm.root())
       {
         h5::file file(rot_file, 'r');
         h5::group grp = h5::group(file).create_group(h5_path);
-        memory::array<MEM, ComplexType,2> R;
-        h5::read(grp, "RotationMatrix", XRot);
+        h5::read(grp, "RotationMatrix", R);
 
-        utils::check(XRot.shape(1) != NMO, "Rotation has wrong number of rows {} (expected {})", XRot.shape(1), NMO);
+        utils::check(R.shape(1) != NMO, "Rotation has wrong number of rows {} (expected {})", R.shape(1), NMO);
       }
 
-      std::array<long int,2> dim = XRot.shape();
+      std::array<long int,2> dim = R.shape();
       mpi->node_comm.broadcast_n(dim.data(), dim.size(), 0);
-      XRot.resize(dim);
-      mpi->node_comm.broadcast_n(XRot.data(), XRot.size(), 0);
+      R.resize(dim);
+      mpi->node_comm.broadcast_n(R.data(), R.size(), 0);
+      XRot = memory::to_memory_space<MEM>(std::move(R));
 
       dm_size = XRot.shape(0);
     }

--- a/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
@@ -283,8 +283,8 @@ public:
                     for(int i=0; i<nw; ++i)
                       Wuv(i,all,all) *= Zuv(iq,all,all);
                   } else {
-                    nda::tensor::elementwise(ComplexType(1.0),Zuv(iq,all,all),"uv",
-                                             ComplexType(1.0),Wuv,"wuv",nda::tensor::op::MUL);
+                    nda::tensor::elementwise(1.0,Zuv(iq,all,all),"uv",
+                                             1.0,Wuv,"wuv",nda::tensor::binary_op::PROD);
                   }
 
                   // R[w,u][b] = sum_v Guv[w,u][v] * Yau[b][v]
@@ -507,10 +507,10 @@ public:
 
             // Qwiu[w][i][u] = T[w][u] * conj(Piu[i][u])
             auto Xkiu = Xsiu(is,all,range(ip*nbnd,(ip+1)*nbnd),all); 
-            nda::tensor::elementwise_trinary(ComplexType(1.0),Twqu(all,iq,all),"wu",
-              ComplexType(1.0),nda::conj(Xkiu),"kiu",
-              ComplexType(0.0),Qwiu,"kwiu",
-              nda::tensor::op::MUL,nda::tensor::op::SUM);
+            nda::tensor::elementwise_trinary(1.0,Twqu(all,iq,all),"wu",
+              1.0,nda::conj(Xkiu),"kiu",
+              0.0,Qwiu,"kwiu",
+              nda::tensor::binary_op::PROD,nda::tensor::binary_op::SUM);
 
             // v(nstot,nwalk,nptot,nkpts,nbnd,nkpts,nbnd)
             Av.clear(); 
@@ -547,10 +547,10 @@ public:
 
             auto Xkiu = Xsiu(is,all,range(ip*nbnd,(ip+1)*nbnd),all);
             // Qwiu[w][i][u] = T[w][u] * Piu[i][u]
-            nda::tensor::elementwise_trinary(ComplexType(1.0),Twu,"wu",
-                      ComplexType(1.0),Xkiu,"kiu",
-                      ComplexType(0.0),Qwiu,"kwiu",
-                      nda::tensor::op::MUL,nda::tensor::op::SUM);
+            nda::tensor::elementwise_trinary(1.0,Twu,"wu",
+                      1.0,Xkiu,"kiu",
+                      0.0,Qwiu,"kwiu",
+                      nda::tensor::binary_op::PROD,nda::tensor::binary_op::SUM);
 
             // v(nstot,nwalk,nptot,nkpts,nbnd,nkpts,nbnd)
             Av.clear();

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -243,11 +243,11 @@ public:
             } else {
 	      if constexpr(REAL) {
                 auto Guv4d = memory::to_real_view(Guv);
-                nda::tensor::elementwise(RealType(1.0),Zuv,"uv",
-                                         RealType(1.0),Guv4d,"wuvc",nda::tensor::op::MUL);
+                nda::tensor::elementwise(1.0,Zuv,"uv",
+                                         1.0,Guv4d,"wuvc",nda::tensor::binary_op::PROD);
               } else {
-                nda::tensor::elementwise(ComplexType(1.0),Zuv,"uv",
-                                         ComplexType(1.0),Guv,"wuv",nda::tensor::op::MUL);
+                nda::tensor::elementwise(1.0,Zuv,"uv",
+                                         1.0,Guv,"wuv",nda::tensor::binary_op::PROD);
               }
             }
 
@@ -382,11 +382,11 @@ public:
           } else {
             if constexpr(REAL) {
               auto Guv4d = memory::to_real_view(Guv);
-              nda::tensor::elementwise(RealType(1.0),Zuv,"uv",
-                                       RealType(1.0),Guv4d,"wuvc",nda::tensor::op::MUL);
+              nda::tensor::elementwise(1.0,Zuv,"uv",
+                                       1.0,Guv4d,"wuvc",nda::tensor::binary_op::PROD);
             } else {
-              nda::tensor::elementwise(ComplexType(1.0),Zuv,"uv",
-                                       ComplexType(1.0),Guv,"wuv",nda::tensor::op::MUL);
+              nda::tensor::elementwise(1.0,Zuv,"uv",
+                                       1.0,Guv,"wuv",nda::tensor::binary_op::PROD);
             }
           }
 
@@ -532,7 +532,7 @@ public:
                   Quwi(all,w,i) = Tuw(all,iw+w) * Xiu(i,all);
             } else {
               auto Quwi_r = memory::to_real_view(Quwi);
-              nda::tensor::elementwise_trinary(1.0,Tuw_r(all,range(iw,iw+nw),all),"uwc",1.0,Xiu,"iu",0.0,Quwi_r,"uwic",nda::tensor::op::MUL,nda::tensor::op::SUM);
+              nda::tensor::elementwise_trinary(1.0,Tuw_r(all,range(iw,iw+nw),all),"uwc",1.0,Xiu,"iu",0.0,Quwi_r,"uwic",nda::tensor::binary_op::PROD,nda::tensor::binary_op::SUM);
             }
             
             auto Q2d = nda::reshape(Quwi, std::array<long,2>{nu,nw*NMO});
@@ -554,7 +554,7 @@ public:
                 for(int i=0; i<NMO; ++i)
                   Qwiu(w,i,all) = Tuw(all,iw+w) * nda::conj(Xiu(i,all));
             } else {
-              nda::tensor::elementwise_trinary(ComplexType(1.0),Tuw(all,range(iw,iw+nw)),"uw",ComplexType(1.0),nda::conj(Xiu),"iu",ComplexType(0.0),Qwiu,"wiu",nda::tensor::op::MUL,nda::tensor::op::SUM); 
+              nda::tensor::elementwise_trinary(1.0,Tuw(all,range(iw,iw+nw)),"uw",1.0,nda::conj(Xiu),"iu",0.0,Qwiu,"wiu",nda::tensor::binary_op::PROD,nda::tensor::binary_op::SUM);
             }
 
             auto Q2d = nda::reshape(Qwiu, std::array<long,2>{nw*NMO,nu});

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -27,6 +27,7 @@
 #include "utilities/check_shape.hpp"
 #include "utilities/h5_utils.hpp"
 #include "numerics/nda_functions.hpp"
+#include "numerics/operations/tensor.hpp"
 #include "AFQMC/config.h"
 
 #include "nda/h5.hpp"
@@ -362,8 +363,12 @@ KPFactorizedHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
     memory::array<MEM,ComplexType,3> hfull(nspin_in_H1, npol_in_H1*nkpts*nbnd, npol_in_H1*nkpts*nbnd);
     hfull() = 0;
     auto hfull7 = nda::reshape(hfull, nspin_in_H1, npol_in_H1, nkpts, nbnd, npol_in_H1, nkpts, nbnd);
+    // nkpts is nested inside npol in hfull but outside it in H1, so fixing ik leaves the
+    // destination with two strided levels: not a block layout, hence the copy kernel
+    auto H1_mem = memory::to_memory_space<MEM>(H1());
+    auto H1_6d = nda::reshape(H1_mem, nspin_in_H1, nkpts, npol_in_H1, nbnd, npol_in_H1, nbnd);
     for(int ik = 0; ik < nkpts; ik++) {
-      hfull7(all, all, ik, all, all, ik, all) = nda::reshape(H1(), nspin_in_H1, nkpts, npol_in_H1, nbnd, npol_in_H1, nbnd)(all, ik, all, all, all, all);
+      math::copy(H1_6d(all, ik, all, all, all, all), hfull7(all, all, ik, all, all, ik, all));
     }
 
     return hfull;

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -329,8 +329,8 @@ KPTHCHamiltonian::getHamiltonianOperations(WALKER_TYPES type,
           if constexpr (MEM==HOST_MEMORY)
             Tuv() = Zu() * Tuv();
           else
-            nda::tensor::elementwise(ComplexType(1.0), Zu, "uv",
-                                     ComplexType(1.0), Tuv, "uv", nda::tensor::op::MUL);
+            nda::tensor::elementwise(1.0, Zu, "uv",
+                                     1.0, Tuv, "uv", nda::tensor::binary_op::PROD);
           nda::tensor::add(ComplexType(1.0),Tuv,"uv",ComplexType(1.0),Wuv,"uv");
         }
         auto Xiu = Xsiu()(is,ik,range(ip*nbnd,(ip+1)*nbnd),all);

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
@@ -311,8 +311,8 @@ THCHamiltonian::getHamiltonianOperations_impl(WALKER_TYPES type,
               auto Xiv = Xsiu()(is,range(ip*NMO,(ip+1)*NMO),all);
               auto Zu = (*Zuv)()(range(u0,u1),all);
               nda::tensor::contract(Xiu, "iu", nda::conj(Xiv), "iv", Wuv, "uv");
-              nda::tensor::elementwise(ValueType(1.0), Zu, "uv", ValueType(1.0), Wuv, "uv",
-                                       nda::tensor::op::MUL);
+              nda::tensor::elementwise(1.0, Zu, "uv", 1.0, Wuv, "uv",
+                                       nda::tensor::binary_op::PROD);
               nda::tensor::contract(nda::conj(Xiu), "iu", Wuv, "uv", Tiv, "iv");
               nda::tensor::contract(ValueType(-0.5),Tiv, "iv", Xiv, "jv",
                                     ValueType(0.0),vt(isp,all,all), "ij");

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
@@ -145,7 +145,7 @@ void AFQMCBasePropagator<MEM>::generateP1(double dt, WALKER_TYPES walker_type, b
     math::hermitize(H1);
 
     nda::tensor::add(1, H1, -1, H1tmp);
-    if(nda::norm(nda::flatten(H1tmp())) > 1e-5) {
+    if(nda::linalg::norm(nda::flatten(H1tmp())) > 1e-5) {
       app_warning("H1 is not hermitian!");
     }
 

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -232,10 +232,10 @@ void AFQMCBasePropagator<MEM>::BackPropagate(int nbpsteps, int nStabalize, WlkSe
       {
         // 3. copy reference to SlaterMatrix
         if(nup > 0) {
-          wset.SlaterMatrices(Alpha) = Refs(all,nr,all,range(nup));
+          math::copy(Refs(all,nr,all,range(nup)), wset.SlaterMatrices(Alpha));
         }
         if(walker_type==COLLINEAR && ndown > 0) {
-          wset.SlaterMatrices(Beta) = Refs(all,nr,all,range(nup,nup+ndown));        
+          math::copy(Refs(all,nr,all,range(nup,nup+ndown)), wset.SlaterMatrices(Beta));
         }
 
         // 4. Propagate walkers 
@@ -250,10 +250,10 @@ void AFQMCBasePropagator<MEM>::BackPropagate(int nbpsteps, int nStabalize, WlkSe
 
         // 5. copy reference to back
         if(nup > 0) {
-          Refs(all,nr,all,range(nup)) = wset.SlaterMatrices(Alpha);
+          math::copy(wset.SlaterMatrices(Alpha), Refs(all,nr,all,range(nup)));
         }
         if(walker_type==COLLINEAR && ndown > 0)
-          Refs(all,nr,all,range(nup,nup+ndown)) = wset.SlaterMatrices(Beta);
+          math::copy(wset.SlaterMatrices(Beta), Refs(all,nr,all,range(nup,nup+ndown)));
       }
 
     } else {
@@ -268,9 +268,9 @@ void AFQMCBasePropagator<MEM>::BackPropagate(int nbpsteps, int nStabalize, WlkSe
       for (int nr = 0; nr < nrefs; ++nr)
       { 
         // 3. copy reference to SlaterMatrix
-        wset.SlaterMatrices(Alpha) = Refs(all,nr,all,range(nup));
+        math::copy(Refs(all,nr,all,range(nup)),wset.SlaterMatrices(Alpha));
         if(walker_type==COLLINEAR)
-          wset.SlaterMatrices(Beta) = Refs(all,nr,all,range(nup,nup+ndown));
+          math::copy(Refs(all,nr,all,range(nup,nup+ndown)),wset.SlaterMatrices(Beta));
         
         // 4. Propagate walkers
         apply_propagators<'H'>(wset,vHS); 
@@ -283,9 +283,9 @@ void AFQMCBasePropagator<MEM>::BackPropagate(int nbpsteps, int nStabalize, WlkSe
         }
         
         // 5. copy reference to back
-        Refs(all,nr,all,range(nup)) = wset.SlaterMatrices(Alpha);
+        math::copy(wset.SlaterMatrices(Alpha), Refs(all,nr,all,range(nup)));
         if(walker_type==COLLINEAR)
-          Refs(all,nr,all,range(nup,nup+ndown)) = wset.SlaterMatrices(Beta);
+          math::copy(wset.SlaterMatrices(Beta), Refs(all,nr,all,range(nup,nup+ndown)));
       }
 
     }

--- a/src/AFQMC/SlaterDeterminantOperations/density_matrix.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/density_matrix.hpp
@@ -257,13 +257,13 @@ void log_overlap_impl(UL_t const& UL, DL_t const& DL, VL_t const& VL,
         //nda::tensor::contract(VL,"ij",DLmin,"j",M0,"ij");
         // FIX: copy because elementwise is in-place (is there an alternative?) 
         M0 = VL;
-        nda::tensor::elementwise(ComplexType(1.0),DLmin,"j",ComplexType(1.0),M0,"ij",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,DLmin,"j",1.0,M0,"ij",nda::tensor::binary_op::PROD);
 
         // M1 <-- DRmin * VR
         //nda::tensor::contract(VR,"nij",DRmin,"ni",M1,"nij");
         // FIX: copy because elementwise is in-place (is there an alternative?)  
         M1 = VR;
-        nda::tensor::elementwise(ComplexType(1.0),DRmin,"ni",ComplexType(1.0),M1,"nij",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,DRmin,"ni",1.0,M1,"nij",nda::tensor::binary_op::PROD);
 
         // G <-- DRmin*VR*VL*DLmin
         nda::tensor::contract(ComplexType(1.0),M1,"nij",M0,"jk",ComplexType(0.0),TNN,"nik");
@@ -277,7 +277,7 @@ void log_overlap_impl(UL_t const& UL, DL_t const& DL, VL_t const& VL,
           // and det(UL) has a phase (i.e. det(UL) =/= +-1)
           detail::inverse_logdet(UL,ovlp,M0,nbatch,false);
           // M0() = nda::dagger(UL);
-          nda::tensor::add(nda::conj(UL),"ji",M0,"ij");
+          nda::tensor::add(1.0,nda::conj(UL),"ji",0.0,M0,"ij");
         }
         // M1 <-- UR^-1
         if(!unitaryR){
@@ -287,16 +287,16 @@ void log_overlap_impl(UL_t const& UL, DL_t const& DL, VL_t const& VL,
           // still need to compute log(det(UR)) if it is not stored, in the event UR is complex
           // and det(UR) has a phase (i.e. det(UR) =/= +-1)
           detail::inverse_logdet(UR,ovlp,M1,false); 
-          nda::tensor::add(nda::conj(UR),"nij",M1,"nji");
+          nda::tensor::add(1.0,nda::conj(UR),"nij",0.0,M1,"nji");
         }
 
         // M0 <-- UL^-1*DLmax^-1
         //nda::tensor::contract(ComplexType(1.0),M0,"ij",DLmax_inv,"j",ComplexType(0.0),M0,"ij");  
-        nda::tensor::elementwise(ComplexType(1.0),DLmax_inv,"j",ComplexType(1.0),M0,"ij",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,DLmax_inv,"j",1.0,M0,"ij",nda::tensor::binary_op::PROD);
 
         // M1 <-- DRmax^-1*UR^-1
         //nda::tensor::contract(M1,"nij",DRmax_inv,"ni",M1,"nij"); 
-        nda::tensor::elementwise(ComplexType(1.0),DRmax_inv,"ni",ComplexType(1.0),M1,"nij",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,DRmax_inv,"ni",1.0,M1,"nij",nda::tensor::binary_op::PROD);
 
       } // end of scope for DRmin, DRmax_inv, DLmin, DLmax_inv 
 
@@ -352,7 +352,7 @@ void log_overlap_impl(UL_t const& UL, DL_t const& DL, VL_t const& VL,
           detail::inverse_logdet(UL,ovlp,M0,nbatch,false);
           // U -> U^+ = U^-1 (for U unitary) 
           //M0() = nda::dagger(UL);
-          nda::tensor::add(nda::conj(UL),"ji",M0,"ij");
+          nda::tensor::add(1.0,nda::conj(UL),"ji",0.0,M0,"ij");
         }
         // M1 <-- UR^-1
         if(!unitaryR){
@@ -363,7 +363,7 @@ void log_overlap_impl(UL_t const& UL, DL_t const& DL, VL_t const& VL,
           // and det(UR) has a phase (i.e. det(UR) =/= +-1)
           detail::inverse_logdet(UR,ovlp,M1,false);
           // U -> U^+ = U^-1 (for U unitary) 
-          nda::tensor::add(nda::conj(UR),"nij",M1,"nji");
+          nda::tensor::add(1.0,nda::conj(UR),"nij",0.0,M1,"nji");
         }
 
         // M0 <-- UL^-1*DLmax^-1 
@@ -415,9 +415,8 @@ void LUsolve(A_t && A, B_t && B, O_t && ovlp)
  
   ipiv() = 0;
 
-  //nda::tensor::add(B,"nij",T0,"ijn");
-  //permute indices
-  T0 = nda::permuted_indices_view<nda::encode(nda::permutations::cycle<3>(1))>(std::forward<B_t>(B));
+  // permute indices: T0(i,j,n) <-- B(n,i,j)
+  nda::tensor::assign(B,"nij",T0,"ijn");
 
   // LU 
   nda::lapack::getrf(A,ipiv,work);
@@ -428,9 +427,8 @@ void LUsolve(A_t && A, B_t && B, O_t && ovlp)
   // solve Ax = b
   nda::lapack::getrs(A,T0,ipiv);
 
-  //nda::tensor::add(T0,"ijn",B,"nij");
-  //permute indices
-  B = nda::permuted_indices_view<nda::encode(nda::permutations::cycle<3>(2))>(T0);
+  // permute indices: B(n,i,j) <-- T0(i,j,n)
+  nda::tensor::assign(T0,"ijn",B,"nij");
 }
 
 }
@@ -891,13 +889,13 @@ void MixedDensityMatrix(A_t const& UL, B_t const& DL, C_t const& VL,
         //nda::tensor::contract(VL,"ij",DLmin,"j",M0,"ij");
         // FIX: copy because elementwise is in-place (is there an alternative?)  
         M0 = VL;
-        nda::tensor::elementwise(ComplexType(1.0),DLmin,"j",ComplexType(1.0),M0,"ij",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,DLmin,"j",1.0,M0,"ij",nda::tensor::binary_op::PROD);
 
         // M1 <-- DRmin * VR (M1 used as temporary storage)
         //nda::tensor::contract(VR,"nij",DRmin,"ni",M1,"nij");
         // FIX: copy because elementwise is in-place (is there an alternative?)  
         M1 = VR;
-        nda::tensor::elementwise(ComplexType(1.0),DRmin,"ni",ComplexType(1.0),M1,"nij",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,DRmin,"ni",1.0,M1,"nij",nda::tensor::binary_op::PROD);
 
         // G <-- DRmin*VR*VL*DLmin
         nda::tensor::contract(ComplexType(1.0),M1,"nij",M0,"jk",ComplexType(0.0),G,"nik");
@@ -911,7 +909,7 @@ void MixedDensityMatrix(A_t const& UL, B_t const& DL, C_t const& VL,
           // and det(UL) has a phase (i.e. det(UL) =/= +-1)
           detail::inverse_logdet(UL,ovlp,M0,nbatch,false);
           //M0() = nda::dagger(UL);
-          nda::tensor::add(nda::conj(UL),"ji",M0,"ij");
+          nda::tensor::add(1.0,nda::conj(UL),"ji",0.0,M0,"ij");
         }
         // M1 <-- UR^-1
         if(!unitaryR){
@@ -921,16 +919,16 @@ void MixedDensityMatrix(A_t const& UL, B_t const& DL, C_t const& VL,
           // still need to compute log(det(UR)) if it is not stored, in the event UR is complex
           // and det(UR) has a phase (i.e. det(UR) =/= +-1)
           detail::inverse_logdet(UR,ovlp,M1,false); 
-          nda::tensor::add(nda::conj(UR),"nij",M1,"nji");
+          nda::tensor::add(1.0,nda::conj(UR),"nij",0.0,M1,"nji");
         }
 
         // M0 <-- UL^-1*DLmax^-1
         //nda::tensor::contract(ComplexType(1.0),M0,"ij",DLmax_inv,"j",ComplexType(0.0),M0,"ij");
-        nda::tensor::elementwise(ComplexType(1.0),DLmax_inv,"j",ComplexType(1.0),M0,"ij",nda::tensor::op::MUL);  
+        nda::tensor::elementwise(1.0,DLmax_inv,"j",1.0,M0,"ij",nda::tensor::binary_op::PROD);
 
         // M1 <-- DRmax^-1*UR^-1
         //nda::tensor::contract(M1,"nij",DRmax_inv,"ni",M1,"nij"); 
-        nda::tensor::elementwise(ComplexType(1.0),DRmax_inv,"ni",ComplexType(1.0),M1,"nij",nda::tensor::op::MUL); 
+        nda::tensor::elementwise(1.0,DRmax_inv,"ni",1.0,M1,"nij",nda::tensor::binary_op::PROD);
 
       } // end of scope for DRmin, DRmax_inv, DLmin, DLmax_inv 
 
@@ -990,7 +988,7 @@ void MixedDensityMatrix(A_t const& UL, B_t const& DL, C_t const& VL,
           detail::inverse_logdet(UL,ovlp,M0,nbatch,false);
           // U -> U^+ = U^-1 (for U unitary) 
           //M0() = nda::dagger(UL);
-          nda::tensor::add(nda::conj(UL),"ji",M0,"ij");
+          nda::tensor::add(1.0,nda::conj(UL),"ji",0.0,M0,"ij");
         }
         // M1 <-- UR^-1
         if(!unitaryR){
@@ -1001,7 +999,7 @@ void MixedDensityMatrix(A_t const& UL, B_t const& DL, C_t const& VL,
           // and det(UR) has a phase (i.e. det(UR) =/= +-1)
           detail::inverse_logdet(UR,ovlp,M1,false);
           // U -> U^+ = U^-1 (for U unitary) 
-          nda::tensor::add(nda::conj(UR),"nij",M1,"nji");
+          nda::tensor::add(1.0,nda::conj(UR),"nij",0.0,M1,"nji");
         }
 
         // M0 <-- UL^-1*DLmax^-1 
@@ -1151,7 +1149,7 @@ void MixedDensityMatrix_v2(A_t const& UL, B_t const& DL, C_t const& VL,
           // and det(UL) has a phase (i.e. det(UL) =/= +-1)
           detail::inverse_logdet(VL,ovlp,M0,nbatch,false);
           //M0() = nda::dagger(VL);
-          nda::tensor::add(nda::conj(VL),"ji",M0,"ij");
+          nda::tensor::add(1.0,nda::conj(VL),"ji",0.0,M0,"ij");
         }
         // M1 <-- VR^-1
         if(!unitaryR){
@@ -1161,14 +1159,14 @@ void MixedDensityMatrix_v2(A_t const& UL, B_t const& DL, C_t const& VL,
           // still need to compute log(det(UR)) if it is not stored, in the event UR is complex
           // and det(UR) has a phase (i.e. det(UR) =/= +-1)
           detail::inverse_logdet(VR,ovlp,M1,false); 
-          nda::tensor::add(nda::conj(VR),"nij",M1,"nji");
+          nda::tensor::add(1.0,nda::conj(VR),"nij",0.0,M1,"nji");
         }
 
         // M0 <-- DLmax^-1*VL^-1
-        nda::tensor::elementwise(ComplexType(1.0),DLmax_inv,"i",ComplexType(1.0),M0,"ij",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,DLmax_inv,"i",1.0,M0,"ij",nda::tensor::binary_op::PROD);
 
         // M1 <-- VR^-1*DRmax^-1   (M1 used as temporary storage)
-        nda::tensor::elementwise(ComplexType(1.0),DRmax_inv,"nj",ComplexType(1.0),M1,"nij",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,DRmax_inv,"nj",1.0,M1,"nij",nda::tensor::binary_op::PROD);
 
         // G <-- (DLmax^-1*VL^-1*VR^-1*DRmax^-1)^T
         nda::tensor::contract(ComplexType(1.0),M1,"nkj",M0,"ik",ComplexType(0.0),G,"nji");
@@ -1176,14 +1174,14 @@ void MixedDensityMatrix_v2(A_t const& UL, B_t const& DL, C_t const& VL,
         // M0 <-- UL^T*DLmin
         //nda::tensor::contract(ComplexType(1.0),UL,"ij",DLmin,"i",ComplexType(0.0),M0,"ji");  
         // FIX: copy because elementwise is in-place (is there an alternative?) 
-        M0 = nda::transpose(UL);
-        nda::tensor::elementwise(ComplexType(1.0),DLmin,"j",ComplexType(1.0),M0,"ij",nda::tensor::op::MUL);
+        nda::tensor::assign(UL,"ij",M0,"ji");
+        nda::tensor::elementwise(1.0,DLmin,"j",1.0,M0,"ij",nda::tensor::binary_op::PROD);
 
         // M1 <-- DRmin*UR^T
         //nda::tensor::contract(ComplexType(1.0),UR,"nij",DRmin,"nj",ComplexType(0.0),M1,"nji");
         // FIX: copy because elementwise is in-place (is there an alternative?) 
-        nda::tensor::add(UR,"nij",M1,"nji");
-        nda::tensor::elementwise(ComplexType(1.0),DRmin,"ni",ComplexType(1.0),M1,"nij",nda::tensor::op::MUL);
+        nda::tensor::assign(UR,"nij",M1,"nji");
+        nda::tensor::elementwise(1.0,DRmin,"ni",1.0,M1,"nij",nda::tensor::binary_op::PROD);
 
       } // end of scope for DRmin, DRmax_inv, DLmin, DLmax_inv 
 
@@ -1225,7 +1223,7 @@ void MixedDensityMatrix_v2(A_t const& UL, B_t const& DL, C_t const& VL,
           // and det(UL) has a phase (i.e. det(UL) =/= +-1)
           detail::inverse_logdet(VL,ovlp,M0,nbatch,false);
           // M0() = nda::dagger(VL);
-          nda::tensor::add(nda::conj(VL),"ji",M0,"ij");
+          nda::tensor::add(1.0,nda::conj(VL),"ji",0.0,M0,"ij");
         }
         // M1 <-- VR^-1
         if(!unitaryR){
@@ -1237,7 +1235,7 @@ void MixedDensityMatrix_v2(A_t const& UL, B_t const& DL, C_t const& VL,
           detail::inverse_logdet(VR,ovlp,M1,false); 
 //          for(int b = 0; b < nbatch; ++b)
 //            M1(b,nda::range::all,nda::range::all) = nda::dagger(VR(b,nda::ellipsis{}));
-          nda::tensor::add(nda::conj(VR),"bji",M1,"bij");
+          nda::tensor::add(1.0,nda::conj(VR),"bji",0.0,M1,"bij");
         }
 
         // M0 <-- DLmax^-1*VL^-1

--- a/src/AFQMC/SlaterDeterminantOperations/density_matrix.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/density_matrix.hpp
@@ -406,7 +406,7 @@ void LUsolve(A_t && A, B_t && B, O_t && ovlp)
 
   auto [nbatch, NMO, NMO2] = A.shape();
 
-  utils::check(B.shape() == std::array<long,3>{nbatch,NMO,NMO}, "Size mismatch"); 
+  utils::check_shape(B, "B", nbatch, NMO, NMO); 
 
   memory::buffered_array<MEM,Type,3,nda::F_layout> T0(NMO,NMO,nbatch);
   memory::buffered_array<MEM,int,2> ipiv(nbatch,NMO);

--- a/src/AFQMC/SlaterDeterminantOperations/orthogonalize.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/orthogonalize.hpp
@@ -157,11 +157,11 @@ void orthogonalize(A_t && A, B_t && log_detR)
   nda::lapack::gqr(nda::transpose(Q),tau,work);
 
   // copy back
-  nda::tensor::add(Q,"nab",A,"nba");  
+  nda::tensor::assign(Q,"nab",A,"nba");
 
   // scale A by scl, to make sign of determinant consistent
   if constexpr (nda::mem::have_device_compatible_addr_space<A_t>) {
-    nda::tensor::elementwise(ComplexType(1.0), scl, "wn", ComplexType(1.0), A, "win", nda::tensor::op::MUL);
+    nda::tensor::elementwise(1.0, scl, "wn", 1.0, A, "win", nda::tensor::binary_op::PROD);
   } else {
     for (int i = 0; i < M; ++i)
       A(nda::range::all,i,nda::range::all) *= scl();
@@ -430,10 +430,10 @@ void orthogonalize_wSVD(U_t && U, D_t && D, V_t && V, B_t && scl)
    math::copy(S(nda::range::all,b),D(b,nda::range::all));
   }
 
-  nda::tensor::add(UT,"ijn",U,"nij");
+  nda::tensor::assign(UT,"ijn",U,"nij");
 
   // FIX : need V^+ (not just V^T)
-  nda::tensor::add(VT,"ijn",M1,"nij");
+  nda::tensor::assign(VT,"ijn",M1,"nij");
 
   // V <-- V'*V
   nda::tensor::contract(V,"nij",nda::conj(M1),"nki",V,"nkj");

--- a/src/AFQMC/SlaterDeterminantOperations/orthogonalize.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/orthogonalize.hpp
@@ -147,14 +147,14 @@ void orthogonalize(A_t && A, B_t && log_detR)
   memory::buffered_array<MEM,Type,2> scl(Nw,Nel);
   memory::buffered_array<MEM,Type,1> work;
 
-  nda::tensor::add(A,"nab",Q,"nba");  
-  nda::lapack::geqrf(nda::transpose(Q),tau,work);
+  nda::tensor::assign(A,"nab",Q,"nba");
+  nda::lapack::geqrf(nda::transpose(Q),nda::transpose(tau),work);
 
   // log(Det)
   math::log_determinant_from_geqrf(Q,scl,log_detR(nda::range(Nw)));
   
   // Q
-  nda::lapack::gqr(nda::transpose(Q),tau,work);
+  nda::lapack::gqr(nda::transpose(Q),nda::transpose(tau),work);
 
   // copy back
   nda::tensor::assign(Q,"nab",A,"nba");
@@ -233,7 +233,7 @@ void orthogonalize_wQR(U_t && U, D_t && D, V_t && V, B_t && scl)
         UT(nda::range::all,col) = Dh(b,col) * Uh(b,nda::range::all,col);
 
       // pivoted QR : U*D = Q*R*P^T
-      // NOTE : non-batched version of geqp3 returns jpvt indexed starting from 0
+      // NOTE : geqp3 returns jpvt in LAPACK's 1-based indexing
       nda::lapack::geqp3(UT,jpvt,tau,work);
 
       // get Q, R
@@ -245,9 +245,9 @@ void orthogonalize_wQR(U_t && U, D_t && D, V_t && V, B_t && scl)
         memory::buffered_array<HOST_MEMORY,int,1> P1(M);
       
         for(int i = 0; i < M; ++i){ 
-          P1(jpvt(i)) = i;
+          P1(jpvt(i)-1) = i;
           // D(i) = norm(R(i,:))
-          Dh(b,i) = nda::norm(VT(i,nda::range(i,M)));
+          Dh(b,i) = nda::linalg::norm(VT(i,nda::range(i,M)));
         }
 
         for(int i = 0; i < M; ++i)
@@ -293,7 +293,7 @@ void orthogonalize_wQR(U_t && U, D_t && D, V_t && V, B_t && scl)
         UT(nda::range::all,col) = D(b,col) * U(b,nda::range::all,col);
 
       // pivoted QR : U*D = Q*R*P^T
-      // NOTE : non-batched version of geqp3 return jpvt indexed starting from 0
+      // NOTE : geqp3 returns jpvt in LAPACK's 1-based indexing
       nda::lapack::geqp3(UT,jpvt,tau,work);
 
       // get Q, R
@@ -305,9 +305,9 @@ void orthogonalize_wQR(U_t && U, D_t && D, V_t && V, B_t && scl)
         memory::buffered_array<MEM,int,1> P1(M);
       
         for(int i = 0; i < M; ++i){ 
-          P1(jpvt(i)) = i;
+          P1(jpvt(i)-1) = i;
           // D(i) = norm(R(i,:))
-          D(b,i) = nda::norm(VT(i,nda::range(i,M)));
+          D(b,i) = nda::linalg::norm(VT(i,nda::range(i,M)));
         }
 
         for(int i = 0; i < M; ++i)
@@ -330,9 +330,7 @@ void orthogonalize_wQR(U_t && U, D_t && D, V_t && V, B_t && scl)
       nda::blas::scal(std::exp(-scl_new),D(b,nda::range::all));
       scl(b) += scl_new; 
 
-      //nda::blas::gemm(ComplexType(1.0),VT(nda::range::all,nda::range::all),V(b,nda::ellipsis{}),
-      //                ComplexType(0.0),V(b,nda::ellipsis{}));
-
+      // gemm into UT, since V(b,...) is both input and output
       nda::blas::gemm(ComplexType(1.0),VT(nda::range::all,nda::range::all),V(b,nda::ellipsis{}),
                       ComplexType(0.0),UT);
       

--- a/src/AFQMC/SlaterDeterminantOperations/orthogonalize.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/orthogonalize.hpp
@@ -270,18 +270,17 @@ void orthogonalize_wQR(U_t && U, D_t && D, V_t && V, B_t && scl)
       nda::blas::scal(std::exp(-scl_new),Dh(b,nda::range::all));
       sclh(b) += scl_new; 
 
-      //nda::blas::gemm(ComplexType(1.0),VT(nda::range::all,nda::range::all),Vh(b,nda::ellipsis{}),
-      //                ComplexType(0.0),Vh(b,nda::ellipsis{}));
+      // gemm into UT, since Vh(b,...) is both input and output
       nda::blas::gemm(ComplexType(1.0),VT(nda::range::all,nda::range::all),Vh(b,nda::ellipsis{}),
                       ComplexType(0.0),UT);
-              
-      V(b,nda::ellipsis{}) = nda::to_device(UT);
+
+      Vh(b,nda::ellipsis{}) = UT;
 
     }
 
     U = nda::to_device(Uh);
     D = nda::to_device(Dh);
-    //V = nda::to_device(Vh);
+    V = nda::to_device(Vh);
     scl = nda::to_device(sclh);
 
   }

--- a/src/AFQMC/Walkers/WalkerSetBase.h
+++ b/src/AFQMC/Walkers/WalkerSetBase.h
@@ -457,7 +457,7 @@ public:
 
   void scaleWeightsByOverlap()
   {
-    using nda::tensor::op::MUL;
+    using nda::tensor::binary_op::PROD;
     utils::check(walker_buffer.extent(1) == walker_size, "Shape mismatch");
     nda::range r(tot_num_walkers);
     nda::array<ComplexType,1> ov(tot_num_walkers);  // on host
@@ -468,20 +468,20 @@ public:
       buff(i) = ComplexType(1.0 / std::abs(ov[i]), 0.0);
     buff_d() = buff(); // to device
     // A(i) = A(i) * x(i)
-    nda::tensor::elementwise(ComplexType(1.0),buff_d,"i",
-                             ComplexType(1.0),walker_buffer(r,data_displ[WEIGHT]),"i",MUL);
+    nda::tensor::elementwise(1.0,buff_d,"i",
+                             1.0,walker_buffer(r,data_displ[WEIGHT]),"i",PROD);
     for (int i = 0; i < tot_num_walkers; i++)
       buff[i] = std::exp(ComplexType(0.0, -std::arg(ov[i])));
     buff_d() = buff();  // to device
     // A(i) = A(i) * x(i)
-    nda::tensor::elementwise(ComplexType(1.0),buff_d,"i",
-                             ComplexType(1.0),walker_buffer(r,data_displ[PHASE]),"i",MUL);
-    nda::tensor::elementwise(ComplexType(1.0),buff_d,"i",
-                             ComplexType(1.0),walker_buffer(r,data_displ[PHASE1]),"i",MUL);
-    nda::tensor::elementwise(ComplexType(1.0),buff_d,"i",
-                             ComplexType(1.0),walker_buffer(r,data_displ[PHASE2]),"i",MUL);
-    nda::tensor::elementwise(ComplexType(1.0),buff_d,"i",
-                             ComplexType(1.0),walker_buffer(r,data_displ[PHASE3]),"i",MUL);
+    nda::tensor::elementwise(1.0,buff_d,"i",
+                             1.0,walker_buffer(r,data_displ[PHASE]),"i",PROD);
+    nda::tensor::elementwise(1.0,buff_d,"i",
+                             1.0,walker_buffer(r,data_displ[PHASE1]),"i",PROD);
+    nda::tensor::elementwise(1.0,buff_d,"i",
+                             1.0,walker_buffer(r,data_displ[PHASE2]),"i",PROD);
+    nda::tensor::elementwise(1.0,buff_d,"i",
+                             1.0,walker_buffer(r,data_displ[PHASE3]),"i",PROD);
   }
 
   auto get_mpi() const { return mpi; }

--- a/src/AFQMC/Wavefunctions/NOMSD.cpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.cpp
@@ -175,7 +175,7 @@ void NOMSD<MEM,devPsiT>::Energy(WalkerSet<MEM> const& wset,
     nda::array<ComplexType,1> Ov_h(nw,ComplexType(0.0)); 
     nda::array<ComplexType,1> sum(3,0.0);
     for(int i=0; i<nw; i++) {
-      ComplexType log_m = *std::max_element(ovlp_h(all,i).begin(),ovlp_h(all,i).end());
+      ComplexType log_m = *std::ranges::max_element(ovlp_h(all,i).begin(),ovlp_h(all,i).end(), {}, [](auto a) { return std::real(a); });
       sum() = ComplexType(0.0);
       ComplexType deno(0.0);
       for(int d=0; d<ndet; ++d) {
@@ -297,7 +297,7 @@ void NOMSD<MEM,devPsiT>::Log_Overlap(WalkerSet<MEM> const& wset,
     for(int i=0; i<nw; ++i) {
       auto ai = log_h(nda::range::all,i);
       // find largest determinant for each walker to use as reference
-      ComplexType log_m = *std::max_element(ai.begin(),ai.end());
+      ComplexType log_m = *std::ranges::max_element(ai.begin(),ai.end(), {}, [](auto a) { return std::real(a); });
       ComplexType sum = 0.0;
       for(int p=0; p<ndet; ++p)
         sum += std::exp( ai(p) - log_m );

--- a/src/AFQMC/Wavefunctions/NOMSD.cpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.cpp
@@ -119,10 +119,10 @@ void NOMSD<MEM,devPsiT>::getReferences(memory::buffered_array<MEM,ComplexType,3>
   } else {
     for(int i=0; i<number_of_references; ++i) {
       if(nup != 0) {
-        nda::tensor::add(nda::conj(OrbMats(i,0)()),"ji",Refs(i,all,range(nup)),"ij");
+        nda::tensor::add(1.0,nda::conj(OrbMats(i,0)()),"ji",0.0,Refs(i,all,range(nup)),"ij");
       }
       if(walker_type == COLLINEAR && ndown != 0) {
-        nda::tensor::add(nda::conj(OrbMats(i,1)()),"ji",Refs(i,all,range(nup,nel)),"ij");
+        nda::tensor::add(1.0,nda::conj(OrbMats(i,1)()),"ji",0.0,Refs(i,all,range(nup,nel)),"ij");
       }
     }
   }
@@ -227,7 +227,7 @@ void NOMSD<MEM,devPsiT>::MixedDensityMatrix(WalkerSet<MEM> const& wset,
       // doing in host for now!!!
       
       nda::tensor::add(ComplexType(-1.0),log_m,"w",ComplexType(1.0),Ot,"w");
-      nda::apply(std::conj(ci(d)),Ot,nda::tensor::op::EXP);
+      nda::apply(std::conj(ci(d)),Ot,nda::tensor::unary_op::EXP);
       nda::tensor::add(ComplexType(1.0),Ot,"w",ComplexType(1.0),Ov,"w");
       if constexpr (MEM==HOST_MEMORY) {
         for(int w=0; w<nw; ++w) 
@@ -243,9 +243,9 @@ void NOMSD<MEM,devPsiT>::MixedDensityMatrix(WalkerSet<MEM> const& wset,
         G(w,all) /= Ov(w); 
     } else {
       Ot() = Ov();
-      nda::apply(ComplexType(1.0),Ot,nda::tensor::op::RCP);
+      nda::apply(1.0,Ot,nda::tensor::unary_op::RCP);
       // is this doing the righ thing???
-      nda::tensor::elementwise(ComplexType(1.0),Ot,"w",ComplexType(1.0),G,"wi",nda::tensor::op::MUL);
+      nda::tensor::elementwise(1.0,Ot,"w",1.0,G,"wi",nda::tensor::binary_op::PROD);
     }
     // Ov(iw) += log_ov(iw)
     nda::tensor::add(ComplexType(1.0),log_m,"w",ComplexType(1.0),Ov,"w");

--- a/src/AFQMC/Wavefunctions/NOMSD.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.hpp
@@ -429,7 +429,7 @@ void NOMSD<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Memor
 
         //2.accumulate Ov[m] += ci[n] * exp(LogOv[n]-log_m[n]) 
         nda::tensor::add(ComplexType(-1.0),log_m,"w",ComplexType(1.0),Ot,"w");
-        nda::apply(std::conj(ci(d)),Ot,nda::tensor::op::EXP);
+        nda::apply(std::conj(ci(d)),Ot,nda::tensor::unary_op::EXP);
         nda::tensor::add(ComplexType(1.0),Ot,"w",ComplexType(1.0),Ov,"w");
       }
 
@@ -437,8 +437,8 @@ void NOMSD<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Memor
       if constexpr (MEM==HOST_MEMORY) {
         scl_wgt() /= Ov();
       } else {
-        nda::apply(ComplexType(1.0),Ov,nda::tensor::op::RCP);
-        nda::tensor::elementwise(ComplexType(1.0),Ov,"w",ComplexType(1.0),scl_wgt,"w",nda::tensor::op::MUL);
+        nda::apply(1.0,Ov,nda::tensor::unary_op::RCP);
+        nda::tensor::elementwise(1.0,Ov,"w",1.0,scl_wgt,"w",nda::tensor::binary_op::PROD);
       }
     }
 
@@ -472,7 +472,7 @@ void NOMSD<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Memor
       
       // Ot = conj(ci) * exp(Ot-log_m) 
       nda::tensor::add(ComplexType(-1.0),log_m,"w",ComplexType(1.0),Ot,"w");
-      nda::apply(std::conj(ci(d)),Ot,nda::tensor::op::EXP);
+      nda::apply(std::conj(ci(d)),Ot,nda::tensor::unary_op::EXP);
       // Ov += Ot 
       nda::tensor::add(ComplexType(1.0),Ot,"w",ComplexType(1.0),Ov,"w");
       if(properties_1body.size() > 0) {
@@ -488,7 +488,7 @@ void NOMSD<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Memor
       
       if(properties.size() > 0) {
         // Ot(w) *= scl_wgt(w);
-        nda::tensor::elementwise(ComplexType(1.0),scl_wgt,"w",ComplexType(1.0),Ot,"w",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,scl_wgt,"w",1.0,Ot,"w",nda::tensor::binary_op::PROD);
         auto Gt_h = nda::to_host(Gt());
         auto wgt_h  = nda::to_host(Ot());
         for (auto& v : properties)
@@ -502,9 +502,9 @@ void NOMSD<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Memor
         Gfull(w,nda::ellipsis{}) /= Ov(w); 
     } else {
       Ot() = Ov();
-      nda::apply(ComplexType(1.0),Ot,nda::tensor::op::RCP);
+      nda::apply(1.0,Ot,nda::tensor::unary_op::RCP);
       // is this doing the righ thing???
-      nda::tensor::elementwise(ComplexType(1.0),Ot,"w",ComplexType(1.0),Gfull,"wiab",nda::tensor::op::MUL);
+      nda::tensor::elementwise(1.0,Ot,"w",1.0,Gfull,"wiab",nda::tensor::binary_op::PROD);
     }
 
     auto Gh = nda::to_host(Gfull());

--- a/src/AFQMC/Wavefunctions/NOMSD_FT.cpp
+++ b/src/AFQMC/Wavefunctions/NOMSD_FT.cpp
@@ -198,7 +198,7 @@ void NOMSD_FT<MEM,devPsiT>::MixedDensityMatrix(WalkerSet<MEM> const& wset, memor
       // doing in host for now!!!
       
       nda::tensor::add(ComplexType(-1.0),log_m,"w",ComplexType(1.0),Ot,"w");
-      nda::tensor::scale(std::conj(ci(d)),Ot,nda::tensor::op::EXP);
+      nda::tensor::scale(std::conj(ci(d)),Ot,nda::tensor::unary_op::EXP);
       nda::tensor::add(ComplexType(1.0),Ot,"w",ComplexType(1.0),Ov,"w");
       if constexpr (MEM==HOST_MEMORY) {
         for(int w=0; w<nw; ++w) 
@@ -215,9 +215,9 @@ void NOMSD_FT<MEM,devPsiT>::MixedDensityMatrix(WalkerSet<MEM> const& wset, memor
         G(w,all) /= Ov(w); 
     } else {
       Ot() = Ov();
-      nda::tensor::scale(ComplexType(1.0),Ot,nda::tensor::op::RCP);
+      nda::tensor::scale(1.0,Ot,nda::tensor::unary_op::RCP);
       // is this doing the righ thing???
-      nda::tensor::elementwise(ComplexType(1.0),Ot,"w",ComplexType(1.0),G,"wi",nda::tensor::op::MUL);
+      nda::tensor::elementwise(1.0,Ot,"w",1.0,G,"wi",nda::tensor::binary_op::PROD);
     }
     */
   }

--- a/src/AFQMC/Wavefunctions/NOMSD_FT.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD_FT.hpp
@@ -476,7 +476,7 @@ void NOMSD_FT<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Me
 
         //2.accumulate Ov[m] += ci[n] * exp(LogOv[n]-log_m[n]) 
         nda::tensor::add(ComplexType(-1.0),log_m,"w",ComplexType(1.0),Ot,"w");
-        nda::tensor::scale(std::conj(ci(d)),Ot,nda::tensor::op::EXP);
+        nda::tensor::scale(std::conj(ci(d)),Ot,nda::tensor::unary_op::EXP);
         nda::tensor::add(ComplexType(1.0),Ot,"w",ComplexType(1.0),Ov,"w");
       }
 
@@ -484,8 +484,8 @@ void NOMSD_FT<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Me
       if constexpr (MEM==HOST_MEMORY) {
         scl_wgt() /= Ov();
       } else {
-        nda::tensor::scale(ComplexType(1.0),Ov,nda::tensor::op::RCP);
-        nda::tensor::elementwise(ComplexType(1.0),Ov,"w",ComplexType(1.0),scl_wgt,"w",nda::tensor::op::MUL);
+        nda::tensor::scale(1.0,Ov,nda::tensor::unary_op::RCP);
+        nda::tensor::elementwise(1.0,Ov,"w",1.0,scl_wgt,"w",nda::tensor::binary_op::PROD);
       }
     }
 
@@ -519,7 +519,7 @@ void NOMSD_FT<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Me
       
       // Ot = conj(ci) * exp(Ot-log_m) 
       nda::tensor::add(ComplexType(-1.0),log_m,"w",ComplexType(1.0),Ot,"w");
-      nda::tensor::scale(std::conj(ci(d)),Ot,nda::tensor::op::EXP);
+      nda::tensor::scale(std::conj(ci(d)),Ot,nda::tensor::unary_op::EXP);
       // Ov += Ot 
       nda::tensor::add(ComplexType(1.0),Ot,"w",ComplexType(1.0),Ov,"w");
       if(properties_1body.size() > 0) {
@@ -535,7 +535,7 @@ void NOMSD_FT<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Me
       
       if(properties.size() > 0) {
         // Ot(w) *= scl_wgt(w);
-        nda::tensor::elementwise(ComplexType(1.0),scl_wgt,"w",ComplexType(1.0),Ot,"w",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,scl_wgt,"w",1.0,Ot,"w",nda::tensor::binary_op::PROD);
         auto Gt_h = nda::to_host(Gt());
         auto wgt_h  = nda::to_host(Ot());
         for (auto& v : properties)
@@ -549,9 +549,9 @@ void NOMSD_FT<MEM,devPsiT>::accumulate_estimators(int iav, WlkSet& wset, nda::Me
         Gfull(w,nda::ellipsis{}) /= Ov(w); 
     } else {
       Ot() = Ov();
-      nda::tensor::scale(ComplexType(1.0),Ot,nda::tensor::op::RCP);
+      nda::tensor::scale(1.0,Ot,nda::tensor::unary_op::RCP);
       // is this doing the righ thing???
-      nda::tensor::elementwise(ComplexType(1.0),Ot,"w",ComplexType(1.0),Gfull,"wiab",nda::tensor::op::MUL);
+      nda::tensor::elementwise(1.0,Ot,"w",1.0,Gfull,"wiab",nda::tensor::binary_op::PROD);
     }
 
     auto Gh = nda::to_host(Gfull());

--- a/src/AFQMC/Wavefunctions/PHMSD.cpp
+++ b/src/AFQMC/Wavefunctions/PHMSD.cpp
@@ -246,7 +246,7 @@ void PHMSD<MEM>::energy_alg0(WalkerSet<MEM> const& wset, memory::array_view<MEM,
           // log_ov(n) - log_ov(0)
           nda::tensor::add(ComplexType(-1.0),log_ov(spin,all),"w",ComplexType(1.0),Ovmsd(spin,nd,all),"w");
           // Ovmsd = exp(log_ov(n) - log_ov(0)) -> Ov(n)/Ov(0)
-          nda::apply(ComplexType(1.0),Ovmsd(spin,nd,all),nda::tensor::op::EXP);
+          nda::apply(1.0,Ovmsd(spin,nd,all),nda::tensor::unary_op::EXP);
         }
         // kernel for gpu???
         for(int a=0; a<nel[spin]; ++a)
@@ -262,8 +262,8 @@ void PHMSD<MEM>::energy_alg0(WalkerSet<MEM> const& wset, memory::array_view<MEM,
           nda::tensor::contract(ComplexType(1.0),KEright(nd,all,all),"wn",KEleft,"wn",
                                 ComplexType(0.0),eloc,"w"); 
           // tmp[iw] *= Ovmsd[spin][nd][iw]
-          nda::tensor::elementwise(ComplexType(1.0),Ovmsd(spin,nd,all),"w",
-                                   ComplexType(1.0),eloc,"w",nda::tensor::op::MUL);
+          nda::tensor::elementwise(1.0,Ovmsd(spin,nd,all),"w",
+                                   1.0,eloc,"w",nda::tensor::binary_op::PROD);
           // opSpinEJ[iw] += tmp[iw]
           nda::tensor::add(ComplexType(1.0),eloc,"w",ComplexType(1.0),opSpinEJ,"w");  
         }
@@ -275,8 +275,8 @@ void PHMSD<MEM>::energy_alg0(WalkerSet<MEM> const& wset, memory::array_view<MEM,
             for(int w=0; w<nwalk; ++w)
               KEright(d,w,all) *= Ovmsd(0,d,w);
         else
-          nda::tensor::elementwise(ComplexType(1.0),Ovmsd(0,range(nexcit[0]),all),"dw",
-                                   ComplexType(1.0),KEright(range(nexcit[0]),all,all),"dwn",nda::tensor::op::MUL);
+          nda::tensor::elementwise(1.0,Ovmsd(0,range(nexcit[0]),all),"dw",
+                                   1.0,KEright(range(nexcit[0]),all,all),"dwn",nda::tensor::binary_op::PROD);
         // Tdn[idet_down][iw][n] = DetCouplings[idet_down][idet_up] * KEright[idet_up][iw][n] 
         memory::buffered_array<MEM,ComplexType,2> Tdn(nexcit[0],nwalk*nkev); 
         Tdn() = KEr2d(range(nexcit[0]),all);
@@ -301,30 +301,30 @@ void PHMSD<MEM>::energy_alg0(WalkerSet<MEM> const& wset, memory::array_view<MEM,
              wgt(range(nexcit[0]),all),"uw",ComplexType(0.0),Ov,"w");
 
     // W[u][iw] *= Ovmsd[0][u][iw]   
-    nda::tensor::elementwise(ComplexType(1.0),Ovmsd(0,range(nexcit[0]),all),"uw",
-                         ComplexType(1.0),wgt(range(nexcit[0]),all),"uw",nda::tensor::op::MUL);
+    nda::tensor::elementwise(1.0,Ovmsd(0,range(nexcit[0]),all),"uw",
+                         1.0,wgt(range(nexcit[0]),all),"uw",nda::tensor::binary_op::PROD);
     if constexpr (MEM==HOST_MEMORY) {
       for(int u=0; u<nexcit[0]; ++u) 
         for(int w=0; w<nwalk; ++w) 
           Emsd(0,u,w,all) *= wgt(u,w);
     } else { 
-      nda::tensor::elementwise(ComplexType(1.0),wgt(range(nexcit[0]),all),"uw",
-              ComplexType(1.0),Emsd(0,range(nexcit[0]),all,all),"uwc",nda::tensor::op::MUL);
+      nda::tensor::elementwise(1.0,wgt(range(nexcit[0]),all),"uw",
+              1.0,Emsd(0,range(nexcit[0]),all,all),"uwc",nda::tensor::binary_op::PROD);
     }
 
     // spin down
     // W[d][iw] = sum_u OpSpinDetCouplings[d][u] Ov[u][iw]   
     math::sparse::csrmm<'N'>(OpSpinDetCouplings(1),Ovmsd(0,range(nexcit[0]),all),wgt(range(nexcit[1]),all));
     // W[u][iw] *= Ovmsd[0][u][iw]   
-    nda::tensor::elementwise(ComplexType(1.0),Ovmsd(1,range(nexcit[1]),all),"uw",
-                         ComplexType(1.0),wgt(range(nexcit[1]),all),"uw",nda::tensor::op::MUL);
+    nda::tensor::elementwise(1.0,Ovmsd(1,range(nexcit[1]),all),"uw",
+                         1.0,wgt(range(nexcit[1]),all),"uw",nda::tensor::binary_op::PROD);
     if constexpr (MEM==HOST_MEMORY) {
       for(int u=0; u<nexcit[1]; ++u)
         for(int w=0; w<nwalk; ++w) 
           Emsd(1,u,w,all) *= wgt(u,w);
     } else {
-      nda::tensor::elementwise(ComplexType(1.0),wgt(range(nexcit[1]),all),"uw",
-              ComplexType(1.0),Emsd(1,range(nexcit[1]),all,all),"uwc",nda::tensor::op::MUL);
+      nda::tensor::elementwise(1.0,wgt(range(nexcit[1]),all),"uw",
+              1.0,Emsd(1,range(nexcit[1]),all,all),"uwc",nda::tensor::binary_op::PROD);
     }
   } else {
 /*
@@ -351,16 +351,16 @@ void PHMSD<MEM>::energy_alg0(WalkerSet<MEM> const& wset, memory::array_view<MEM,
       E(iw,all) /= Ov(iw);
   } else {
     // implemented in nda_functions.hpp
-    nda::tensor::reduce(ComplexType(1.0),Emsd,"snwc",ComplexType(0.0),E,"wc",nda::tensor::op::SUM);
+    nda::tensor::reduce(1.0,Emsd,"snwc",0.0,E,"wc",nda::tensor::binary_op::SUM);
     if(walker_type == COLLINEAR) 
       nda::tensor::add(ComplexType(1.0),opSpinEJ,"w",ComplexType(1.0),E(all,2),"w");
     memory::buffered_array<MEM,ComplexType,1> Ot(Ov);
-    nda::apply(ComplexType(1.0),Ot,nda::tensor::op::RCP);
-    nda::tensor::elementwise(ComplexType(1.0),Ot,"w",
-                             ComplexType(1.0),E,"wc",nda::tensor::op::MUL);
+    nda::apply(1.0,Ot,nda::tensor::unary_op::RCP);
+    nda::tensor::elementwise(1.0,Ot,"w",
+                             1.0,E,"wc",nda::tensor::binary_op::PROD);
   }
   // Ov -> log( Ov(n)/Ov(0) ) 
-  nda::apply(ComplexType(1.0),Ov,nda::tensor::op::LOG);
+  nda::apply(1.0,Ov,nda::tensor::unary_op::LOG);
   // Ov += log_ov(0) -> log(Ov)
   if(walker_type == COLLINEAR) 
     nda::tensor::add(ComplexType(1.0),log_ov(1,all),"w",ComplexType(1.0),log_ov(0,all),"w");
@@ -443,7 +443,7 @@ void PHMSD<MEM>::energy_alg1(WalkerSet<MEM> const& wset, memory::array_view<MEM,
         // Ov[iw] = sum_u W(u,iw) * ovlp_ratio(u,iw)  
         nda::tensor::contract(one,ovlp_ratios_up,"uw",wgt,"uw",zero,Ov(w_rng),"w");
         // W(u,iw) *= ovlp_ratio(u,iw)   
-        nda::tensor::elementwise(one,ovlp_ratios_up,"uw",one,wgt,"uw",nda::tensor::op::MUL);
+        nda::tensor::elementwise(one,ovlp_ratios_up,"uw",one,wgt,"uw",nda::tensor::binary_op::PROD);
 
         // 3a. Reference energy and temporary matrices
         HamOp.ph_reference_energy(Alpha, eloc, GA2d, KEright(0,all,all));
@@ -455,7 +455,7 @@ void PHMSD<MEM>::energy_alg1(WalkerSet<MEM> const& wset, memory::array_view<MEM,
           for(int i=0; i<nw; ++i)
             eloc(i,all) *= Ov(iw+i);
         } else {
-          nda::tensor::elementwise(one,Ov(w_rng),"w",one,eloc,"wi",nda::tensor::op::MUL);
+          nda::tensor::elementwise(one,Ov(w_rng),"w",one,eloc,"wi",nda::tensor::binary_op::PROD);
         }
         nda::tensor::add(one, eloc, "wi", one, E(w_rng,all), "wi");
 
@@ -473,7 +473,7 @@ void PHMSD<MEM>::energy_alg1(WalkerSet<MEM> const& wset, memory::array_view<MEM,
               KEright(i,w,all) *= ovlp_ratios_up(i,w);
         } else {
           nda::tensor::elementwise(one,ovlp_ratios_up,"nw",
-                   one,KEright(range(nexcit[0]),all,all),"nwk",nda::tensor::op::MUL);
+                   one,KEright(range(nexcit[0]),all,all),"nwk",nda::tensor::binary_op::PROD);
         }
 
         // Tdn[idet_down][iw][n] = DetCouplings[idet_down][idet_up] * KEright[idet_up][iw][n] 
@@ -487,7 +487,7 @@ void PHMSD<MEM>::energy_alg1(WalkerSet<MEM> const& wset, memory::array_view<MEM,
               KEright(i,w,all) *= ovlp_ratios_dn(i,w);
         } else {
           nda::tensor::elementwise(one,ovlp_ratios_dn,"nw",
-                   one,KEright(range(nexcit[1]),all,all),"nwk",nda::tensor::op::MUL);
+                   one,KEright(range(nexcit[1]),all,all),"nwk",nda::tensor::binary_op::PROD);
         }
       }
 
@@ -497,7 +497,7 @@ void PHMSD<MEM>::energy_alg1(WalkerSet<MEM> const& wset, memory::array_view<MEM,
         // W[u][iw] = sum_d OpSpinDetCouplings[u][d] Ov[d][iw]   
         math::sparse::csrmm<'N'>(OpSpinDetCouplings(1),ovlp_ratios_up,wgt);
         // W[u][iw] *= Ovlps[0][u][iw]   
-        nda::tensor::elementwise(one,ovlp_ratios_dn,"uw",one,wgt,"uw",nda::tensor::op::MUL);
+        nda::tensor::elementwise(one,ovlp_ratios_dn,"uw",one,wgt,"uw",nda::tensor::binary_op::PROD);
 
         // 3b. Reference energy and temporary matrices
         memory::buffered_array<MEM,ComplexType,2> KEleft(nw, nkev);
@@ -508,7 +508,7 @@ void PHMSD<MEM>::energy_alg1(WalkerSet<MEM> const& wset, memory::array_view<MEM,
           for(int i=0; i<nw; ++i)
             eloc(i,all) *= Ov(iw+i);
         } else {
-          nda::tensor::elementwise(one,Ov(w_rng),"w",one,eloc,"wi",nda::tensor::op::MUL);
+          nda::tensor::elementwise(one,Ov(w_rng),"w",one,eloc,"wi",nda::tensor::binary_op::PROD);
         }
         nda::tensor::add(one, eloc, "wi", one, E(w_rng,all), "wi");
 
@@ -531,12 +531,12 @@ void PHMSD<MEM>::energy_alg1(WalkerSet<MEM> const& wset, memory::array_view<MEM,
       E(iw,all) /= Ov(iw);
   } else {
     memory::buffered_array<MEM,ComplexType,1> Ot(Ov);
-    nda::apply(ComplexType(1.0),Ot,nda::tensor::op::RCP);
-    nda::tensor::elementwise(ComplexType(1.0),Ot,"w",
-                             ComplexType(1.0),E,"wc",nda::tensor::op::MUL);
+    nda::apply(1.0,Ot,nda::tensor::unary_op::RCP);
+    nda::tensor::elementwise(1.0,Ot,"w",
+                             1.0,E,"wc",nda::tensor::binary_op::PROD);
   }
   // Ov -> log( Ov(n)/Ov(0) ) 
-  nda::apply(ComplexType(1.0),Ov,nda::tensor::op::LOG);
+  nda::apply(1.0,Ov,nda::tensor::unary_op::LOG);
   // Ov += log_ov(0) -> log(Ov)
   nda::tensor::add(ComplexType(1.0),log_ov,"w",ComplexType(1.0),Ov,"w");
 }
@@ -718,8 +718,8 @@ void PHMSD<MEM>::MixedDensityMatrix(WalkerSet<MEM> const& wset, memory::array_vi
         nda::tensor::contract(ComplexType(1.0),ovlp_ratios_up,"nw",wgt,"nw",ComplexType(0.0),Ov(range(iw,iw+nw)),"w");
 
         // wgt() = wgt() * ovlp_ratios_up()  
-        nda::tensor::elementwise(ComplexType(1.0),ovlp_ratios_up,"nw",
-                                 ComplexType(1.0),wgt,"nw",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,ovlp_ratios_up,"nw",
+                                 1.0,wgt,"nw",nda::tensor::binary_op::PROD);
 
         // calculate R
         memory::buffered_array<MEM,ComplexType,3> Ra(nw,nup,nactA);
@@ -753,8 +753,8 @@ void PHMSD<MEM>::MixedDensityMatrix(WalkerSet<MEM> const& wset, memory::array_vi
         // W[u][iw] = sum_d OpSpinDetCouplings[u][d] Ov[d][iw]   
         math::sparse::csrmm<'N'>(OpSpinDetCouplings(1),ovlp_ratios_up,wgt);
         // wgt() = wgt() * ovlp_ratios_up()  
-        nda::tensor::elementwise(ComplexType(1.0),ovlp_ratios_dn,"nw",
-                                 ComplexType(1.0),wgt,"nw",nda::tensor::op::MUL);
+        nda::tensor::elementwise(1.0,ovlp_ratios_dn,"nw",
+                                 1.0,wgt,"nw",nda::tensor::binary_op::PROD);
 
         // calculate R
         memory::buffered_array<MEM,ComplexType,3> Rb(nw,ndown,nactB);
@@ -784,11 +784,11 @@ void PHMSD<MEM>::MixedDensityMatrix(WalkerSet<MEM> const& wset, memory::array_vi
       } else {
         memory::buffered_array<MEM,ComplexType,1> Ot(nw);
         Ot() = Ov(range(iw,iw+nw)); 
-        nda::apply(ComplexType(1.0),Ot,nda::tensor::op::RCP);
-        nda::tensor::elementwise(ComplexType(1.0),Ot,"w",ComplexType(1.0),G(range(iw,iw+nw),all),"wi",nda::tensor::op::MUL);
+        nda::apply(1.0,Ot,nda::tensor::unary_op::RCP);
+        nda::tensor::elementwise(1.0,Ot,"w",1.0,G(range(iw,iw+nw),all),"wi",nda::tensor::binary_op::PROD);
       }
       // Ov -> log( Ov ) + log_ov(n=0) 
-      nda::apply(ComplexType(1.0),Ov(range(iw,iw+nw)),nda::tensor::op::LOG);
+      nda::apply(1.0,Ov(range(iw,iw+nw)),nda::tensor::unary_op::LOG);
       // 3. Ov(iw) += log_ov(iw)
       nda::tensor::add(ComplexType(1.0),log_ov,"w",ComplexType(1.0),Ov(range(iw,iw+nw)),"w");
     }
@@ -890,7 +890,7 @@ void PHMSD<MEM>::Log_Overlap(WalkerSet<MEM> const& wset, memory::array_view<MEM,
       // 1. Ov(iw) = sum_n wgt(n,iw) * ov_up(n,iw) 
       nda::tensor::contract(ComplexType(1.0),ovlp_ratios_up,"nw",wgt,"nw",ComplexType(0.0),Ov(range(iw,iw+nw)),"w");
       // 2. Ov(iw) = log( Ov(iw) ) = log (sum_n wgt(n,iw) * ov_up(n,iw)) 
-      nda::apply(ComplexType(1.0),Ov(range(iw,iw+nw)),nda::tensor::op::LOG);
+      nda::apply(1.0,Ov(range(iw,iw+nw)),nda::tensor::unary_op::LOG);
       // 3. Ov(iw) += log_ov(iw)
       nda::tensor::add(ComplexType(1.0),log_ov,"w",ComplexType(1.0),Ov(range(iw,iw+nw)),"w");
     }

--- a/src/arch/CUDA/cuda_init.cpp
+++ b/src/arch/CUDA/cuda_init.cpp
@@ -99,7 +99,7 @@ void init()
 	    world.rank(),node.rank(),devn);
 
   // explicit synchronization after every call is not useful
-  nda::tensor::cutensor::set_synchronization(false);
+  nda::tensor::device::set_synchronization(false);
 
   check_probe_kernel();
   

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -18,6 +18,7 @@
 #include "config.0.h"
 #include "IO/AppAbort.hpp"
 #include "nda/nda.hpp"
+#include "utilities/allocators.hpp"
 
 using RealType = double;
 using SPRealType = float;
@@ -135,66 +136,8 @@ decltype(auto) to_memory_space(auto &&A)
 namespace detail
 {
 
-  // Corrected copy of nda::mem::static_fallback (upstream triqs/nda, tag `tensor`).
-  // Upstream BUG: a "static" bucket pool with a secondary (raw malloc) fallback for
-  // pool-overflow allocations.  nda::mem::dynamic_bucket::allocate() bumps its
-  // internal request counter BEFORE checking capacity, and when it declines (pool
-  // full) it returns nullptr while the counter stays bumped; the overflow allocation
-  // is then served by the secondary allocator.  On free, static_fallback routes those
-  // (non-owned) blocks ONLY to the secondary, so the primary's release counter is
-  // never incremented.  The primary's maximum_memory() (used by
-  // resize_nda_static_allocator to size the real pool) therefore grows without bound
-  // as freed-per-call fallback temporaries accumulate on the counter, and the pool is
-  // eventually resized to a bogus, unallocatable size -> OOM, even though the true
-  // concurrent footprint is small.  Fix: route the accounting of fallback releases to
-  // the primary as well (alloc.deallocate on a non-owned block only updates counters),
-  // so allocate/deallocate stay balanced and the pool is sized to the real peak.
-  template<typename Primary>
-  class corrected_static_fallback
-  {
-    inline static Primary alloc = {};
-    using Secondary = nda::mem::mallocator<Primary::address_space>;
-
-  public:
-    static constexpr auto address_space = Primary::address_space;
-
-    corrected_static_fallback()                                            = default;
-    corrected_static_fallback(corrected_static_fallback const&)            = delete;
-    corrected_static_fallback(corrected_static_fallback&&)                 = default;
-    corrected_static_fallback& operator=(corrected_static_fallback const&) = delete;
-    corrected_static_fallback& operator=(corrected_static_fallback&&)      = default;
-
-    auto get_primary()       { return std::addressof(alloc); }
-    auto get_primary() const { return std::addressof(alloc); }
-
-    nda::mem::blk_t allocate(std::size_t s) noexcept
-    {
-      nda::mem::blk_t b = alloc.allocate(s);
-      if (b.ptr) return b;
-      return Secondary::allocate(s);
-    }
-
-    nda::mem::blk_t allocate_zero(std::size_t s) noexcept
-    {
-      nda::mem::blk_t b = this->allocate(s);
-      if (b.ptr and b.s > 0) nda::mem::memset<address_space>(b.ptr, 0, b.s);
-      return b;
-    }
-
-    void deallocate(nda::mem::blk_t b) noexcept
-    {
-      if (alloc.owns(b)) {
-        alloc.deallocate(b);
-      } else {
-        // account the release in the primary's counters, then free via the secondary
-        alloc.deallocate(b);
-        Secondary::deallocate(b);
-      }
-    }
-  };
-
   template<MEMORY_SPACE MEM>
-  using static_allocator_t = corrected_static_fallback<nda::mem::dynamic_bucket<to_nda_address_space(MEM)>>;
+  using static_allocator_t = memory::static_fallback<memory::dynamic_bucket<to_nda_address_space(MEM)>>;
 
   template<MEMORY_SPACE MEM>
   using buffered_handle_t = nda::heap_basic<static_allocator_t<MEM>>;

--- a/src/numerics/device_kernels/cuda/accumulate.cu
+++ b/src/numerics/device_kernels/cuda/accumulate.cu
@@ -12,6 +12,7 @@
 #include "utilities/type_traits.hpp"
 #include "numerics/device_kernels/cuda/cuda_settings.h"
 #include "numerics/device_kernels/cuda/cuda_aux.hpp"
+#include "numerics/device_kernels/cuda/accumulate.cuh"
 #include "nda/nda.hpp"
 #include <cuda/std/mdspan>
 #include "cub/device/device_for.cuh"
@@ -198,26 +199,39 @@ void scale_impl(nda::get_value_t<A> alpha, A & a)
   }
 }
 
-template<typename A, typename B>
-void copy_impl(A const& a, B & b)
-{ 
-  using T = nda::get_value_t<A>;
-  sfqmc::utils::check(a.shape() == b.shape(), "Shape mismatch");
-  auto a_d = to_cuda_std_mdspan(a);
-  auto b_d = to_cuda_std_mdspan(b);
+template<typename MdIn, typename MdOut>
+struct copy_functor
+{
+  MdIn  a;
+  MdOut b;
+  // ForEachInExtents passes the linear iteration index ahead of the coordinates
+  template<typename Idx, typename... I>
+  __device__ void operator()(Idx, I... idx) { b(idx...) = a(idx...); }
+};
 
-  // Determine temporary device storage requirements
-  void*  d_temp_storage     = nullptr;
-  size_t temp_storage_bytes = 0;
-  auto status = cub::DeviceCopy::Copy(d_temp_storage, temp_storage_bytes, a_d, b_d);
+template<typename T, int R>
+void copy_strided(T const* src, std::array<long,R> const& src_str,
+                  T* dst, std::array<long,R> const& dst_str,
+                  std::array<long,R> const& ext)
+{
+  using dext = cuda::std::dextents<long,R>;
+  using cuda::std::layout_stride;
+
+  cuda::std::array<long,R> e, ss, ds;
+  std::copy_n(ext.begin(),R,e.begin());
+  std::copy_n(src_str.begin(),R,ss.begin());
+  std::copy_n(dst_str.begin(),R,ds.begin());
+
+  auto sp = cuda_std_ptr_cast(src);
+  auto dp = cuda_std_ptr_cast(dst);
+  using src_t = typename std::pointer_traits<decltype(sp)>::element_type;
+  using dst_t = typename std::pointer_traits<decltype(dp)>::element_type;
+  auto a_d = cuda::std::mdspan<src_t,dext,layout_stride>(sp,layout_stride::mapping<dext>(e,ss));
+  auto b_d = cuda::std::mdspan<dst_t,dext,layout_stride>(dp,layout_stride::mapping<dext>(e,ds));
+
+  auto status = cub::DeviceFor::ForEachInExtents(a_d.extents(),
+                    copy_functor<decltype(a_d),decltype(b_d)>{a_d,b_d});
   // cuda_check(status)
-
-  memory::buffered_array<DEVICE_MEMORY,T,1> temp_storage(temp_storage_bytes); 
-  d_temp_storage = (void*)(temp_storage.data()); 
-
-  // Run copy algorithm
-  status = cub::DeviceCopy::Copy(d_temp_storage, temp_storage_bytes, a_d, b_d);
-  //cuda_heck(status);
 }
 
 using memory::device_array_view;
@@ -239,15 +253,23 @@ template void accumulate_impl(T,V<const T,3,basic_layout_t<3>> const&, V<T,3,per
 template void scale_impl(T,V<T,1,basic_layout_t<1>> &);  \
 template void scale_impl(T,V<T,2,basic_layout_t<2>> &);  \
 template void scale_impl(T,V<T,3,basic_layout_t<3>> &);  \
-template void scale_impl(T,V<T,4,basic_layout_t<4>> &);  \
-template void copy_impl(V<const T,1,basic_layout_t<1>> const&, V<T,1,basic_layout_t<1>>&);  \
-template void copy_impl(V<const T,2,basic_layout_t<2>> const&, V<T,2,basic_layout_t<2>>&);  \
-template void copy_impl(V<const T,3,basic_layout_t<3>> const&, V<T,3,basic_layout_t<3>>&);  \
-template void copy_impl(V<const T,4,basic_layout_t<4>> const&, V<T,4,basic_layout_t<4>>&);  \
-template void copy_impl(V<const T,5,basic_layout_t<5>> const&, V<T,5,basic_layout_t<5>>&);  
+template void scale_impl(T,V<T,4,basic_layout_t<4>> &);
 
 _inst_(double,device_array_view)
 _inst_(std::complex<double>,device_array_view)
+
+// copy_strided takes extents and strides as arguments, so layout is not part of its type
+static_assert(max_copy_rank == 6, "_inst_copy_ranks_ must cover every rank up to max_copy_rank");
+
+#define _inst_copy_(T,R) \
+template void copy_strided<T,R>(T const*, std::array<long,R> const&, \
+                                T*, std::array<long,R> const&, std::array<long,R> const&);
+
+#define _inst_copy_ranks_(T) \
+_inst_copy_(T,1) _inst_copy_(T,2) _inst_copy_(T,3) _inst_copy_(T,4) _inst_copy_(T,5) _inst_copy_(T,6)
+
+_inst_copy_ranks_(double)
+_inst_copy_ranks_(std::complex<double>)
 
 
 } // namespace kernels::device::detail

--- a/src/numerics/device_kernels/cuda/accumulate.cuh
+++ b/src/numerics/device_kernels/cuda/accumulate.cuh
@@ -17,8 +17,37 @@ void accumulate_impl(nda::get_value_t<A> alpha, A const& a, B & b);
 template<typename A> 
 void scale_impl(nda::get_value_t<A> alpha, A& a);
 
-template<typename A, typename B> 
-void copy_impl(A const& a, B & b);
+// B(...) = A(...) for arbitrary rank and arbitrary strides. Extents and strides are runtime
+// arguments, so a layout and any permutation of it share one instantiation.
+//
+// Instantiated for every rank in [1,max_copy_rank] by accumulate.cu. Each rank is a separate
+// device kernel, so the bound is a code-size choice: copy() handles anything above it by
+// peeling off outer dimensions until what is left fits.
+inline constexpr int max_copy_rank = 6;
+
+template<typename T, int R>
+void copy_strided(T const* src, std::array<long,R> const& src_str,
+                  T* dst, std::array<long,R> const& dst_str,
+                  std::array<long,R> const& ext);
+
+// Slice A at a fixed index along axis D, keeping every other axis whole. D is a constant, so
+// the scalar/range argument mix is built by the pack expansion rather than dispatched on.
+template<int D, std::size_t I>
+auto slice_index(long i)
+{
+  if constexpr (int(I) == D) {
+    return i;
+  } else {
+    (void) i;
+    return nda::range::all;
+  }
+}
+
+template<int D, typename A_t, std::size_t... I>
+auto slice_at(A_t && A, long i, std::index_sequence<I...>)
+{
+  return A(slice_index<D,I>(i)...);
+}
 
 }
 
@@ -68,14 +97,34 @@ template<nda::MemoryArray A_t, nda::MemoryArray B_t>
 void copy(A_t const& A, B_t && B)
 requires( nda::get_rank<A_t> == nda::get_rank<B_t> ) 
 {
-  if(A.is_contiguous() and B.is_contiguous() and nda::get_rank<A_t> > 1) {
-    kernels::device::copy(nda::flatten(A),nda::flatten(B));
+  using T = nda::get_value_t<A_t>;
+  constexpr int R = nda::get_rank<A_t>;
+  sfqmc::utils::check(A.shape() == B.shape(), "Shape mismatch");
+  // a flat memcpy, rather than cub, whose mdspan Copy asserts on overlapping spans with a
+  // check that also rejects two allocations that merely touch
+  constexpr bool same_stride_order = std::decay_t<A_t>::layout_t::stride_order_encoded ==
+                                     std::decay_t<B_t>::layout_t::stride_order_encoded;
+  if constexpr (same_stride_order) {
+    if(A.is_contiguous() and B.is_contiguous()) {
+      nda::mem::memcpy<nda::mem::get_addr_space<std::decay_t<B_t>>,
+                       nda::mem::get_addr_space<std::decay_t<A_t>>>(
+          B.data(), A.data(), A.size()*sizeof(T));
+      return;
+    }
+  }
+  if constexpr (R > detail::max_copy_rank) {
+    // peel off the slowest-varying dimension and recurse, so a rank beyond the instantiated
+    // range still works.
+    constexpr int d = std::decay_t<decltype(A.indexmap())>::stride_order[0];
+    constexpr auto seq = std::make_index_sequence<R>{};
+    for(long i = 0; i < A.extent(d); ++i) {
+      kernels::device::copy(detail::slice_at<d>(A,i,seq),detail::slice_at<d>(B,i,seq));
+    }
     return;
   }
-  // careful with ranks here 
-  auto A_b = to_basic_layout(A());
-  auto B_b = to_basic_layout(B());
-  detail::copy_impl(A_b,B_b);
+  else {
+    detail::copy_strided<T,R>(A.data(),A.strides(),B.data(),B.strides(),A.shape());
+  }
 }
 
 

--- a/src/numerics/device_kernels/cuda/apply.cu
+++ b/src/numerics/device_kernels/cuda/apply.cu
@@ -17,16 +17,16 @@ namespace kernels::device::detail
 {
 
 template<typename V> 
-void apply_impl(nda::get_value_t<V> alpha, V& A, nda::tensor::op::TENSOR_OP oper)
+void apply_impl(nda::get_value_t<V> alpha, V& A, nda::tensor::unary_op oper)
 {
   constexpr int rank = nda::get_rank<V>;
   if(A.size()==0) return;
   // these seem fine in cutensor_permute
-  if(oper==nda::tensor::op::ID or oper==nda::tensor::op::CONJ) // or oper==nda::tensor::op::RCP) 
+  if(oper==nda::tensor::unary_op::IDENTITY or oper==nda::tensor::unary_op::CONJ) // or oper==nda::tensor::unary_op::RCP)
   {
     nda::tensor::scale(alpha,A,oper);
     return;
-  } else if(oper==nda::tensor::op::NEG) {
+  } else if(oper==nda::tensor::unary_op::NEG) {
     nda::tensor::scale(-alpha,A);
     return;
   }
@@ -37,7 +37,7 @@ void apply_impl(nda::get_value_t<V> alpha, V& A, nda::tensor::op::TENSOR_OP oper
 
   // some operations appear to not be allowed in cutensor permute
   switch (oper) {
-    case nda::tensor::op::SQRT:
+    case nda::tensor::unary_op::SQRT:
     {
       //a = alpha * sqrt(a); break;
       if constexpr (rank==1) {
@@ -59,7 +59,7 @@ void apply_impl(nda::get_value_t<V> alpha, V& A, nda::tensor::op::TENSOR_OP oper
         sfqmc::utils::check(false,"Invalid rank in kernel::apply.");
       }
     }
-    case nda::tensor::op::ABS:
+    case nda::tensor::unary_op::ABS:
     {
       //a = alpha * abs(a); break;
       if constexpr (rank==1) {
@@ -81,7 +81,7 @@ void apply_impl(nda::get_value_t<V> alpha, V& A, nda::tensor::op::TENSOR_OP oper
         sfqmc::utils::check(false,"Invalid rank in kernel::apply.");
       }
     }
-    case nda::tensor::op::RCP: 
+    case nda::tensor::unary_op::RCP:
     {
       //a = alpha * (1/a); break;
       if constexpr (rank==1) {
@@ -103,7 +103,7 @@ void apply_impl(nda::get_value_t<V> alpha, V& A, nda::tensor::op::TENSOR_OP oper
         sfqmc::utils::check(false,"Invalid rank in kernel::apply.");
       }
     }
-    case nda::tensor::op::EXP: 
+    case nda::tensor::unary_op::EXP:
     {
       //a = alpha * nda::exp(a); break;
       if constexpr (rank==1) {
@@ -125,7 +125,7 @@ void apply_impl(nda::get_value_t<V> alpha, V& A, nda::tensor::op::TENSOR_OP oper
         sfqmc::utils::check(false,"Invalid rank in kernel::apply.");
       }
     }
-    case nda::tensor::op::LOG: 
+    case nda::tensor::unary_op::LOG:
     {
       // a = alpha * nda::log(a); break;
       if constexpr (rank==1) {
@@ -160,9 +160,9 @@ template<int Rank>
 using basic_layout_t = typename nda::basic_layout<0, nda::C_stride_order<Rank>, nda::layout_prop_e::none>;
 
 #define _inst_(T,V) \
-template void apply_impl(T,V<T,1,basic_layout_t<1>>&,nda::tensor::op::TENSOR_OP);  \
-template void apply_impl(T,V<T,2,basic_layout_t<2>>&,nda::tensor::op::TENSOR_OP);  \
-template void apply_impl(T,V<T,3,basic_layout_t<3>>&,nda::tensor::op::TENSOR_OP);  
+template void apply_impl(T,V<T,1,basic_layout_t<1>>&,nda::tensor::unary_op);  \
+template void apply_impl(T,V<T,2,basic_layout_t<2>>&,nda::tensor::unary_op);  \
+template void apply_impl(T,V<T,3,basic_layout_t<3>>&,nda::tensor::unary_op);
 
 _inst_(double,device_array_view)
 _inst_(std::complex<double>,device_array_view)

--- a/src/numerics/device_kernels/cuda/apply.cuh
+++ b/src/numerics/device_kernels/cuda/apply.cuh
@@ -12,12 +12,12 @@ namespace kernels::device
 namespace detail
 {
   template<typename V>
-  void apply_impl(nda::get_value_t<V> alpha, V& a, nda::tensor::op::TENSOR_OP oper);
+  void apply_impl(nda::get_value_t<V> alpha, V& a, nda::tensor::unary_op oper);
 }
 
 template<typename V, nda::MemoryArray A>
 requires(std::decay_t<A>::is_stride_order_C())
-void apply(V alpha, A&& a, nda::tensor::op::TENSOR_OP oper = nda::tensor::op::ID) {
+void apply(V alpha, A&& a, nda::tensor::unary_op oper = nda::tensor::unary_op::IDENTITY) {
   using T = nda::get_value_t<V>;
   if(a.is_contiguous() and nda::get_rank<A> > 1) {
     kernels::device::apply(T(alpha),nda::flatten(a),oper);

--- a/src/numerics/device_kernels/cuda/copy_cast.cu
+++ b/src/numerics/device_kernels/cuda/copy_cast.cu
@@ -12,9 +12,8 @@
 #include "utilities/type_traits.hpp"
 #include "numerics/device_kernels/cuda/cuda_settings.h"
 #include "numerics/device_kernels/cuda/cuda_aux.hpp"
-#include "nda/nda.hpp"
 #include <cuda/std/mdspan>
-#include "cub/device/device_for.cuh"
+#include <cub/device/device_for.cuh>
 
 namespace kernels::device::detail
 {

--- a/src/numerics/device_kernels/cuda/copy_cast.cuh
+++ b/src/numerics/device_kernels/cuda/copy_cast.cuh
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <complex>
-#include "nda/nda.hpp"
 #include "numerics/device_kernels/cuda/nda_aux.hpp"
 
 namespace kernels::device

--- a/src/numerics/device_kernels/cuda/phmsd_determinants.cu
+++ b/src/numerics/device_kernels/cuda/phmsd_determinants.cu
@@ -6,9 +6,9 @@
 #include "numerics/device_kernels/cuda/cuda_aux.hpp"
 #include "arch/atomics.hpp"
 #include <nda/nda.hpp>
-#include "numerics/nda_functions.hpp"
 #include <cuda/std/mdspan>
 #include "cub/device/device_for.cuh"
+#include "numerics/nda_functions.hpp"
 #include "numerics/operations/determinants.hpp"
 
 namespace kernels::device::detail

--- a/src/numerics/nda_functions.hpp
+++ b/src/numerics/nda_functions.hpp
@@ -289,7 +289,7 @@ void copy_select(bool expand, int indx, V1 const& m, V2 const& s, T alpha, V3 co
 
 template<typename V, nda::MemoryArray A>
 requires(std::decay_t<A>::is_stride_order_C())
-void apply(V alpha, A&& a, nda::tensor::op::TENSOR_OP oper) {
+void apply(V alpha, A&& a, nda::tensor::unary_op oper) {
   if constexpr(nda::mem::have_device_compatible_addr_space<A>) {
 #if defined(ENABLE_DEVICE)
     kernels::device::apply(alpha,a,oper);
@@ -428,7 +428,7 @@ auto to_cutensor(Arr&& A) {
  */
 template <MemoryArray A, MemoryArray B>
   requires(have_same_value_type_v<get_value_t<A>,get_value_t<B>> and is_blas_lapack_v<get_value_t<A>>)
-void reduce([[maybe_unused]] get_value_t<A> alpha, A const& a, std::string_view const indxA, [[maybe_unused]] get_value_t<B> beta, B& b, std::string_view const indxB, op::TENSOR_OP oper = op::SUM) 
+void reduce([[maybe_unused]] get_value_t<A> alpha, A const& a, std::string_view const indxA, [[maybe_unused]] get_value_t<B> beta, B& b, std::string_view const indxB, binary_op oper = binary_op::SUM)
 {
   static_assert(mem::have_compatible_addr_space<A, B>, "Matrices must have compatible memory address space");
 
@@ -439,11 +439,9 @@ void reduce([[maybe_unused]] get_value_t<A> alpha, A const& a, std::string_view 
   if constexpr (mem::have_device_compatible_addr_space<A, B>) {
 #if defined(ENABLE_DEVICE)
 #if defined(NDA_HAVE_CUTENSOR)
-      cutensor::cutensor_desc<get_value_t<A>, get_rank<A>> a_t(a);
-      cutensor::cutensor_desc<get_value_t<B>, get_rank<B>> b_t(b);
-      cutensor::reduce(alpha, a_t, op::ID, a.data(), indxA, beta, b_t, op::ID, b.data(), indxB, b.data(), oper);
+    nda::tensor::device::reduce(alpha, a, indxA, beta, b, indxB, b, oper);
 #else
-      compile_error_no_gpu();
+    compile_error_no_gpu();
 #endif
 #endif
   } else {

--- a/src/numerics/nda_functions.hpp
+++ b/src/numerics/nda_functions.hpp
@@ -405,21 +405,6 @@ auto getri_or_zero(MemoryArray auto &&A, MemoryArray auto&& ipiv, MemoryArray au
 namespace tensor
 {
 
-namespace cutensor
-{
-
-#if defined(ENABLE_DEVICE)
-template<nda::MemoryArray Arr>
-requires( nda::mem::have_device_compatible_addr_space<Arr> )
-auto to_cutensor(Arr&& A) {
-  using T = nda::get_value_t<Arr>;
-  constexpr int R = nda::get_rank<Arr>;
-  return nda::tensor::cutensor::cutensor_desc<T,R>(A);
-}
-#endif
-
-} // namespace cutensor
-
 /**
  * Computes B(...) = op(A(...)), where op = {std::plus<>{},std::max<>{},std::min<>{},...}. 
  * Reduction is assumed, the rank of B should be smaller than the rank of A.

--- a/src/numerics/nda_linalg_lapack_extensions.hpp
+++ b/src/numerics/nda_linalg_lapack_extensions.hpp
@@ -227,54 +227,6 @@ namespace linalg
    * @{
    */
 
-  /**
-   * @brief Get the permutation vector \f$ \mathbf{\sigma} \f$ from the pivot indices returned by nda::lapack::getrf or
-   * other LAPACK routines.
-   *
-   * @details The function constructs the permutation vector \f$ \mathbf{\sigma} \f$ of size \f$ m \f$ from the pivot
-   * index vector `ipiv` of size \f$ l \f$. Starting from an identity permutation, i.e. \f$ \mathbf{\sigma} = (0, 1,
-   * \ldots, m - 1) \f$, it interchanges \f$ \sigma_i \f$ with \f$ \sigma_{\mathrm{ipiv}_i - 1} \f$ for all \f$ i = 0,
-   * 1, \dots, l - 1 \f$.
-   *
-   * @param ipiv nda::Vector containing the pivot indices returned by nda::lapack::getrf.
-   * @param m Number of elements of the permutation vector \f$ \mathbf{\sigma} \f$.
-   * @return Permutation vector \f$ \mathbf{\sigma} \f$ as an nda::vector.
-   */
-  auto get_permutation_vector(Vector auto const &ipiv, int m) {
-    static_assert(nda::mem::have_host_compatible_addr_space<decltype(ipiv)>);
-    EXPECTS(m >= ipiv.size());
-    auto sigma = vector<int>{arange<int>(m)};
-    for (int i = 0; i < ipiv.size(); ++i) std::swap(sigma(i), sigma(ipiv(i) - 1));
-    return sigma;
-  }
-
-  /**
-   * @brief Get the permutation matrix \f$ \mathbf{P} \f$ from a permutation vector \f$ \mathbf{\sigma} \f$.
-   *
-   * @details The function constructs the permutation matrix \f$ \mathbf{P} \f$ of size \f$ m \times m \f$ from the
-   * permutation vector \f$ \sigma \f$ of size \f$ m \f$. 
-   * 
-   * The permutation matrix only has the following non-zero elements (for all \f$ i = 0, 1, \ldots, m - 1 \f$):
-   * - \f$ \mathbf{P}_{i, \sigma_i} = 1 \f$ for row permutations,
-   * - \f$ \mathbf{P}_{\sigma_i, i} = 1 \f$ for column permutations.
-   *
-   * @tparam T nda::Scalar value type of the permutation matrix.
-   * @tparam LP Policy determining the memory layout of the permutation matrix.
-   * @param sigma nda::Vector containing the permutation vector with values \f$ \in \{0, 1, \ldots, m - 1 \} \f$.
-   * @param column_permutations If true, constructs the permutation matrix for column permutations.
-   * @return Permutation matrix \f$ \mathbf{P} \f$ as an nda::matrix.
-   */
-  template <Scalar T, typename LP = F_layout>
-  auto get_permutation_matrix(Vector auto const &sigma, bool column_permutations = false) {
-    static_assert(nda::mem::have_host_compatible_addr_space<decltype(sigma)>);
-    int m  = sigma.size();
-    auto P = matrix<T, LP>::zeros(m, m);
-    for (int i = 0; i < m; ++i){ 
-      (column_permutations ? P(sigma(i), i) : P(i, sigma(i))) = T{1};
-    }
-    return P;
-  }
-
   template <Scalar T, typename LP = F_layout>
   auto get_permutation_matrix_qr(Vector auto const &jpvt) {
     static_assert(nda::mem::have_host_compatible_addr_space<decltype(jpvt)>);
@@ -284,24 +236,6 @@ namespace linalg
       P(jpvt(i)-1, i) = T{1};
     }
     return P;
-  }
-
-  /**
-   * @brief Get the permutation matrix \f$ \mathbf{P} \f$ from the pivot indices returned by nda::lapack::getrf or other
-   * LAPACK routines.
-   *
-   * @details It simply calls nda::linalg::get_permutation_vector to get the permutation vector from the pivot indices,
-   * and then calls nda::linalg::get_permutation_matrix to get the permutation matrix.
-   *
-   * @tparam T nda::Scalar value type of the permutation matrix.
-   * @tparam LP Policy determining the memory layout of the permutation matrix.
-   * @param ipiv nda::Vector containing the pivot indices returned by nda::lapack::getrf.
-   * @param m Number of rows/columns of the square permutation matrix \f$ \mathbf{P} \f$.
-   * @return Permutation matrix \f$ \mathbf{P} \f$ as an nda::matrix.
-   */
-  template <Scalar T, typename LP = F_layout>
-  auto get_permutation_matrix(Vector auto const &ipiv, int m) {
-    return get_permutation_matrix<T, LP>(get_permutation_vector(ipiv, m));
   }
 
   template <Scalar T, typename LP = F_layout>

--- a/src/numerics/operations/exp.hpp
+++ b/src/numerics/operations/exp.hpp
@@ -36,18 +36,11 @@ auto exp_hermitian(A_t const& A, bool printeV = false)
   long N = A.extent(0);
 
   // do in host for now
-  nda::array<Type,2> X(A);
-
-  for(int i=0; i<N; ++i)
-    for(int j=i+1; j<N; ++j) {
-      sfqmc::utils::check(std::abs(X(i,j)-std::conj(X(j,i))) < 1e-8, "Error in exp_hermitian: Matrix not hermitian, {} {} diff:{}",X(i,j),X(j,i),std::abs(X(i,j)-std::conj(X(j,i))));
-      X(i,j) = 0.5*(X(i,j)+std::conj(X(j,i)));
-      X(j,i) = std::conj(X(i,j));
-    }
+  nda::matrix<Type> X(A);
 
   // A = M*V*dagger(M)
   // careful, M is in Fortran layout
-  auto [V,M] = nda::linalg::eigenelements(X); 
+  auto [V,M] = nda::linalg::eigh(X);
 
   // exp(A) = M*exp(V)*dagger(M)
   if (printeV)
@@ -61,9 +54,12 @@ auto exp_hermitian(A_t const& A, bool printeV = false)
   } 
   for (int j = 0; j < N; j++)
     M(nda::range::all,j) *= std::sqrt(std::exp(V(j)));
-  nda::blas::gemm(M,nda::dagger(M),X);
+  // M is in Fortran layout, so dagger(M) wraps a C-layout view. BLAS can only fold a lazy
+  // conjugate into a 'C' operation when the result has the layout opposite to that view.
+  nda::matrix<Type,nda::F_layout> R(N,N);
+  nda::blas::gemm(M,nda::dagger(M),R);
 
-  return Array_t(X);
+  return Array_t(R);
 }
 
 } // namespace math

--- a/src/numerics/operations/tensor.hpp
+++ b/src/numerics/operations/tensor.hpp
@@ -37,7 +37,7 @@ void copy(A_t const& A, B_t && B) {
   sfqmc::utils::check(A.shape() == B.shape(), "Shape mismatch");
   if constexpr (std::is_same_v<nda::get_value_t<A_t>,nda::get_value_t<B_t>>) {
 #if defined(ENABLE_DEVICE)
-    if constexpr (nda::mem::have_device_compatible_addr_space<A_t,B_t> and nda::get_rank<A_t> < 5) {
+    if constexpr (nda::mem::have_device_compatible_addr_space<A_t,B_t>) {
       kernels::device::copy(A,B);
     } else
 #endif

--- a/src/numerics/sparse/csr_utils.hpp
+++ b/src/numerics/sparse/csr_utils.hpp
@@ -289,7 +289,7 @@ auto to_array(nda::MemoryMatrix auto const& view, nda::range row_range, nda::ran
       if(A.size() == 0) {
         return A;  // transposing an empty matrix is a no-op; cuTENSOR rejects zero-length modes
       }
-      nda::tensor::add(view,"ji",A,"ij");
+      nda::tensor::assign(view,"ji",A,"ij");
       return A; 
     } else if constexpr (op=='H' or op=='C') {
 //      typename v_t::regular_t A(col_range.size(),row_range.size()); 
@@ -298,7 +298,7 @@ auto to_array(nda::MemoryMatrix auto const& view, nda::range row_range, nda::ran
       if(A.size() == 0) {
         return A;  // transposing an empty matrix is a no-op; cuTENSOR rejects zero-length modes
       }
-      nda::tensor::add(nda::conj(view),"ji",A,"ij");
+      nda::tensor::add(1.0,nda::conj(view),"ji",0.0,A,"ij");
       return A; 
     } else
       return view(row_range,col_range);    
@@ -325,7 +325,7 @@ auto to_array(nda::MemoryMatrix auto const& view)
       if(A.size() == 0) {
         return A;  // transposing an empty matrix is a no-op; cuTENSOR rejects zero-length modes
       }
-      nda::tensor::add(view,"ji",A,"ij");
+      nda::tensor::assign(view,"ji",A,"ij");
       return A; 
     } else if constexpr (op=='H' or op=='C') {
 //      typename v_t::regular_t A(view.extent(1),view.extent(0));
@@ -334,7 +334,7 @@ auto to_array(nda::MemoryMatrix auto const& view)
       if(A.size() == 0) {
         return A;  // transposing an empty matrix is a no-op; cuTENSOR rejects zero-length modes
       }
-      nda::tensor::add(nda::conj(view),"ji",A,"ij");
+      nda::tensor::add(1.0,nda::conj(view),"ji",0.0,A,"ij");
       return A; 
     } else
       return view();

--- a/src/utilities/allocators.hpp
+++ b/src/utilities/allocators.hpp
@@ -1,0 +1,274 @@
+#pragma once
+
+#include <utility>
+
+#include <nda/nda.hpp>
+
+namespace memory {
+  
+template<typename Primary>
+class static_fallback
+{
+  inline static Primary alloc = {};
+  using Secondary = nda::mem::mallocator<Primary::address_space>;
+
+public:
+  static constexpr auto address_space = Primary::address_space;
+
+  static_fallback()                                  = default;
+  static_fallback(static_fallback const&)            = delete;
+  static_fallback(static_fallback&&)                 = default;
+  static_fallback& operator=(static_fallback const&) = delete;
+  static_fallback& operator=(static_fallback&&)      = default;
+
+  auto get_primary()       { return std::addressof(alloc); }
+  auto get_primary() const { return std::addressof(alloc); }
+
+  nda::mem::blk_t allocate(std::size_t s) noexcept
+  {
+    nda::mem::blk_t b = alloc.allocate(s);
+    if (b.ptr) return b;
+    return Secondary::allocate(s);
+  }
+
+  nda::mem::blk_t allocate_zero(std::size_t s) noexcept
+  {
+    nda::mem::blk_t b = this->allocate(s);
+    if (b.ptr and b.s > 0) nda::mem::memset<address_space>(b.ptr, 0, b.s);
+    return b;
+  }
+
+  void deallocate(nda::mem::blk_t b) noexcept
+  {
+    if (alloc.owns(b)) {
+      alloc.deallocate(b);
+    } else {
+      // account the release in the primary's counters, then free via the secondary
+      alloc.deallocate(b);
+      Secondary::deallocate(b);
+    }
+  }
+};
+
+namespace detail {
+  // returns the next address aligned to "align"
+  inline char *align_up(char *ptr, std::size_t align = alignof(std::max_align_t)) {
+    std::uintptr_t align_(align);
+    uintptr_t ptr_i = reinterpret_cast<uintptr_t>(ptr);
+    return reinterpret_cast<char *>(align_ * ((ptr_i + (align_ - 1)) / align_));
+  };
+} // namespace detail
+
+template <nda::mem::AddressSpace AdrSp = nda::mem::Host, size_t Alignment = alignof(std::max_align_t)>
+class dynamic_bucket {
+private:
+  // auxiliary allocator
+  using Auxiliary = nda::mem::mallocator<AdrSp>;
+
+  /// alignment
+  constexpr static size_t align_ = std::max(size_t(1), Alignment);
+
+  // size of the pool
+  size_t size_ = 0;
+
+  /// maximum amount of memory needed
+  size_t maximum_needed_ = 0;
+
+  /// total amount of memory requested
+  size_t total_requested_ = 0;
+
+  /// total amount of memory released
+  size_t total_released_ = 0;
+
+  // pool of memory
+  nda::mem::blk_t pool_;
+
+  // aligned start of pool_
+  char *p0 = nullptr;
+
+  // list of available memory segments
+  std::vector<nda::mem::blk_t> avail_;
+
+  // list of allocated memory segments
+  std::vector<nda::mem::blk_t> segments_;
+
+  public:
+  /// Default constructor.
+  dynamic_bucket(size_t s = 8000) : size_(s + align_), pool_{Auxiliary::allocate(size_)} {
+    // first alligned memory location
+    p0 = detail::align_up(pool_.ptr, align_);
+    avail_.reserve(10);
+    segments_.reserve(10);
+    // initialize avail_
+    avail_.emplace_back(nda::mem::blk_t{p0, size_t(std::distance(p0, pool_.ptr + pool_.s))});
+  }
+
+  /// Destructor
+  ~dynamic_bucket() {
+    if (pool_.s > 0 and pool_.ptr != nullptr) Auxiliary::deallocate(pool_);
+  }
+
+  dynamic_bucket(dynamic_bucket const &) = delete;
+  dynamic_bucket &operator=(dynamic_bucket const &) = delete;
+
+  dynamic_bucket(dynamic_bucket &&other) noexcept
+     : size_(std::exchange(other.size_, 0)),
+       maximum_needed_(std::exchange(other.maximum_needed_, 0)),
+       total_requested_(std::exchange(other.total_requested_, 0)),
+       total_released_(std::exchange(other.total_released_, 0)),
+       pool_(std::exchange(other.pool_, nda::mem::blk_t{})),
+       p0(std::exchange(other.p0, nullptr)),
+       avail_(std::move(other.avail_)),
+       segments_(std::move(other.segments_)) {
+    // a moved-from vector is valid but unspecified; make the empty state explicit
+    other.avail_.clear();
+    other.segments_.clear();
+  }
+
+  dynamic_bucket &operator=(dynamic_bucket &&other) noexcept {
+    if(this != &other) {
+      if(pool_.s > 0 && pool_.ptr != nullptr) Auxiliary::deallocate(pool_);
+      size_            = std::exchange(other.size_, 0);
+      maximum_needed_  = std::exchange(other.maximum_needed_, 0);
+      total_requested_ = std::exchange(other.total_requested_, 0);
+      total_released_  = std::exchange(other.total_released_, 0);
+      pool_            = std::exchange(other.pool_, nda::mem::blk_t{});
+      p0               = std::exchange(other.p0, nullptr);
+      avail_           = std::move(other.avail_);
+      segments_        = std::move(other.segments_);
+      other.avail_.clear();
+      other.segments_.clear();
+    }
+    return *this;
+  }
+
+  /// nda::mem::AddressSpace in which the memory is allocated.
+  static constexpr auto address_space = AdrSp;
+
+  void resize(size_t s) {
+    if (segments_.size() > 0) throw std::bad_alloc{};
+    size_ = s + align_;
+    Auxiliary::deallocate(pool_);
+    pool_ = Auxiliary::allocate(size_);
+    p0    = detail::align_up(pool_.ptr, align_);
+    avail_.clear();
+    avail_.emplace_back(nda::mem::blk_t{p0, size_t(std::distance(p0, pool_.ptr + pool_.s))});
+  }
+
+  auto size() const {
+    return std::distance(p0, pool_.ptr + pool_.s);
+  }
+
+  auto maximum_memory() const { return maximum_needed_; }
+
+  nda::mem::blk_t allocate(size_t s) noexcept {
+    // round up to closest multiple of align
+    size_t aligned_s = ((s + (align_ - 1)) / align_) * align_;
+    total_requested_ += aligned_s;
+    maximum_needed_ = std::max(maximum_needed_, total_requested_ - total_released_);
+    // find available block with enough space
+    auto b = std::find_if(avail_.begin(), avail_.end(), [&](auto const &a) { return a.s >= aligned_s; });
+    if (b != avail_.end()) {
+      auto p_s = b->ptr;
+      // add segment to list, keeping list unsorted
+      segments_.push_back({p_s, aligned_s});
+      // remove segment from avail_
+      if (aligned_s == b->s)
+        avail_.erase(b);
+      else {
+        b->ptr += aligned_s;
+        b->s -= aligned_s;
+      }
+      return {p_s, s};
+    }
+    return {nullptr, 0};
+  }
+
+  nda::mem::blk_t allocate_zero(size_t s) noexcept {
+    nda::mem::blk_t b = allocate(s);
+    if (b.ptr and b.s > 0) memset<address_space>(b.ptr, 0, b.s);
+    return b;
+  }
+
+  void deallocate(nda::mem::blk_t b) noexcept {
+    if (segments_.size() == 0 or size_ == 0) {
+      total_released_ += b.s;
+      return;
+    }
+    // 1. find blk in segments_
+    auto it = std::find_if(segments_.begin(), segments_.end(), [&](auto const &a) { return std::distance(a.ptr, b.ptr) == 0; });
+    if (it != segments_.end()) {
+      total_released_ += it->s;
+      move_blk_to_avail(*it);
+      segments_.erase(it);
+      return;
+    }
+    // 2. Deallocates owned memory.
+    EXPECTS_WITH_MESSAGE(
+       (std::distance(b.ptr, p0) > 0) or (std::distance(pool_.ptr + pool_.s, b.ptr) > 0),
+       "Error in nda::mem::dynamic_bucket::deallocate: Deallocating memory within the pool of the allocator, yet not registered as a segment.")
+    // signal that memory is not owned by this allocator
+    total_released_ += b.s;
+  }
+
+  bool owns(nda::mem::blk_t b) const noexcept {
+    if (segments_.size() == 0 or size_ == 0) return false;
+    return (std::distance(p0, b.ptr) >= 0) and (std::distance(b.ptr, pool_.ptr + pool_.s) > 0);
+  }
+
+  private:
+  void move_blk_to_avail(nda::mem::blk_t b) {
+    if (avail_.size() == 0) {
+      avail_.emplace_back(b);
+      return;
+    }
+    // 0. find location of b.ptr in list
+    auto it = std::lower_bound(avail_.begin(), avail_.end(), b, [&](auto &&i, auto &&j) { return std::distance(i.ptr, j.ptr) > 0; });
+    // add in front
+    if (it == avail_.begin()) {
+      auto it_beg = avail_.begin();
+      if (std::distance(b.ptr + b.s, it_beg->ptr) == 0) {
+        //merge
+        it_beg->ptr = b.ptr;
+        it_beg->s += b.s;
+      } else {
+        // add
+        avail_.insert(it_beg, b);
+      }
+      return;
+    }
+    // add in back
+    if (it == avail_.end()) {
+      auto it_last = avail_.end() - 1;
+      if (std::distance(it_last->ptr + it_last->s, b.ptr) == 0) {
+        //merge
+        it_last->s += b.s;
+      } else {
+        // add
+        avail_.emplace_back(b);
+      }
+      return;
+    }
+    // General scenario: 4 cases to consider
+    auto prev   = it - 1;
+    auto d_prev = std::distance(prev->ptr + prev->s, b.ptr);
+    auto d_next = std::distance(b.ptr + b.s, it->ptr);
+    if ((d_prev == 0) and (d_next == 0)) {
+      // a. b is contiguous with previous and next element in avail_: merge into a single segment
+      prev->s += b.s + it->s;
+      avail_.erase(it);
+    } else if (d_prev == 0) {
+      // b. b is contiguous with previous element, not with next: merge with previous
+      prev->s += b.s;
+    } else if (d_next == 0) {
+      // c. b is contiguous with next element, not with previous: merge with next
+      it->ptr = b.ptr;
+      it->s += b.s;
+    } else {
+      // d. b is completely isolated: add new segment
+      avail_.insert(it, b);
+    }
+  }
+};
+
+}

--- a/tests/test_common.hpp
+++ b/tests/test_common.hpp
@@ -301,6 +301,34 @@ inline std::shared_ptr<mpi_context_t<mpi3::communicator>>& make_unit_test_mpi_co
   return detail::__unit_test_mpi_context__;
 }
 
+/*
+ * Flat host copy of a, with the elements in C order of the logical indices.
+ *
+ * nda::flatten reinterprets the storage in memory order, so flattening two arrays of equal
+ * shape only lines their elements up if both have the same stride order. Going through a
+ * C-layout copy makes the flat order independent of how either operand happens to be stored,
+ * so e.g. a view and its transpose flatten to different sequences, as they should.
+ */
+template<nda::Array A>
+auto make_flat_regular(A const& a)
+{
+  using value_type    = std::remove_const_t<nda::get_value_t<A>>;
+  constexpr int rank  = nda::get_rank<A>;
+  static_assert(nda::MemoryArray<A> || !nda::mem::have_device_compatible_addr_space<A>,
+                "Pass nda::make_regular(expr) for expressions over device arrays");
+
+  if constexpr(nda::MemoryArray<A> && nda::mem::have_device_compatible_addr_space<A>) {
+    // a device array cannot be read elementwise from the host, and a strided device to host
+    // assignment is not supported either, so contract to a contiguous device copy first
+    constexpr MEMORY_SPACE MEM = memory::get_memory_space<A>();
+    memory::array<MEM, value_type, rank> a_contiguous(a.shape());
+    math::copy(a(), a_contiguous());
+    return nda::flatten(nda::to_host(std::move(a_contiguous)));
+  } else {
+    return nda::flatten(memory::host_array<value_type, rank>(a));
+  }
+}
+
 template<nda::Array Array>
 struct ApproxArrayMatcher : Catch::Matchers::MatcherGenericBase {
   ApproxArrayMatcher(Array const& array, RealType abstol, RealType reltol)
@@ -313,9 +341,8 @@ struct ApproxArrayMatcher : Catch::Matchers::MatcherGenericBase {
     if(other.shape() != array.shape()) {
       return false;
     }
-    // make_regular required for flatten in case array is not contiguous
-    auto other_host = nda::flatten(nda::make_regular(nda::to_host(other)));
-    auto array_host = nda::flatten(nda::make_regular(nda::to_host(array)));
+    auto other_host = make_flat_regular(other);
+    auto array_host = make_flat_regular(array);
     auto diffnorm = nda::linalg::norm(other_host - array_host, INFINITY);
     auto valnorm = std::max(nda::linalg::norm(array_host, INFINITY), nda::linalg::norm(other_host, INFINITY));
 
@@ -323,7 +350,7 @@ struct ApproxArrayMatcher : Catch::Matchers::MatcherGenericBase {
   }
 
   std::string describe() const override {
-      return std::format("Approx(atol={}, rtol={}): {}", abstol, reltol, array);
+    return std::format("Approx(atol={}, rtol={}): {}", abstol, reltol, array);
   }
 
 private:

--- a/tests/test_common.hpp
+++ b/tests/test_common.hpp
@@ -314,8 +314,8 @@ struct ApproxArrayMatcher : Catch::Matchers::MatcherGenericBase {
     // make_regular required for flatten in case array is not contiguous
     auto other_host = nda::flatten(nda::make_regular(nda::to_host(other)));
     auto array_host = nda::flatten(nda::make_regular(nda::to_host(array)));
-    auto diffnorm = nda::norm(other_host - array_host, INFINITY);
-    auto valnorm = std::max(nda::norm(array_host, INFINITY), nda::norm(other_host, INFINITY));
+    auto diffnorm = nda::linalg::norm(other_host - array_host, INFINITY);
+    auto valnorm = std::max(nda::linalg::norm(array_host, INFINITY), nda::linalg::norm(other_host, INFINITY));
 
     return diffnorm < std::max(abstol, reltol * valnorm);
   }

--- a/tests/test_common.hpp
+++ b/tests/test_common.hpp
@@ -35,6 +35,8 @@
 #include "configuration.hpp"
 #include "utilities/check.hpp"
 #include "utilities/type_traits.hpp"
+#include "numerics/nda_functions.hpp"
+#include "numerics/operations/tensor.hpp"
 #include "utilities/mpi_context.h"
 #include "AFQMC/config.h"
 #include "IO/app_loggers.h"

--- a/tests/test_phmsd.cpp
+++ b/tests/test_phmsd.cpp
@@ -328,7 +328,7 @@ void phmsd_compute(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicato
   memory::array<MEM,ComplexType,2> eloc_ph0(nwalk,3);
   memory::array<MEM,ComplexType,1> ov_ph0(nwalk);
   wfn.Energy(wset,eloc_ph0,ov_ph0);
-  nda::apply(ComplexType(1.0),ov_ph0,nda::tensor::op::EXP);
+  nda::apply(1.0,ov_ph0,nda::tensor::unary_op::EXP);
 
   {
     auto eloc_h = nda::to_host(eloc_ph0);
@@ -352,7 +352,7 @@ void phmsd_compute(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicato
     memory::array<MEM,ComplexType,2> eloc(nwalk,3);
     memory::array<MEM,ComplexType,1> ov(nwalk);
     nomsd.Energy(wset,eloc,ov);
-    nda::apply(ComplexType(1.0),ov,nda::tensor::op::EXP);
+    nda::apply(1.0,ov,nda::tensor::unary_op::EXP);
     CHECK_THAT(ov_ph0, utils::Approx(ov));
     CHECK_THAT(eloc_ph0, utils::Approx(eloc));
   }
@@ -368,7 +368,7 @@ void phmsd_compute(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communicato
     memory::array<MEM,ComplexType,2> eloc(nwalk,3);
     memory::array<MEM,ComplexType,1> ov(nwalk);
     wfn1.Energy(wset,eloc,ov);
-    nda::apply(ComplexType(1.0),ov,nda::tensor::op::EXP);
+    nda::apply(1.0,ov,nda::tensor::unary_op::EXP);
 
     CHECK_THAT(ov_ph0, utils::Approx(ov));
     CHECK_THAT(eloc_ph0, utils::Approx(eloc));

--- a/tests/test_polarized_consistency.cpp
+++ b/tests/test_polarized_consistency.cpp
@@ -102,7 +102,7 @@ inline PsiT_Matrix<HOST_MEMORY> widen_csr(PsiT_Matrix<HOST_MEMORY> const& up, in
 inline std::string polarized_tmp_path(std::string const& tag, WALKER_TYPES target)
 {
   auto p = std::filesystem::temp_directory_path() /
-           std::format("polarized_{}_{}.h5", tag, walkerTypeToString(target));
+           std::format("polarized_{}_{}_{}.h5", tag, walkerTypeToString(target), getpid());
   return p.string();
 }
 
@@ -314,6 +314,7 @@ void polarized_consistency(std::shared_ptr<utils::mpi_context_t<boost::mpi3::com
     mpi->comm.barrier();
     auto cand = run_polarized<MEM>(mpi, hamil_file, cand_file, nsteps, nStab);
     compare_to_reference(walkerTypeToString(cand_type), cand, ref);
+    std::filesystem::remove(cand_file);
   }
 }
 

--- a/tests/test_wfn_factory.cpp
+++ b/tests/test_wfn_factory.cpp
@@ -157,7 +157,7 @@ void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
         memory::array<MEM, ComplexType, 3> p(reshape(p_h, nwalk, npol * NMO, nels[spin]));
         auto SM = wset.SlaterMatrices(static_cast<SpinTypes>(spin));
         if(SM.size() > 0) {
-          nda::tensor::add(p, "ijk", SM, "ijk");
+          SM() = p();
         }
       }
     }

--- a/tests/test_wfn_factory.cpp
+++ b/tests/test_wfn_factory.cpp
@@ -215,8 +215,8 @@ void wfn_factory_sdet(std::shared_ptr<utils::mpi_context_t<boost::mpi3::communic
     ComplexType trG = 0;
     for(int spin = 0; spin < nspin; spin++) {
       auto gMF_spin = gMF()(spin,all,all);
-      trG += nda::sum(nda::diagonal(gMF_spin)); 
-      CHECK_THAT(gMF_spin, utils::Approx(nda::transpose(gMF_spin)));
+      trG += nda::sum(nda::diagonal(gMF_spin));
+      CHECK_THAT(gMF_spin, utils::Approx(nda::make_regular(nda::dagger(gMF_spin))));
     }
     if(!finiteT) {
       CHECK_THAT(trG.real(), utils::Approx(nel));


### PR DESCRIPTION
- cmake: remove rocm flags (currently unsupported)
- cmake: use my safire-adjusted nda branch for now
- c++: rename to nda/unstable names
- c++/Observables: do not h5::read into device array
- c++/kernels: nda no longer supports strided device A() = B(), replace by math::copy
- c++/numerics: account for behavior changes of nda linalg functions
- c++/memory: take over allocators no longer inside nda
- c++/SDetOps: use check_shape
- c++/NOMSD: explicitly sort by real part
- c++/tests: leftover nda namespace renames
- c++/tests: clean tmp files properly
