### PR TITLE
Update README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 ######################################################################
 # set options
 ######################################################################
-option(HAVE_MKL "Assume MKL BLAS/LAPACK library." OFF)
 option(BUILD_UNIT_TESTS "Build unit tests" ON)
 option(BUILD_STATIC "Link to static libraries" OFF)
 OPTION(BUILD_DOCUMENTATION "Enable compiling C++ Docs" OFF)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,9 +1,6 @@
 # Contributors
 
 We thank everyone who has contributed to this project.
-Contributors are listed by contribution category.
-Core developers are listed below.
-We consider "Core Developers" and "Contributors" to be mutually-exclusive categories.
 
 ## Core Developers
 
@@ -11,14 +8,13 @@ We consider "Core Developers" and "Contributors" to be mutually-exclusive catego
 
 - **(Brandon) Kyle Eskridge**
 - **Miguel Morales**
-- **Peter Rosenberg**
 - **Lukas Weber**
 
 ### Alumni
 
 - **Ryan Levy**
+- **Peter Rosenberg**
 - **Paul Yang**
-
 
 ### Additional Contributors to the Initial Version
 
@@ -28,8 +24,8 @@ We consider "Core Developers" and "Contributors" to be mutually-exclusive catego
 ## Contributors
 
 - **Thomas Hahn**
-- **Zhou-Quan Wan**
 - **Chunhan Feng**
+- **Zhou-Quan Wan**
 - **Yiqi Yang**
 
 ## Special Thanks

--- a/README.md
+++ b/README.md
@@ -87,3 +87,48 @@ This project is licensed under the [Apache License, Version 2.0](LICENSE).
 Portions of this software are derived from the QMCPACK
 project, which was originally distributed under the [University of Illinois/NCSA Open Source License](LICENSES/NCSA.txt).
 The full text of that license can be found in [LICENSES/NCSA.txt](LICENSES/NCSA.txt).
+
+## Contributors
+
+The core developers of SAFIRE are listed below. For the full list of contributors, see [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/bkesk">
+        <img src="https://github.com/bkesk.png" width="80"/><br/>
+        <sub><b>(Brandon) Kyle Eskridge</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/ryanlevy">
+        <img src="https://github.com/ryanlevy.png" width="80"/><br/>
+        <sub><b>Ryan Levy</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/mmorale3">
+        <img src="https://github.com/mmorale3.png" width="80"/><br/>
+        <sub><b>Miguel Morales</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/prosenberg15">
+        <img src="https://github.com/prosenberg15.png" width="80"/><br/>
+        <sub><b>Peter Rosenberg</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/lukas-weber">
+        <img src="https://github.com/lukas-weber.png" width="80"/><br/>
+        <sub><b>Lukas Weber</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/Paul-St-Young">
+        <img src="https://github.com/Paul-St-Young.png" width="80"/><br/>
+        <sub><b>Paul Yang</b></sub>
+      </a>
+    </td>
+  </tr>
+</table>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # SAFIRE
+[![Build Status](https://jenkins-new.flatironinstitute.org/job/CCQ/job/SAFIRE/job/main/badge/icon)](https://jenkins-new.flatironinstitute.org/job/CCQ/job/SAFIRE/job/main/)
+[![Docs dev](https://img.shields.io/badge/docs-latest-blue.svg)](https://safire.flatironinstitute.org/docs/dev/)
 
 
 **S**tochastic **A**uxiliary-**F**ields for **I**nte**R**acting **E**lectrons (SAFIRE)
@@ -6,11 +8,7 @@ is a flexible, high-performance implementation of the auxiliary-field quantum Mo
 
 ## Installation
 
-This project uses submodules which must be initialized.
-This can be achievied using the following commands:
-
-Next, follow one of the sections below depending on whether you want a CPU-only build,
-or a GPU-accelerated build.
+Next, follow one of the sections below depending on whether you want a CPU-only build, or a GPU-accelerated build.
 
 Also, see the afqmctools Python package [Readme](utils/README.md#installation) to install the afqmctools Python package.
 
@@ -25,7 +23,7 @@ For a CPU-only build:
 - Boost 1.61.0+
 - BLAS library
 - LAPACK library
-- Intel oneAPI MKL (for sparse matrices on CPU)
+- Intel oneAPI MKL (for optimized sparse matrix operations on CPU)
 
 The build system will fetch the following dependencies automatically if they are not installed
 
@@ -36,7 +34,7 @@ The build system will fetch the following dependencies automatically if they are
 - nlohmann_json
 - Catch2 (for tests)
 
-For a GPU-build, the following are also required:
+For a GPU build, the following are also required:
 
 - CUDA 12+
 - CuTENSOR
@@ -59,25 +57,6 @@ $ mkdir build
 $ cd build
 $ cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_CUDA=ON
 $ make -j10
-```
-
-## Documentation
-
-The user documentation can be built using sphinx as follows.
-
-First, install the python dependencies of the documentation by installing [afqmctools](utils/README.md#installation) with the `DOCS` optional dependency set.
-
-Next, build the docs by running the following starting from the root of this repository:
-```bash
-$ cd docs
-$ make html
-```
-some error messages and warnings may occur, but this should generate an html document in `_build/html`.
-
-Finally, to view the documentation locally, navigate in a browser to the documentation using:
-
-```
-file:///path/to/SAFIRE/docs/_build/html/index.html
 ```
 
 ## License

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -21,15 +21,9 @@
 /* building from Git repository or not */
 #cmakedefine IS_GIT_PROJECT
 
-/* Assume MKL library is available. */ 
-#cmakedefine HAVE_MKL
-
 /* Enable device code and use CUDA backend */
 #cmakedefine ENABLE_CUDA
 
-/* Enable device code and use HIP backend */
-#cmakedefine ENABLE_HIP
- 
 /* Enable device code, with some backend. */
 #cmakedefine ENABLE_DEVICE
 

--- a/src/utilities/app_version.cpp
+++ b/src/utilities/app_version.cpp
@@ -23,7 +23,7 @@
 
 void print_version() {
   constexpr const char* mkl_feature =
-  #ifdef HAVE_MKL
+  #ifdef NDA_USE_MKL
       " MKL";
   #else
       "";


### PR DESCRIPTION
- readme: restore contributors table lost in the overhaul merge
- README: update with badges and docs link
- update CONTRIBUTORS.md
- cmake: use NDA_USE_MKL instead of our own
