### PR TITLE
fix(afqmctools): decide hcore storage from dtype, not element values

### DIFF
--- a/utils/afqmctools/hamiltonian/io.py
+++ b/utils/afqmctools/hamiltonian/io.py
@@ -52,11 +52,6 @@ def write_dense(
         else:
             write_to_hdf5(fh5,'Hamiltonian/DenseFactorized/L', data=to_complex(chol.astype(numpy.complex128)))
         
-        # Test the dtype, not the values. `numpy.iscomplex` is elementwise and returns
-        # False wherever the imaginary part is exactly zero, so `numpy.all(...)` only
-        # holds when EVERY entry has a non-zero imaginary part. A physical hcore is
-        # hermitian, so its diagonal is real, and the old predicate sent it down the
-        # `numpy.real` branch -- silently discarding every off-diagonal imaginary part.
         if numpy.iscomplexobj(hcore):
             write_to_hdf5(fh5,'Hamiltonian/hcore',data=to_complex(hcore.astype(numpy.complex128)))
         else:

--- a/utils/afqmctools/hamiltonian/io.py
+++ b/utils/afqmctools/hamiltonian/io.py
@@ -52,7 +52,12 @@ def write_dense(
         else:
             write_to_hdf5(fh5,'Hamiltonian/DenseFactorized/L', data=to_complex(chol.astype(numpy.complex128)))
         
-        if numpy.all(numpy.iscomplex(hcore)):
+        # Test the dtype, not the values. `numpy.iscomplex` is elementwise and returns
+        # False wherever the imaginary part is exactly zero, so `numpy.all(...)` only
+        # holds when EVERY entry has a non-zero imaginary part. A physical hcore is
+        # hermitian, so its diagonal is real, and the old predicate sent it down the
+        # `numpy.real` branch -- silently discarding every off-diagonal imaginary part.
+        if numpy.iscomplexobj(hcore):
             write_to_hdf5(fh5,'Hamiltonian/hcore',data=to_complex(hcore.astype(numpy.complex128)))
         else:
             write_to_hdf5(fh5,'Hamiltonian/hcore', data = numpy.real(hcore))

--- a/utils/tests/test_hamiltonian_io.py
+++ b/utils/tests/test_hamiltonian_io.py
@@ -1,0 +1,105 @@
+# This file is distributed under the Apache License, Version 2.0 License.
+# See LICENSE file in top directory for details.
+#
+# Copyright (c) 2021-2025 The Simons Foundation, Inc.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+"""
+Tests for utils/afqmctools/hamiltonian/io.py that need no SCF backend.
+"""
+
+import h5py as h5
+import numpy as np
+import pytest
+
+from afqmctools.hamiltonian.io import write_dense
+from afqmctools.utils.io import from_complex
+
+
+def _hermitian_cplx(nmo, seed=11):
+    """A hermitian complex matrix -- i.e. one with a purely real diagonal."""
+    rng = np.random.default_rng(seed)
+    a = rng.standard_normal((nmo, nmo)) + 1j * rng.standard_normal((nmo, nmo))
+    return a + a.conj().T
+
+
+def _real_chol(nmo, nchol, seed=12):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((nmo * nmo, nchol))
+
+
+class TestWriteDenseHcore:
+    """`write_dense` must decide hcore's storage from its dtype, not its values."""
+
+    def test_hermitian_cplx_hcore_keeps_imaginary_part(self, tmp_path):
+        # A hermitian hcore has a real diagonal, so an elementwise
+        # `all(iscomplex(...))` test reports it as real even though it is not.
+        nmo, nchol = 8, 5
+        hcore = _hermitian_cplx(nmo)
+        assert np.iscomplexobj(hcore)
+        assert not np.all(np.iscomplex(hcore)), "fixture must have a real diagonal"
+
+        fname = tmp_path / 'hamiltonian.h5'
+        write_dense(hcore, _real_chol(nmo, nchol), (3, 3), nmo,
+                    enuc=0.0, filename=fname)
+
+        with h5.File(fname, 'r') as fh5:
+            stored = fh5['Hamiltonian/hcore'][()]
+
+        # internal complex storage is float64 pairs on a trailing axis
+        assert stored.shape == (nmo, nmo, 2)
+        got = from_complex(stored, shape=(nmo, nmo))
+        assert np.array_equal(got, hcore)
+
+    def test_real_hcore_stays_real(self, tmp_path):
+        nmo, nchol = 8, 5
+        rng = np.random.default_rng(13)
+        hcore = rng.standard_normal((nmo, nmo))
+
+        fname = tmp_path / 'hamiltonian.h5'
+        write_dense(hcore, _real_chol(nmo, nchol), (3, 3), nmo,
+                    enuc=0.0, filename=fname)
+
+        with h5.File(fname, 'r') as fh5:
+            stored = fh5['Hamiltonian/hcore'][()]
+
+        assert stored.shape == (nmo, nmo)
+        assert np.array_equal(stored, hcore)
+
+    def test_fully_complex_hcore_unchanged(self, tmp_path):
+        # The pre-existing behaviour for an hcore whose every entry is complex.
+        nmo, nchol = 8, 5
+        rng = np.random.default_rng(14)
+        hcore = rng.standard_normal((nmo, nmo)) + 1j * (rng.standard_normal((nmo, nmo)) ** 2 + 1.0)
+        assert np.all(np.iscomplex(hcore))
+
+        fname = tmp_path / 'hamiltonian.h5'
+        write_dense(hcore, _real_chol(nmo, nchol), (3, 3), nmo,
+                    enuc=0.0, filename=fname)
+
+        with h5.File(fname, 'r') as fh5:
+            stored = fh5['Hamiltonian/hcore'][()]
+
+        assert np.array_equal(from_complex(stored, shape=(nmo, nmo)), hcore)
+
+    @pytest.mark.parametrize("real_chol", [True, False])
+    def test_hcore_branch_is_independent_of_cholesky(self, tmp_path, real_chol):
+        # hcore's storage must not be driven by the Cholesky vectors' dtype.
+        nmo, nchol = 8, 5
+        hcore = _hermitian_cplx(nmo)
+        chol = _real_chol(nmo, nchol)
+        if not real_chol:
+            chol = chol + 1j * _real_chol(nmo, nchol, seed=15)
+
+        fname = tmp_path / 'hamiltonian.h5'
+        write_dense(hcore, chol, (3, 3), nmo, enuc=0.0,
+                    filename=fname, real_chol=real_chol)
+
+        with h5.File(fname, 'r') as fh5:
+            stored = fh5['Hamiltonian/hcore'][()]
+
+        assert np.array_equal(from_complex(stored, shape=(nmo, nmo)), hcore)


### PR DESCRIPTION
## Summary

`write_dense` picks between the real and complex `Hamiltonian/hcore` branches with

```python
if numpy.all(numpy.iscomplex(hcore)):
```

`numpy.iscomplex` is **elementwise** and returns `False` wherever the imaginary part is
exactly zero, so `numpy.all(...)` only holds when *every* entry has a non-zero imaginary
part.

A physical hcore is hermitian, so its diagonal is real. Such a matrix therefore takes the
`numpy.real(hcore)` branch and is written to file with **every off-diagonal imaginary part
silently discarded** — no warning, no error, and a file that reads back as a valid real
Hamiltonian.

The fix is one predicate: `numpy.iscomplexobj(hcore)`, which tests the array dtype.

Two files, +106 / −1: a **one-line** change to `utils/afqmctools/hamiltonian/io.py`, and a
new `utils/tests/test_hamiltonian_io.py`.

## Reproducer

```python
>>> import numpy as np
>>> a = np.random.randn(4, 4) + 1j*np.random.randn(4, 4)
>>> h = a + a.conj().T          # hermitian => real diagonal
>>> np.iscomplexobj(h)          # what the array actually is
True
>>> np.all(np.iscomplex(h))     # what write_dense asked
False
```

With the old predicate the resulting `Hamiltonian/hcore` dataset has shape `(4, 4)`
instead of `(4, 4, 2)`, and the imaginary part is gone.

## Why the existing test does not catch it

`TestConverter::test_convert_cplx` exercises the complex path, but cannot detect this, for
two independent reasons:

1. Its fixture builds `h1e = random((n,n)) + 1j*random((n,n))` (`tests/conftest.py:123`),
   which is **not** hermitian and has no exactly-real entry — so `np.all(np.iscomplex(...))`
   happens to be `True` and the buggy branch is never taken.
2. Its assertion contracts `h1e` against a diagonal density matrix
   (`np.einsum('ij,ij->', dm, h1e - h1e_r)`), so it only ever probes the **diagonal** —
   which is real for any hermitian hcore regardless.

## What is in the new test file

`utils/tests/test_hamiltonian_io.py`, no SCF backend required:

- `test_hermitian_cplx_hcore_keeps_imaginary_part` — the failing case; asserts the fixture
  really does have a real diagonal, then round-trips the matrix through the file.
- `test_real_hcore_stays_real` — regression pin: a real hcore is still stored as `(n, n)`.
- `test_fully_complex_hcore_unchanged` — regression pin for the previously-working case.
- `test_hcore_branch_is_independent_of_cholesky[True/False]` — hcore's storage must not be
  driven by the Cholesky vectors' dtype.

Verified that the three targeted tests fail on `overhaul` as-is and pass with the fix,
while the two regression pins pass either way.


## Notes for the reviewer

- Real-valued Hamiltonians are completely unaffected: `iscomplexobj` is `False` for a real
  dtype, exactly as before.
- The `ComplexIntegrals` flag is still derived from `real_chol` alone, so a complex hcore
  beside a real Cholesky is written complex but flagged real. That inconsistency predates
  this change and is deliberately **left alone** to keep the PR minimal; happy to open it
  as a follow-up if you would like it addressed.
- Untouched pre-existing lint noise in `io.py` (trailing whitespace at lines 29–31/38/54,
  one 110-char line at 53) was left as-is so the diff stays minimal.